### PR TITLE
Simplify CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,12 @@ jobs:
   "docker-go112 build":
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/hashicorp/terraform-plugin-sdk
-    environment:
-      GO111MODULE: "on"
     steps:
       - get_dependencies
       - run: go build ./...
   "docker-go112 test":
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/hashicorp/terraform-plugin-sdk
-    environment:
-      GO111MODULE: "on"
     parameters:
       test_results:
         type: string
@@ -49,18 +43,12 @@ jobs:
   "docker-go112 vet":
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/hashicorp/terraform-plugin-sdk
-    environment:
-      GO111MODULE: "on"
     steps:
       - get_dependencies
       - run: go vet ./...
   "docker-go112 gofmt":
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/hashicorp/terraform-plugin-sdk
-    environment:
-      GO111MODULE: "on"
     steps:
       - get_dependencies
       - run: ./scripts/gofmtcheck.sh


### PR DESCRIPTION
Somehow I didn't catch this in the initial PR, but it appears that `working_directory` is actually optional and that has a neat side effect of using workdir which is outside of GOPATH, i.e. Go modules get enabled automatically without `GO111MODULE` set.
