### PR TITLE
helper/resource: Introduce sweeper flag to continue other sweepers after failures

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -54,12 +54,13 @@ import (
 // destroyed.
 
 var flagSweep = flag.String("sweep", "", "List of Regions to run available Sweepers")
+var flagSweepAllowFailures = flag.Bool("sweep-allow-failures", false, "Enable to allow Sweeper Tests to continue after failures")
 var flagSweepRun = flag.String("sweep-run", "", "Comma seperated list of Sweeper Tests to run")
 var sweeperFuncs map[string]*Sweeper
 
 // map of sweepers that have ran, and the success/fail status based on any error
 // raised
-var sweeperRunList map[string]bool
+var sweeperRunList map[string]error
 
 // type SweeperFunc is a signature for a function that acts as a sweeper. It
 // accepts a string for the region that the sweeper is to be ran in. This
@@ -105,22 +106,49 @@ func TestMain(m *testing.M) {
 
 		// get filtered list of sweepers to run based on sweep-run flag
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
+
+		// track sweeper errors across regions
+		var regionSweeperErrorFound, sweeperErrorFound bool
+
 		for _, region := range regions {
 			region = strings.TrimSpace(region)
-			// reset sweeperRunList for each region
-			sweeperRunList = map[string]bool{}
+			// reset sweeperRunList and regionSweeperErrorFound for each region
+			sweeperRunList = map[string]error{}
+			regionSweeperErrorFound = false
 
 			log.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
 			for _, sweeper := range sweepers {
-				if err := runSweeperWithRegion(region, sweeper); err != nil {
-					log.Fatalf("[ERR] error running (%s): %s", sweeper.Name, err)
+				if err := runSweeperWithRegion(region, sweeper, *flagSweepAllowFailures); err != nil {
+					if *flagSweepAllowFailures {
+						continue
+					}
+
+					os.Exit(1)
 				}
 			}
 
-			log.Printf("Sweeper Tests ran:\n")
-			for s, _ := range sweeperRunList {
-				fmt.Printf("\t- %s\n", s)
+			log.Printf("Sweeper Tests ran successfully:\n")
+			for sweeper, sweeperErr := range sweeperRunList {
+				if sweeperErr == nil {
+					fmt.Printf("\t- %s\n", sweeper)
+				} else {
+					regionSweeperErrorFound = true
+				}
 			}
+
+			if regionSweeperErrorFound {
+				sweeperErrorFound = true
+				log.Printf("Sweeper Tests ran unsuccessfully:\n")
+				for sweeper, sweeperErr := range sweeperRunList {
+					if sweeperErr != nil {
+						fmt.Printf("\t- %s: %s\n", sweeper, sweeperErr)
+					}
+				}
+			}
+		}
+
+		if sweeperErrorFound {
+			os.Exit(1)
 		}
 	} else {
 		os.Exit(m.Run())
@@ -153,11 +181,18 @@ func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
 // itself with that region for every dependency found for that sweeper. If there
 // are no dependencies, invoke the contained sweeper fun with the region, and
 // add the success/fail status to the sweeperRunList.
-func runSweeperWithRegion(region string, s *Sweeper) error {
+func runSweeperWithRegion(region string, s *Sweeper, allowFailures bool) error {
 	for _, dep := range s.Dependencies {
 		if depSweeper, ok := sweeperFuncs[dep]; ok {
 			log.Printf("[DEBUG] Sweeper (%s) has dependency (%s), running..", s.Name, dep)
-			if err := runSweeperWithRegion(region, depSweeper); err != nil {
+			err := runSweeperWithRegion(region, depSweeper, allowFailures)
+
+			if err != nil {
+				if allowFailures {
+					log.Printf("[ERROR] Error running Sweeper (%s) in region (%s): %s", depSweeper.Name, region, err)
+					continue
+				}
+
 				return err
 			}
 		} else {
@@ -170,11 +205,14 @@ func runSweeperWithRegion(region string, s *Sweeper) error {
 		return nil
 	}
 
+	log.Printf("[DEBUG] Running Sweeper (%s) in region (%s)", s.Name, region)
+
 	runE := s.F(region)
-	if runE == nil {
-		sweeperRunList[s.Name] = true
-	} else {
-		sweeperRunList[s.Name] = false
+
+	sweeperRunList[s.Name] = runE
+
+	if runE != nil {
+		log.Printf("[ERROR] Error running Sweeper (%s) in region (%s): %s", s.Name, region, runE)
 	}
 
 	return runE

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -58,10 +59,6 @@ var flagSweepAllowFailures = flag.Bool("sweep-allow-failures", false, "Enable to
 var flagSweepRun = flag.String("sweep-run", "", "Comma seperated list of Sweeper Tests to run")
 var sweeperFuncs map[string]*Sweeper
 
-// map of sweepers that have ran, and the success/fail status based on any error
-// raised
-var sweeperRunList map[string]error
-
 // type SweeperFunc is a signature for a function that acts as a sweeper. It
 // accepts a string for the region that the sweeper is to be ran in. This
 // function must be able to construct a valid client for that region.
@@ -107,52 +104,63 @@ func TestMain(m *testing.M) {
 		// get filtered list of sweepers to run based on sweep-run flag
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
 
-		// track sweeper errors across regions
-		var regionSweeperErrorFound, sweeperErrorFound bool
-
-		for _, region := range regions {
-			region = strings.TrimSpace(region)
-			// reset sweeperRunList and regionSweeperErrorFound for each region
-			sweeperRunList = map[string]error{}
-			regionSweeperErrorFound = false
-
-			log.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
-			for _, sweeper := range sweepers {
-				if err := runSweeperWithRegion(region, sweeper, *flagSweepAllowFailures); err != nil {
-					if *flagSweepAllowFailures {
-						continue
-					}
-
-					os.Exit(1)
-				}
-			}
-
-			log.Printf("Sweeper Tests ran successfully:\n")
-			for sweeper, sweeperErr := range sweeperRunList {
-				if sweeperErr == nil {
-					fmt.Printf("\t- %s\n", sweeper)
-				} else {
-					regionSweeperErrorFound = true
-				}
-			}
-
-			if regionSweeperErrorFound {
-				sweeperErrorFound = true
-				log.Printf("Sweeper Tests ran unsuccessfully:\n")
-				for sweeper, sweeperErr := range sweeperRunList {
-					if sweeperErr != nil {
-						fmt.Printf("\t- %s: %s\n", sweeper, sweeperErr)
-					}
-				}
-			}
-		}
-
-		if sweeperErrorFound {
+		if _, err := runSweepers(regions, sweepers, *flagSweepAllowFailures); err != nil {
 			os.Exit(1)
 		}
 	} else {
 		os.Exit(m.Run())
 	}
+}
+
+func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures bool) (map[string]map[string]error, error) {
+	var sweeperErrorFound bool
+	sweeperRunList := make(map[string]map[string]error)
+
+	for _, region := range regions {
+		region = strings.TrimSpace(region)
+
+		var regionSweeperErrorFound bool
+		regionSweeperRunList := make(map[string]error)
+
+		log.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
+		for _, sweeper := range sweepers {
+			if err := runSweeperWithRegion(region, sweeper, sweepers, regionSweeperRunList, allowFailures); err != nil {
+				if allowFailures {
+					continue
+				}
+
+				sweeperRunList[region] = regionSweeperRunList
+				return sweeperRunList, fmt.Errorf("sweeper (%s) for region (%s) failed: %s", sweeper.Name, region, err)
+			}
+		}
+
+		log.Printf("Sweeper Tests ran successfully:\n")
+		for sweeper, sweeperErr := range regionSweeperRunList {
+			if sweeperErr == nil {
+				fmt.Printf("\t- %s\n", sweeper)
+			} else {
+				regionSweeperErrorFound = true
+			}
+		}
+
+		if regionSweeperErrorFound {
+			sweeperErrorFound = true
+			log.Printf("Sweeper Tests ran unsuccessfully:\n")
+			for sweeper, sweeperErr := range regionSweeperRunList {
+				if sweeperErr != nil {
+					fmt.Printf("\t- %s: %s\n", sweeper, sweeperErr)
+				}
+			}
+		}
+
+		sweeperRunList[region] = regionSweeperRunList
+	}
+
+	if sweeperErrorFound {
+		return sweeperRunList, errors.New("at least one sweeper failed")
+	}
+
+	return sweeperRunList, nil
 }
 
 // filterSweepers takes a comma seperated string listing the names of sweepers
@@ -181,11 +189,11 @@ func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
 // itself with that region for every dependency found for that sweeper. If there
 // are no dependencies, invoke the contained sweeper fun with the region, and
 // add the success/fail status to the sweeperRunList.
-func runSweeperWithRegion(region string, s *Sweeper, allowFailures bool) error {
+func runSweeperWithRegion(region string, s *Sweeper, sweepers map[string]*Sweeper, sweeperRunList map[string]error, allowFailures bool) error {
 	for _, dep := range s.Dependencies {
-		if depSweeper, ok := sweeperFuncs[dep]; ok {
+		if depSweeper, ok := sweepers[dep]; ok {
 			log.Printf("[DEBUG] Sweeper (%s) has dependency (%s), running..", s.Name, dep)
-			err := runSweeperWithRegion(region, depSweeper, allowFailures)
+			err := runSweeperWithRegion(region, depSweeper, sweepers, sweeperRunList, allowFailures)
 
 			if err != nil {
 				if allowFailures {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -814,7 +814,7 @@ func TestTest_Main(t *testing.T) {
 		SweepRun        string
 	}{
 		{
-			Name: "normal",
+			Name: "basic passing",
 			Sweepers: map[string]*Sweeper{
 				"aws_dummy": &Sweeper{
 					Name: "aws_dummy",
@@ -822,6 +822,41 @@ func TestTest_Main(t *testing.T) {
 				},
 			},
 			ExpectedRunList: []string{"aws_dummy"},
+		},
+	}
+
+	for _, tc := range cases {
+		// reset sweepers
+		sweeperFuncs = map[string]*Sweeper{}
+
+		t.Run(tc.Name, func(t *testing.T) {
+			for n, s := range tc.Sweepers {
+				AddTestSweepers(n, s)
+			}
+			*flagSweepRun = tc.SweepRun
+
+			// Verify it does not exit/panic
+			TestMain(&testing.M{})
+		})
+	}
+}
+
+func TestFilterSweepers(t *testing.T) {
+	cases := []struct {
+		Name             string
+		Sweepers         map[string]*Sweeper
+		Filter           string
+		ExpectedSweepers []string
+	}{
+		{
+			Name: "normal",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedSweepers: []string{"aws_dummy"},
 		},
 		{
 			Name: "with dep",
@@ -840,7 +875,7 @@ func TestTest_Main(t *testing.T) {
 					F:    mockSweeperFunc,
 				},
 			},
-			ExpectedRunList: []string{"aws_dummy", "aws_sub", "aws_top"},
+			ExpectedSweepers: []string{"aws_dummy", "aws_sub", "aws_top"},
 		},
 		{
 			Name: "with filter",
@@ -859,8 +894,8 @@ func TestTest_Main(t *testing.T) {
 					F:    mockSweeperFunc,
 				},
 			},
-			ExpectedRunList: []string{"aws_dummy"},
-			SweepRun:        "aws_dummy",
+			ExpectedSweepers: []string{"aws_dummy"},
+			Filter:           "aws_dummy",
 		},
 		{
 			Name: "with two filters",
@@ -879,8 +914,8 @@ func TestTest_Main(t *testing.T) {
 					F:    mockSweeperFunc,
 				},
 			},
-			ExpectedRunList: []string{"aws_dummy", "aws_sub"},
-			SweepRun:        "aws_dummy,aws_sub",
+			ExpectedSweepers: []string{"aws_dummy", "aws_sub"},
+			Filter:           "aws_dummy,aws_sub",
 		},
 		{
 			Name: "with dep and filter",
@@ -899,8 +934,8 @@ func TestTest_Main(t *testing.T) {
 					F:    mockSweeperFunc,
 				},
 			},
-			ExpectedRunList: []string{"aws_top", "aws_sub"},
-			SweepRun:        "aws_top",
+			ExpectedSweepers: []string{"aws_top"},
+			Filter:           "aws_top",
 		},
 		{
 			Name: "filter and none",
@@ -919,7 +954,7 @@ func TestTest_Main(t *testing.T) {
 					F:    mockSweeperFunc,
 				},
 			},
-			SweepRun: "none",
+			Filter: "none",
 		},
 	}
 
@@ -928,16 +963,194 @@ func TestTest_Main(t *testing.T) {
 		sweeperFuncs = map[string]*Sweeper{}
 
 		t.Run(tc.Name, func(t *testing.T) {
-			for n, s := range tc.Sweepers {
-				AddTestSweepers(n, s)
-			}
-			*flagSweepRun = tc.SweepRun
+			actualSweepers := filterSweepers(tc.Filter, tc.Sweepers)
 
-			TestMain(&testing.M{})
+			var keys []string
+			for k, _ := range actualSweepers {
+				keys = append(keys, k)
+			}
+
+			sort.Strings(keys)
+			sort.Strings(tc.ExpectedSweepers)
+			if !reflect.DeepEqual(keys, tc.ExpectedSweepers) {
+				t.Fatalf("Expected keys mismatch, expected:\n%#v\ngot:\n%#v\n", tc.ExpectedSweepers, keys)
+			}
+		})
+	}
+}
+
+func TestRunSweepers(t *testing.T) {
+	cases := []struct {
+		Name            string
+		Sweepers        map[string]*Sweeper
+		ExpectedRunList []string
+		SweepRun        string
+		AllowFailures   bool
+		ExpectError     bool
+	}{
+		{
+			Name: "single",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy"},
+		},
+		{
+			Name: "multiple",
+			Sweepers: map[string]*Sweeper{
+				"aws_one": &Sweeper{
+					Name: "aws_one",
+					F:    mockSweeperFunc,
+				},
+				"aws_two": &Sweeper{
+					Name: "aws_two",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_one", "aws_two"},
+		},
+		{
+			Name: "multiple with dep",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy", "aws_sub", "aws_top"},
+		},
+		{
+			Name: "failing dep",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockFailingSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub"},
+			ExpectError:     true,
+		},
+		{
+			Name: "failing dep allow failures",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockFailingSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub", "aws_top"},
+			AllowFailures:   true,
+			ExpectError:     true,
+		},
+		{
+			Name: "failing top",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockFailingSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub", "aws_top"},
+			ExpectError:     true,
+		},
+		{
+			Name: "failing top allow failures",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockFailingSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub", "aws_top"},
+			AllowFailures:   true,
+			ExpectError:     true,
+		},
+		{
+			Name: "failing top and dep",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockFailingSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockFailingSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub"},
+			ExpectError:     true,
+		},
+		{
+			Name: "failing top and dep allow failues",
+			Sweepers: map[string]*Sweeper{
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockFailingSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockFailingSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_sub", "aws_top"},
+			AllowFailures:   true,
+			ExpectError:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		// reset sweepers
+		sweeperFuncs = map[string]*Sweeper{}
+
+		t.Run(tc.Name, func(t *testing.T) {
+			sweeperRunList, err := runSweepers([]string{"test"}, tc.Sweepers, tc.AllowFailures)
+			fmt.Printf("sweeperRunList: %#v\n", sweeperRunList)
+
+			if err == nil && tc.ExpectError {
+				t.Fatalf("expected error, did not receive error")
+			}
+
+			if err != nil && !tc.ExpectError {
+				t.Fatalf("did not expect error, received error: %s", err)
+			}
 
 			// get list of tests ran from sweeperRunList keys
 			var keys []string
-			for k, _ := range sweeperRunList {
+			for k, _ := range sweeperRunList["test"] {
 				keys = append(keys, k)
 			}
 
@@ -948,6 +1161,10 @@ func TestTest_Main(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mockFailingSweeperFunc(s string) error {
+	return errors.New("failing sweeper")
 }
 
 func mockSweeperFunc(s string) error {


### PR DESCRIPTION
Due to various circumstances, such as a remote API unexpectedly breaking compatibility in a dependency sweeper, it can be desirable to allow the sweepers to continue after failures. This gives the operator the opportunity to try cleaning up other, unrelated infrastructure by using a new `-sweep-allow-failures` flag.

It is still up to the resource implementations to allow continuing on failures within the same sweeper, rather than exiting on the first failure encountered.

Without new flag (same previous behavior on successful sweepers):

```console
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_dx_gateway_association_proposal -timeout 10h
2019/10/08 11:39:30 [DEBUG] Running Sweepers for region (us-west-2):
2019/10/08 11:39:30 [DEBUG] Running Sweeper (aws_dx_gateway_association_proposal) in region (us-west-2)
2019/10/08 11:39:32 Sweeper Tests ran successfully:
  - aws_dx_gateway_association_proposal
ok    github.com/terraform-providers/terraform-provider-aws/aws 3.171s
$ echo $?
0
```

Without new flag (same previous behavior on failing sweepers):

```console
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_vpn_gateway -timeout 10h
2019/10/08 10:44:53 [DEBUG] Running Sweepers for region (us-west-2):
2019/10/08 10:44:53 [DEBUG] Sweeper (aws_vpn_gateway) has dependency (aws_dx_gateway_association), running..
2019/10/08 10:44:53 [DEBUG] Sweeper (aws_dx_gateway_association) has dependency (aws_dx_gateway_association_proposal), running..
2019/10/08 10:44:53 [DEBUG] Running Sweeper (aws_dx_gateway_association_proposal) in region (us-west-2)
2019/10/08 10:44:55 [DEBUG] Running Sweeper (aws_dx_gateway_association) in region (us-west-2)
2019/10/08 10:44:57 [INFO] Deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association: vgw-0dc65a74a20f0ff68
2019/10/08 10:44:58 [ERROR] Error running Sweeper (aws_dx_gateway_association) in region (us-west-2): error deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association (vgw-0dc65a74a20f0ff68): DirectConnectServerException: Unable to process request
  status code: 400, request id: 12c9dad0-add9-4726-ad39-5d02c529bd4c
FAIL  github.com/terraform-providers/terraform-provider-aws/aws 5.569s
FAIL
$ echo $?
1
```

With new flag:

```console
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_vpn_gateway -sweep-allow-failures -timeout 10h
2019/10/08 10:47:13 [DEBUG] Running Sweepers for region (us-west-2):
2019/10/08 10:47:13 [DEBUG] Sweeper (aws_vpn_gateway) has dependency (aws_dx_gateway_association), running..
2019/10/08 10:47:13 [DEBUG] Sweeper (aws_dx_gateway_association) has dependency (aws_dx_gateway_association_proposal), running..
2019/10/08 10:47:13 [DEBUG] Running Sweeper (aws_dx_gateway_association_proposal) in region (us-west-2)
2019/10/08 10:47:15 [DEBUG] Running Sweeper (aws_dx_gateway_association) in region (us-west-2)
2019/10/08 10:47:16 [INFO] Deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association: vgw-0dc65a74a20f0ff68
2019/10/08 10:47:17 [ERROR] Error running Sweeper (aws_dx_gateway_association) in region (us-west-2): error deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association (vgw-0dc65a74a20f0ff68): DirectConnectServerException: Unable to process request
  status code: 400, request id: df997347-77eb-49d4-8a8f-2d3fd6bc7b59
2019/10/08 10:47:17 [ERROR] Error running Sweeper (aws_dx_gateway_association) in region (us-west-2): error deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association (vgw-0dc65a74a20f0ff68): DirectConnectServerException: Unable to process request
  status code: 400, request id: df997347-77eb-49d4-8a8f-2d3fd6bc7b59
2019/10/08 10:47:17 [DEBUG] Running Sweeper (aws_vpn_gateway) in region (us-west-2)
2019/10/08 10:47:18 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-0d83012901b4c0903",
  VpnGatewayId: "vgw-068137a16116b907b"
}
2019/10/08 10:47:18 [DEBUG] Waiting for VPN Gateway (vgw-068137a16116b907b) to detach from VPC (vpc-0d83012901b4c0903)
2019/10/08 10:47:18 [DEBUG] Waiting for state to become: [detached]
2019/10/08 10:52:15 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-068137a16116b907b"
}
2019/10/08 10:52:16 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-0c62fd27265656c2e",
  VpnGatewayId: "vgw-01b70692831191788"
}
2019/10/08 10:52:16 [DEBUG] Waiting for VPN Gateway (vgw-01b70692831191788) to detach from VPC (vpc-0c62fd27265656c2e)
2019/10/08 10:52:16 [DEBUG] Waiting for state to become: [detached]
2019/10/08 10:57:23 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-01b70692831191788"
}
2019/10/08 10:57:24 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-05d5a615959157f27",
  VpnGatewayId: "vgw-0aa8c6fae0a604e10"
}
2019/10/08 10:57:24 [DEBUG] Waiting for VPN Gateway (vgw-0aa8c6fae0a604e10) to detach from VPC (vpc-05d5a615959157f27)
2019/10/08 10:57:24 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:02:32 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-0aa8c6fae0a604e10"
}
2019/10/08 11:02:32 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-0d3407641bd047759",
  VpnGatewayId: "vgw-07576dd2891f26542"
}
2019/10/08 11:02:32 [DEBUG] Waiting for VPN Gateway (vgw-07576dd2891f26542) to detach from VPC (vpc-0d3407641bd047759)
2019/10/08 11:02:32 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:07:50 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-07576dd2891f26542"
}
2019/10/08 11:07:51 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-06287cc0559c30024",
  VpnGatewayId: "vgw-01631d746dfe99ebf"
}
2019/10/08 11:07:51 [DEBUG] Waiting for VPN Gateway (vgw-01631d746dfe99ebf) to detach from VPC (vpc-06287cc0559c30024)
2019/10/08 11:07:51 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:12:59 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-01631d746dfe99ebf"
}
2019/10/08 11:12:59 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-08b202d4b25465bdc",
  VpnGatewayId: "vgw-0ed99c4a2b8d6a339"
}
2019/10/08 11:13:00 [DEBUG] Waiting for VPN Gateway (vgw-0ed99c4a2b8d6a339) to detach from VPC (vpc-08b202d4b25465bdc)
2019/10/08 11:13:00 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:18:07 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-0ed99c4a2b8d6a339"
}
2019/10/08 11:18:07 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-09424d73ee3dfb159",
  VpnGatewayId: "vgw-06169f1efed128de4"
}
2019/10/08 11:18:08 [DEBUG] Waiting for VPN Gateway (vgw-06169f1efed128de4) to detach from VPC (vpc-09424d73ee3dfb159)
2019/10/08 11:18:08 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:23:15 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-06169f1efed128de4"
}
2019/10/08 11:23:16 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-0401f3706243dad85",
  VpnGatewayId: "vgw-0dc65a74a20f0ff68"
}
2019/10/08 11:23:16 [DEBUG] Waiting for VPN Gateway (vgw-0dc65a74a20f0ff68) to detach from VPC (vpc-0401f3706243dad85)
2019/10/08 11:23:16 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:28:23 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-0dc65a74a20f0ff68"
}
2019/10/08 11:28:24 [DEBUG] Detaching VPN Gateway: {
  VpcId: "vpc-09e0bf3c6ea53ee5f",
  VpnGatewayId: "vgw-0f26b1614d922a13d"
}
2019/10/08 11:28:24 [DEBUG] Waiting for VPN Gateway (vgw-0f26b1614d922a13d) to detach from VPC (vpc-09e0bf3c6ea53ee5f)
2019/10/08 11:28:24 [DEBUG] Waiting for state to become: [detached]
2019/10/08 11:33:42 [DEBUG] Deleting VPN Gateway: {
  VpnGatewayId: "vgw-0f26b1614d922a13d"
}
2019/10/08 11:33:42 Sweeper Tests ran successfully:
  - aws_dx_gateway_association_proposal
  - aws_vpn_gateway
2019/10/08 11:33:42 Sweeper Tests ran unsuccessfully:
  - aws_dx_gateway_association: error deleting Direct Connect Gateway (5a00fd97-9872-447d-822c-d2a6245e22d6) Association (vgw-0dc65a74a20f0ff68): DirectConnectServerException: Unable to process request
  status code: 400, request id: df997347-77eb-49d4-8a8f-2d3fd6bc7b59
FAIL  github.com/terraform-providers/terraform-provider-aws/aws 2790.472s
FAIL
$ echo $?
1
```