### PR TITLE
gofmt all the files

### DIFF
--- a/helper/resource/grpc_test_provider.go
+++ b/helper/resource/grpc_test_provider.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	tfplugin "github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/helper/resource/state_shim_test.go
+++ b/helper/resource/state_shim_test.go
@@ -3,8 +3,8 @@ package resource
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/zclconf/go-cty/cty"

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -21,16 +21,16 @@ import (
 	"github.com/hashicorp/logutils"
 	"github.com/mitchellh/colorstring"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/command/format"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/initwd"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // flagSweep is a flag available when running tests on the command line. It

--- a/helper/resource/testing_config.go
+++ b/helper/resource/testing_config.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // testStepConfig runs a config-mode test step

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )

--- a/helper/schema/field_reader_config_test.go
+++ b/helper/schema/field_reader_config_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/helper/plugin/grpc_provider.go
+++ b/internal/helper/plugin/grpc_provider.go
@@ -11,12 +11,12 @@ import (
 	"github.com/zclconf/go-cty/cty/msgpack"
 	context "golang.org/x/net/context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/go-test/deep"
 	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/registry"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -1,8 +1,8 @@
 package convert
 
 import (
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/plugin/convert/diagnostics_test.go
+++ b/internal/plugin/convert/diagnostics_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 )
 
 // ConfigSchemaToProto takes a *configschema.Block and converts it to a

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -9,9 +9,9 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	plugin "github.com/hashicorp/go-plugin"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/version"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"

--- a/plugin/grpc_provider_test.go
+++ b/plugin/grpc_provider_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	mockproto "github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 )
 
 var _ providers.Interface = (*GRPCProvider)(nil)

--- a/plugin/grpc_provisioner.go
+++ b/plugin/grpc_provisioner.go
@@ -9,9 +9,9 @@ import (
 
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/provisioners"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"

--- a/plugin/grpc_provisioner_test.go
+++ b/plugin/grpc_provisioner_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/provisioners"
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/zclconf/go-cty/cty"
 
 	mockproto "github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto"


### PR DESCRIPTION
It looks like we just forgot to run `gofmt` after changing import paths as part of the extraction.
