### PR TITLE
Add 'StringDoesNotContainAny' validation function

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -339,3 +339,22 @@ func FloatBetween(min, max float64) schema.SchemaValidateFunc {
 		return
 	}
 }
+
+// StringDoesNotContainAny returns a SchemaValidateFunc which validates that the
+// provided value does not contain any of the specified Unicode code points in chars.
+func StringDoesNotContainAny(chars string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		if strings.ContainsAny(v, chars) {
+			es = append(es, fmt.Errorf("expected value of %s to not contain any of %q", k, chars))
+			return
+		}
+
+		return
+	}
+}

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -498,3 +498,31 @@ func TestFloatBetween(t *testing.T) {
 		}
 	}
 }
+
+func TestStringDoesNotContainAny(t *testing.T) {
+	chars := "|:/"
+
+	validStrings := []string{
+		"HelloWorld",
+		"ABC_*&^%123",
+	}
+	for _, v := range validStrings {
+		_, errors := StringDoesNotContainAny(chars)(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should not contain any of %q", v, chars)
+		}
+	}
+
+	invalidStrings := []string{
+		"Hello/World",
+		"ABC|123",
+		"This will fail:",
+		chars,
+	}
+	for _, v := range invalidStrings {
+		_, errors := StringDoesNotContainAny(chars)(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should contain one of %q", v, chars)
+		}
+	}
+}


### PR DESCRIPTION
Add `StringDoesNotContainAny()`, a validator to ensure that the provided value does not contain any of the specified Unicode code points in chars.

```console
$ make test
==> Checking that code complies with gofmt requirements...
go generate ./...
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/acctest	0.016s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/customdiff	0.017s
?   	github.com/hashicorp/terraform-plugin-sdk/helper/encryption	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/hashcode	0.001s
?   	github.com/hashicorp/terraform-plugin-sdk/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv	0.052s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents	0.008s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/resource	3.039s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	0.063s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/structure	0.030s
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/validation	0.016s
ok  	github.com/hashicorp/terraform-plugin-sdk/httpclient	0.005s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/addrs	0.014s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/command/format	0.020s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs	0.025s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload	0.012s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema	0.008s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim	0.010s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/dag	1.411s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/flatmap	0.009s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/config	0.028s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean	0.001s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/experiment	0.014s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin	0.031s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/httpclient	0.004s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/initwd	0.020s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang	0.040s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr	0.024s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs	0.140s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/modsdir	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps	0.011s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans	0.010s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plans/internal/planproto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange	0.013s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/planfile	0.013s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert	0.011s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery	0.029s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/providers	0.020s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/provisioners	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry	0.009s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc	0.003s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/response	0.002s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/registry/test	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states	0.003s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile	0.008s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/svchost	0.003s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/svchost/auth	0.608s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco	0.040s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags	0.010s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys	0.243s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil	0.004s
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil	0.011s
?   	github.com/hashicorp/terraform-plugin-sdk/internal/version	[no test files]
?   	github.com/hashicorp/terraform-plugin-sdk/meta	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/plugin	0.075s
ok  	github.com/hashicorp/terraform-plugin-sdk/terraform	3.644s
```