### PR TITLE
Add 'StringDoesNotMatch' validation function

### DIFF
--- a/helper/validation/validation.go
+++ b/helper/validation/validation.go
@@ -183,6 +183,27 @@ func StringMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
 	}
 }
 
+// StringDoesNotMatch returns a SchemaValidateFunc which tests if the provided value
+// does not match a given regexp. Optionally an error message can be provided to
+// return something friendlier than "must not match some globby regexp".
+func StringDoesNotMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) ([]string, []error) {
+		v, ok := i.(string)
+		if !ok {
+			return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+		}
+
+		if ok := r.MatchString(v); ok {
+			if message != "" {
+				return nil, []error{fmt.Errorf("invalid value for %s (%s)", k, message)}
+
+			}
+			return nil, []error{fmt.Errorf("expected value of %s to not match regular expression %q", k, r)}
+		}
+		return nil, nil
+	}
+}
+
 // NoZeroValues is a SchemaValidateFunc which tests if the provided value is
 // not a zero value. It's useful in situations where you want to catch
 // explicit zero values on things like required fields during validation.

--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -212,6 +212,25 @@ func TestValidationStringMatch(t *testing.T) {
 	})
 }
 
+func TestValidationStringDoesNotMatch(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "foobar",
+			f:   StringDoesNotMatch(regexp.MustCompile(".*baz.*"), ""),
+		},
+		{
+			val:         "bar",
+			f:           StringDoesNotMatch(regexp.MustCompile(".*bar.*"), ""),
+			expectedErr: regexp.MustCompile("expected value of [\\w]+ to not match regular expression " + regexp.QuoteMeta(`".*bar.*"`)),
+		},
+		{
+			val:         "bar",
+			f:           StringDoesNotMatch(regexp.MustCompile(".*bar.*"), "value must not contain foo"),
+			expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must not contain foo\\)"),
+		},
+	})
+}
+
 func TestValidationRegexp(t *testing.T) {
 	runTestCases(t, []testCase{
 		{


### PR DESCRIPTION
Add `StringDoesNotMatch()`, a validator to ensure that the provided value does NOT match a given regular expression.
Pulled over from https://github.com/terraform-providers/terraform-provider-aws/pull/9941.

```console
$ make test
==> Checking that code complies with gofmt requirements...
go generate ./...
go test ./...
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/acctest	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/customdiff	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/encryption	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/hashcode	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/resource	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/structure	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/validation	0.221s
ok  	github.com/hashicorp/terraform-plugin-sdk/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/addrs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/command/format	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/dag	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/flatmap	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/config	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/experiment	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/initwd	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/modsdir	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plans/internal/planproto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/planfile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/providers	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/provisioners	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/response	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/registry/test	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/version	[no test files]
?   	github.com/hashicorp/terraform-plugin-sdk/meta	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/terraform	(cached)
```