### PR TITLE
ResourceData: create variadic 'HasChanges' method

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -133,6 +133,16 @@ func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	return d.get(parts, level)
 }
 
+// HasChanges returns whether or not any of the given keys has been changed.
+func (d *ResourceData) HasChanges(keys ...string) bool {
+	for _, key := range keys {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasChange returns whether or not the given key has been changed.
 func (d *ResourceData) HasChange(key string) bool {
 	o, n := d.GetChange(key)


### PR DESCRIPTION
~I'm open to bikeshedding on the function name. Strongest alternative probably `HasChanges` (this alternative just "feels better" than `HaveChange` I may switch if there is support for it)?~ Voted on `HasChanges` Practically speaking we could have switched `HasChange` itself to be variadic and it likely wouldn't have broken anything in the real world, however from a compiled language/type signature point of view anyone who has assigned this method (unlikely) would experience a breaking change (the rare L for compiled languages).

Also I'm allowing a noop call `d.HasChanges()` I wasn't sure maybe it should panic without a single key? Could change signature to
```
func (d *ResourceData) HasChanges(firstKey string, others ...string) bool
```

Closes #194 