### PR TITLE
Tool for incrementally cherry-picking new changes from Core

### DIFF
--- a/scripts/cherry_pick/IGNORE_FILES
+++ b/scripts/cherry_pick/IGNORE_FILES
@@ -1,0 +1,3 @@
+^internal/httpclient/(testdata/.*|test-fixtures/.*|[^/]*)$
+^internal/helper/encryption/(testdata/.*|test-fixtures/.*|[^/]*)$
+^internal/version/(testdata/.*|test-fixtures/.*|[^/]*)$

--- a/scripts/cherry_pick/cherry_pick.sh
+++ b/scripts/cherry_pick/cherry_pick.sh
@@ -12,5 +12,12 @@ git cherry-pick --no-commit --mainline 1 "$COMMIT_ID"
 echo "Unstaging files removed by us..."
 git status --short | sed -n 's/^DU //p' | ifne xargs git rm
 
+echo "Unstaging files where SDK intentionally diverges from Core..."
+for f in $(git diff --name-only --cached | grep -Ef ./scripts/cherry_pick/IGNORE_FILES)
+do
+    git reset "$f"
+    git checkout -- "$f"
+done
+
 echo "Committing changes. If this fails, you must resolve the merge conflict manually."
 git commit -C "$COMMIT_ID" && echo "Success!"


### PR DESCRIPTION
The idea is to avoid running the whole `git filter-branch` extraction process when we want to pull changes from `hashicorp/terraform` that have happened since the extraction.

## How to use it

### Prerequisites

You need `ifne`, which is usually in a package called `moreutils`.

### Add git remote

First, you need to prepare your `hashicorp/terraform-plugin-sdk` repo by adding `hashicorp/terraform` as a remote. 

```
git remote add ht git@github.com:hashicorp/terraform.git
git fetch --all
```

Depending on the state your working directory is in before you do this, this might make a bit of a mess, but clean up after the party's over and everything will be fine.

### Identify merge commit

Now find the commit where your desired PR has been merged into Core's master branch. For example, for https://github.com/hashicorp/terraform/pull/22690 it is `72f9385`.

### Run

```
./scripts/cherry_pick/cherry_pick.sh 72f9385 
```

If this exits 0, the merge commit should have been cherry-picked onto your current branch, and it should contain all the changes from that PR.

If there is a merge conflict in relevant files that must be resolved manually, the script will exit 1 at that point and you will need to complete the cherry-picking process manually. Resolve the merge conflict and commit.

## How it works

`git cherry-pick --mainline 1` specifies that the mainline of the merge commit should be the first parent, which (I hope) is always Core's `master`. The cherry-pick operation will then replay the changes relative to `master`, i.e. the changes made in the PR.

We don't want to include irrelevant changes made in the same PR, so we unstage files that are "removed by us", i.e. not present in the SDK repo.

---
## TODO
 - [x] merged PRs
 - [x] ignore changes made to `version/version.go` and certain other files
 - [ ] ~unmerged PRs~ Consensus is that we don't need this.