### PR TITLE
plugin: Pass TerraformVersion from ConfigureRequest

### DIFF
--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/version"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"
 )
@@ -287,7 +286,7 @@ func (p *GRPCProvider) Configure(r providers.ConfigureRequest) (resp providers.C
 	}
 
 	protoReq := &proto.Configure_Request{
-		TerraformVersion: version.Version,
+		TerraformVersion: r.TerraformVersion,
 		Config: &proto.DynamicValue{
 			Msgpack: mp,
 		},


### PR DESCRIPTION
This is basically just a copy of https://github.com/hashicorp/terraform/pull/22654 

Previously migrated providers would report `0.12.7` only, this patch makes them report `0.12.7-sdk` which will help us differentiate requests coming from acceptance tests and genuine 0.12.7 users.

https://github.com/hashicorp/terraform-plugin-sdk/blob/38fc45fd8c94da5e586e94d04f174727e553921a/internal/version/version.go#L19