### PR TITLE
Correctly update SDKVersion during release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.1 (Unreleased)
+
+BUG FIXES:
+
+ * `SDKVersion` in v1.1.0 was incorrectly set to "1.0.0" due to a bug in the release script. Fix for versions beginning at v1.1.1. [GH-191]
+
 # 1.1.0 (September 27, 2019)
 
 FEATURES:

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -55,7 +55,7 @@ function changelogMain {
 }
 
 function modifyVersionFiles {
-  sed -i "s/const SDKVersion =.*/const SDKVersion = \"${TARGET_VERSION}\"/" meta/meta.go
+  sed -i "s/var SDKVersion =.*/var SDKVersion = \"${TARGET_VERSION}\"/" meta/meta.go
   sed -i "s/var SDKPrerelease =.*/var SDKPrerelease = \"\"/" meta/meta.go
 }
 


### PR DESCRIPTION
v1.1.0 incorrectly reports `SDKVersion` as v1.0.0 in `meta/meta.go`. This is due to a bug in the release script, which we failed to notice in the rush of https://github.com/hashicorp/terraform-plugin-sdk/pull/51.

This PR corrects the bug in the script. After this is merged I will release v1.1.1, which will report its version correctly.

fixes #190 