### PR TITLE
split cherry-pick script

### DIFF
--- a/scripts/cherry_pick/cherry_pick.sh
+++ b/scripts/cherry_pick/cherry_pick.sh
@@ -25,10 +25,5 @@ do
     git checkout -- "$f"
 done
 
-COMMIT_MSG=$(git log --format=%B -n 1 "$COMMIT_ID" | sed -z -r 's/Merge pull request (#[0-9]+) from ([^\n]*\/[^\n]*)\n\n(.*$)/\3\nThis commit was generated from hashicorp\/terraform\1./g')
-
 echo "Committing changes. If this fails, you must resolve the merge conflict manually."
-git commit -C "$COMMIT_ID" && \
-# amend commit message afterwards to preserve authorship information
-git commit --amend --message "${COMMIT_MSG}" \
-&& echo "Success!"
+./scripts/cherry_pick/commit.sh $COMMIT_ID && echo "Success!"

--- a/scripts/cherry_pick/commit.sh
+++ b/scripts/cherry_pick/commit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ./scripts/cherry_pick/commit.sh MERGE_COMMIT_HASH"
+fi
+
+function pleaseUseGNUsed {
+    echo "Please install GNU sed to your PATH as 'sed'."
+    exit 1
+}
+sed --version > /dev/null || pleaseUseGNUsed
+
+COMMIT_ID=$1
+
+COMMIT_MSG=$(git log --format=%B -n 1 "$COMMIT_ID" | \
+                 sed -z -r 's/Merge pull request (#[0-9]+) from ([^\n]*\/[^\n]*)\n\n(.*$)/\3\nThis commit was generated from hashicorp\/terraform\1./g')
+
+git commit -C "$COMMIT_ID" && \
+    # amend commit message afterwards to preserve authorship information
+    git commit --amend --message "${COMMIT_MSG}"


### PR DESCRIPTION
Split out the part of the cherry-pick script that makes the commit and amends the message.

If a merge conflict interrupts `cherry_pick.sh` before the commit, you can now resolve the merge conflict and then run `commit.sh HASH` to preserve commit information (including author).