### PR TITLE
Version tools per Go convention under tools.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 	google.golang.org/appengine v1.6.0 // indirect
 	google.golang.org/genproto v0.0.0-20190513181449-d00d292a067c // indirect
 	google.golang.org/grpc v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/helper/schema/resource_data_get_source.go
+++ b/helper/schema/resource_data_get_source.go
@@ -1,6 +1,6 @@
 package schema
 
-//go:generate stringer -type=getSource resource_data_get_source.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=getSource resource_data_get_source.go
 
 // getSource represents the level we want to get for a value (internally).
 // Any source less than or equal to the level will be loaded (whichever

--- a/helper/schema/valuetype.go
+++ b/helper/schema/valuetype.go
@@ -1,6 +1,6 @@
 package schema
 
-//go:generate stringer -type=ValueType valuetype.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=ValueType valuetype.go
 
 // ValueType is an enum of the type that can be represented by a schema.
 type ValueType int

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -253,7 +253,7 @@ func (r AbsResourceInstance) Less(o AbsResourceInstance) bool {
 // resource lifecycle has a slightly different address format.
 type ResourceMode rune
 
-//go:generate stringer -type ResourceMode
+//go:generate go run golang.org/x/tools/cmd/stringer -type ResourceMode
 
 const (
 	// InvalidResourceMode is the zero value of ResourceMode and is not

--- a/internal/configs/configschema/schema.go
+++ b/internal/configs/configschema/schema.go
@@ -83,7 +83,7 @@ type NestedBlock struct {
 // blocks.
 type NestingMode int
 
-//go:generate stringer -type=NestingMode
+//go:generate go run golang.org/x/tools/cmd/stringer -type=NestingMode
 
 const (
 	nestingModeInvalid NestingMode = iota

--- a/internal/configs/provisioner.go
+++ b/internal/configs/provisioner.go
@@ -118,7 +118,7 @@ type Connection struct {
 // ProvisionerWhen is an enum for valid values for when to run provisioners.
 type ProvisionerWhen int
 
-//go:generate stringer -type ProvisionerWhen
+//go:generate go run golang.org/x/tools/cmd/stringer -type ProvisionerWhen
 
 const (
 	ProvisionerWhenInvalid ProvisionerWhen = iota
@@ -130,7 +130,7 @@ const (
 // for provisioners.
 type ProvisionerOnFailure int
 
-//go:generate stringer -type ProvisionerOnFailure
+//go:generate go run golang.org/x/tools/cmd/stringer -type ProvisionerOnFailure
 
 const (
 	ProvisionerOnFailureInvalid ProvisionerOnFailure = iota

--- a/internal/configs/variable_type_hint.go
+++ b/internal/configs/variable_type_hint.go
@@ -19,7 +19,7 @@ package configs
 //     TypeHintMap requires a type that could be converted to an object
 type VariableTypeHint rune
 
-//go:generate stringer -type VariableTypeHint
+//go:generate go run golang.org/x/tools/cmd/stringer -type VariableTypeHint
 
 // TypeHintNone indicates the absence of a type hint. Values specified in
 // ambiguous contexts will be treated as literal strings, as if TypeHintString

--- a/internal/plans/action.go
+++ b/internal/plans/action.go
@@ -12,7 +12,7 @@ const (
 	Delete           Action = '-'
 )
 
-//go:generate stringer -type Action
+//go:generate go run golang.org/x/tools/cmd/stringer -type Action
 
 // IsReplace returns true if the action is one of the two actions that
 // represents replacing an existing object with a new object:

--- a/internal/plugin/mock_proto/generate.go
+++ b/internal/plugin/mock_proto/generate.go
@@ -1,3 +1,3 @@
-//go:generate bash ./generate.sh
+//go:generate go run github.com/golang/mock/mockgen -destination mock.go github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5 ProviderClient,ProvisionerClient,Provisioner_ProvisionResourceClient,Provisioner_ProvisionResourceServer
 
 package mock_tfplugin5

--- a/internal/plugin/mock_proto/generate.sh
+++ b/internal/plugin/mock_proto/generate.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# mockgen is particularly sensitive about what mode we run it in
-export GOFLAGS=""
-export GO111MODULE=on
-
-mockgen -destination mock.go github.com/hashicorp/terraform/internal/tfplugin5 ProviderClient,ProvisionerClient,Provisioner_ProvisionResourceClient,Provisioner_ProvisionResourceServer

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -40,7 +40,7 @@ type ResourceInstanceObject struct {
 // ObjectStatus represents the status of a RemoteObject.
 type ObjectStatus rune
 
-//go:generate stringer -type ObjectStatus
+//go:generate go run golang.org/x/tools/cmd/stringer -type ObjectStatus
 
 const (
 	// ObjectReady is an object status for an object that is ready to use.

--- a/internal/states/resource.go
+++ b/internal/states/resource.go
@@ -175,7 +175,7 @@ const (
 	EachMap  EachMode = 'M'
 )
 
-//go:generate stringer -type EachMode
+//go:generate go run golang.org/x/tools/cmd/stringer -type EachMode
 
 func eachModeForInstanceKey(key addrs.InstanceKey) EachMode {
 	switch key.(type) {

--- a/internal/tfdiags/diagnostic.go
+++ b/internal/tfdiags/diagnostic.go
@@ -17,7 +17,7 @@ type Diagnostic interface {
 
 type Severity rune
 
-//go:generate stringer -type=Severity
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Severity
 
 const (
 	Error   Severity = 'E'

--- a/terraform/context_graph_type.go
+++ b/terraform/context_graph_type.go
@@ -1,6 +1,6 @@
 package terraform
 
-//go:generate stringer -type=GraphType context_graph_type.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=GraphType context_graph_type.go
 
 // GraphType is an enum of the type of graph to create with a Context.
 // The values of the constants may change so they shouldn't be depended on;

--- a/terraform/graph_walk_operation.go
+++ b/terraform/graph_walk_operation.go
@@ -1,6 +1,6 @@
 package terraform
 
-//go:generate stringer -type=walkOperation graph_walk_operation.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=walkOperation graph_walk_operation.go
 
 // walkOperation is an enum which tells the walkContext what to do.
 type walkOperation byte

--- a/terraform/instancetype.go
+++ b/terraform/instancetype.go
@@ -1,6 +1,6 @@
 package terraform
 
-//go:generate stringer -type=InstanceType instancetype.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=InstanceType instancetype.go
 
 // InstanceType is an enum of the various types of instances store in the State
 type InstanceType int

--- a/terraform/resource_mode.go
+++ b/terraform/resource_mode.go
@@ -1,6 +1,6 @@
 package terraform
 
-//go:generate stringer -type=ResourceMode -output=resource_mode_string.go resource_mode.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=ResourceMode -output=resource_mode_string.go resource_mode.go
 
 // ResourceMode is deprecated, use addrs.ResourceMode instead.
 // It has been preserved for backwards compatibility.

--- a/terraform/variables.go
+++ b/terraform/variables.go
@@ -78,7 +78,7 @@ func (v ValueSourceType) GoString() string {
 	return fmt.Sprintf("terraform.%s", v)
 }
 
-//go:generate stringer -type ValueSourceType
+//go:generate go run golang.org/x/tools/cmd/stringer -type ValueSourceType
 
 // InputValues is a map of InputValue instances.
 type InputValues map[string]*InputValue

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,9 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/golang/mock/mockgen"
+	_ "golang.org/x/tools/cmd/cover"
+	_ "golang.org/x/tools/cmd/stringer"
+)


### PR DESCRIPTION
This allows developers to just run bare `go generate ./...` without having to `go get` the required tooling which is referenced by `go:generate` notations in the code.

Related: https://github.com/hashicorp/terraform/pull/22643

I'd like to get this in before adding a Makefile, so that we can omit certain logic from the Makefile.