### PR TITLE
github: Add issue templates & links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,75 @@
+---
+name: 🐛 Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+labels: bug
+---
+
+### SDK version
+<!---
+Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
+
+go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk")'
+
+If you are not running the latest version of the SDK, please try upgrading
+because your bug may have already been fixed.
+
+If the command above doesn't yield any results, it means you may not have migrated
+to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html for more.
+-->
+
+```
+...
+```
+
+### Relevant provider source code
+
+<!--
+Paste any Go code that you believe to be relevant to the bug
+e.g. schema or implementation of CRUD for a given resource or data source
+-->
+```go
+...
+```
+
+### Terraform Configuration Files
+<!--
+Paste the relevant parts of your Terraform configuration between the ``` marks below.
+
+For large Terraform configs, please use a service like Dropbox and share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
+-->
+
+```hcl
+...
+```
+
+### Debug Output
+<!--
+Full debug output can be obtained by running Terraform with the environment variable `TF_LOG=trace`. Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long.
+
+Debug output may contain sensitive information. Please review it before posting publicly, and if you are concerned feel free to encrypt the files using the HashiCorp security public key.
+-->
+
+
+### Expected Behavior
+<!--
+What should have happened?
+-->
+
+### Actual Behavior
+<!--
+What actually happened?
+-->
+
+### Steps to Reproduce
+<!--
+Please list the full steps required to reproduce the issue, for example:
+1. `terraform init`
+2. `terraform apply`
+-->
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+
+- #6017
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Provider-related Feedback and Questions
+    url: https://github.com/terraform-providers
+    about: Each provider (e.g. AWS, Azure, GCP, Oracle, K8S, etc.) has its own repository, any provider related issues or questions should be directed to appropriate provider repository.
+  - name: Terraform Language or Workflow Feedback and Questions
+    url: https://github.com/hashicorp/terraform/issues/new/choose
+    about: Terraform Core has its own repository, any language (HCL) or workflow related issues or questions should be directed there.
+  - name: ❓ Plugin SDK Questions
+    url: https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk
+    about: Please ask and answer SDK related questions through the Plugin SDK Community Forum.
+  - name: 🔓 Security Vulnerability
+    url: https://www.hashicorp.com/security.html
+    about: Please report security vulnerabilities responsibly.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,53 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+labels: enhancement
+---
+
+### SDK version
+<!--
+Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
+
+go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk")'
+
+If you are not running the latest version of the SDK, please try upgrading
+because your feature may have already been implemented.
+
+If the command above doesn't yield any results, it means you may not have migrated
+to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html for more.
+-->
+```
+...
+```
+
+### Use-cases
+<!---
+In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
+Please describe below the _end goal_ you are trying to achieve that has led you to request this feature.
+Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
+-->
+
+### Attempted Solutions
+<!---
+If you've already tried to solve the problem within SDK's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+
+Ideally, this would include real HCL configuration that you tried, real Terraform command lines you ran, relevant snippet of code from your provider codebase and what results you got in each case.
+
+Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
+--->
+
+### Proposal
+<!---
+If you have an idea for a way to address the problem via a change to SDK features, please describe it below.
+
+In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or on the command line, since that allows us to understand the full picture of what you are proposing.
+
+If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of the SDK and Terraform Core.
+-->
+
+### References
+<!--
+Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please create a list below that mentions each of them. For example:
+
+- #6017
+-->


### PR DESCRIPTION
This is to forward questions to our forum a bit more aggressively by hiding link to blank issues and making links to the forum more visible. I also added links to help users navigate in case they have anything provider-related or core-related.

![Screenshot 2019-11-25 at 14 56 00](https://user-images.githubusercontent.com/287584/69550917-c0f34900-0f93-11ea-9ae1-b87221dd6272.png)
