### PR TITLE
Remove testing package from helper/schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mitchellh/reflectwalk v1.0.1

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -1,14 +1,13 @@
 package schema
 
 import (
-	"testing"
-
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestResourceDataRaw creates a ResourceData from a raw configuration map.
 func TestResourceDataRaw(
-	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	t testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
 	t.Helper()
 
 	c := terraform.NewResourceConfigRaw(raw)


### PR DESCRIPTION
"testing" package dependency causes users of helper/schema to import testing flags in their apps as they are defined on static

There is a simular problem in helpers/resource package.
TestMain defined in helpers/resource  and this brings more problems. Probably testing.go should be extracted to separate package, but that change would probably break compatibility. It also contains staticly defined flags, that could affect user applications.