### PR TITLE
Set default TerraformVersion

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -267,6 +267,11 @@ func (p *Provider) Configure(c *terraform.ResourceConfig) error {
 		return err
 	}
 
+	if p.TerraformVersion == "" {
+		// Terraform 0.12 introduced this field to the protocol
+		// We can therefore assume that if it's unconfigured at this point, it's 0.10 or 0.11
+		p.TerraformVersion = "0.11+compatible"
+	}
 	meta, err := p.ConfigureFunc(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
if the provider is served over the 0.12 protocol it will have a `TerraformVersion` set. If it is serving the old protocol it will be unset. This is to avoid a piece of boilerplate from repeating over and over in provider `ConfigureFunc`s, and ensure a consistent special designation of `0.11+compatible`, implying it was TF 0.10/0.11 (0.11 compatible/protocol 4).