### PR TITLE
cherry_pick.sh: edit commit message of cherry-picked merge commit

### DIFF
--- a/scripts/cherry_pick/cherry_pick.sh
+++ b/scripts/cherry_pick/cherry_pick.sh
@@ -4,13 +4,19 @@ if [ "$#" -ne 1 ]; then
     echo "Usage: ./scripts/cherry_pick/cherry_pick.sh MERGE_COMMIT_HASH"
 fi
 
+function pleaseUseGNUsed {
+    echo "Please install GNU sed to your PATH as 'sed'."
+    exit 1
+}
+sed --version > /dev/null || pleaseUseGNUsed
+
 COMMIT_ID=$1
 
 echo "Cherry-picking changes..."
 git cherry-pick --no-commit --mainline 1 "$COMMIT_ID"
 
 echo "Unstaging files removed by us..."
-git status --short | gsed -n 's/^DU //p' | ifne xargs git rm
+git status --short | sed -n 's/^DU //p' | ifne xargs git rm
 
 echo "Unstaging files where SDK intentionally diverges from Core..."
 for f in $(git diff --name-only --cached | grep -Ef ./scripts/cherry_pick/IGNORE_FILES)
@@ -19,7 +25,7 @@ do
     git checkout -- "$f"
 done
 
-COMMIT_MSG=$(git log --format=%B -n 1 "$COMMIT_ID" | gsed -z -r 's/Merge pull request (#[0-9]+) from ([^\n]*\/[^\n]*)\n\n(.*$)/\3\nThis commit was generated from hashicorp\/terraform\1./g')
+COMMIT_MSG=$(git log --format=%B -n 1 "$COMMIT_ID" | sed -z -r 's/Merge pull request (#[0-9]+) from ([^\n]*\/[^\n]*)\n\n(.*$)/\3\nThis commit was generated from hashicorp\/terraform\1./g')
 
 echo "Committing changes. If this fails, you must resolve the merge conflict manually."
 git commit -C "$COMMIT_ID" && \


### PR DESCRIPTION
As @appilon mentioned in https://github.com/hashicorp/terraform-plugin-sdk/pull/44, merge commits cherry-picked by the script keep their "Merge pull request #..." commit messages.

This PR adds a line to the script to produce a better commit message, including a link to the Core PR, while preserving authorship information.

## Note regarding `sed`

macOS users must install GNU sed and ensure it is available as `gsed`. Linux users are advised to symlink.