### PR TITLE
Add 'FloatAtLeast' and 'FloatAtMost' validation functions

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -340,6 +340,44 @@ func FloatBetween(min, max float64) schema.SchemaValidateFunc {
 	}
 }
 
+// FloatAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type float and is at least min (inclusive)
+func FloatAtLeast(min float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%f), got %f", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// FloatAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type float and is at most max (inclusive)
+func FloatAtMost(max float64) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(float64)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be float", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%f), got %f", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
 // StringDoesNotContainAny returns a SchemaValidateFunc which validates that the
 // provided value does not contain any of the specified Unicode code points in chars.
 func StringDoesNotContainAny(chars string) schema.SchemaValidateFunc {


### PR DESCRIPTION
Add `FloatAtLeast()` and `FloatAtMost()`, validators to ensure that the provided value is at least a specified value and at most a specified value, respectively.
Pulled over from https://github.com/terraform-providers/terraform-provider-aws/pull/2477.

```console
$ make test
==> Checking that code complies with gofmt requirements...
go generate ./...
go test ./...
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/acctest	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/customdiff	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/encryption	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/hashcode	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/resource	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/structure	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/validation	0.215s
ok  	github.com/hashicorp/terraform-plugin-sdk/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/addrs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/command/format	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/dag	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/flatmap	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/config	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/experiment	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/initwd	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/modsdir	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plans/internal/planproto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/planfile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/providers	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/provisioners	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/response	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/registry/test	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/version	[no test files]
?   	github.com/hashicorp/terraform-plugin-sdk/meta	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/terraform	(cached)
```