### PR TITLE
hashibot: configure provider org migrator

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -3,6 +3,20 @@ behavior "remove_labels_on_reply" "remove_stale" {
     only_non_maintainers = true
 }
 
+poll "label_issue_migrater" "provider_migrater" {
+    schedule = "0 40 * * * *"
+    new_owner = env.PROVIDERS_OWNER
+    repo_prefix = "terraform-provider-"
+    label_prefix = "provider/"
+    issue_header = <<-EOF
+    _This issue was originally opened by @${var.user} as ${var.repository}#${var.issue_number}. The original body of the issue is below._
+    
+    <hr>
+    
+    EOF
+    migrated_comment = "This issue has been automatically migrated to ${var.repository}#${var.issue_number} because it looks like an issue with that provider. If you believe this is _not_ an issue with the provider, please reply to ${var.repository}#${var.issue_number}."
+}
+
 poll "closed_issue_locker" "locker" {
   schedule             = "0 50 1 * * *"
   closed_for           = "720h" # 30 days


### PR DESCRIPTION
Simply label an issue `provider/<name>` and it will be migrated just like how Core is handled. The `name` is lifted from the label and the repo name is constructed as `<new_owner>/<repo_prefix><name>`