### PR TITLE
cherry_pick.sh: unstage added ignored files

### DIFF
--- a/scripts/cherry_pick/IGNORE_FILES
+++ b/scripts/cherry_pick/IGNORE_FILES
@@ -1,3 +1,4 @@
 ^internal/httpclient/(testdata/.*|test-fixtures/.*|[^/]*)$
 ^internal/helper/encryption/(testdata/.*|test-fixtures/.*|[^/]*)$
 ^internal/version/(testdata/.*|test-fixtures/.*|[^/]*)$
+^website/.*$

--- a/scripts/cherry_pick/cherry_pick.sh
+++ b/scripts/cherry_pick/cherry_pick.sh
@@ -18,6 +18,9 @@ git cherry-pick --no-commit --mainline 1 "$COMMIT_ID"
 echo "Unstaging files removed by us..."
 git status --short | sed -n 's/^DU //p' | ifne xargs git rm
 
+echo "Unstaging added files that match the ignore list..."
+git status --short | sed -n 's/^A  //p' | grep -Ef ./scripts/cherry_pick/IGNORE_FILES | ifne xargs git rm -f
+
 echo "Unstaging files where SDK intentionally diverges from Core..."
 for f in $(git diff --name-only --cached | grep -Ef ./scripts/cherry_pick/IGNORE_FILES)
 do


### PR DESCRIPTION
Cherry-picking Core PRs often results in `website/` files being added, which is incorrect. We can't ignore all added files as we still want new files in relevant subdirectories. Without bringing back the whitelist, this PR solves the problem quickly and safely by unstaging added files that match the `IGNORE_FILES` regex.