### PR TITLE
Binary acceptance test driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 1.7.0 (Unreleased)
 
+FEATURES:
+* Binary acceptance test driver [GH-262]
+
 DEPRECATED:
 
 * helper/schema: `ResourceData.Partial` [GH-317]

--- a/acctest/helper.go
+++ b/acctest/helper.go
@@ -1,0 +1,26 @@
+package acctest
+
+import (
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-sdk/plugin"
+	tftest "github.com/hashicorp/terraform-plugin-test"
+)
+
+var TestHelper *tftest.Helper
+
+func UseBinaryDriver(name string, providerFunc plugin.ProviderFunc) {
+	sourceDir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	if tftest.RunningAsPlugin() {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: providerFunc,
+		})
+		os.Exit(0)
+	} else {
+		TestHelper = tftest.AutoInitProviderHelper(name, sourceDir)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	github.com/hashicorp/hcl/v2 v2.0.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8
+	github.com/hashicorp/terraform-json v0.4.0
+	github.com/hashicorp/terraform-plugin-test v1.2.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba
@@ -42,7 +44,7 @@ require (
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
-	github.com/zclconf/go-cty v1.1.0
+	github.com/zclconf/go-cty v1.2.1
 	github.com/zclconf/go-cty-yaml v1.0.1
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,10 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8 h1:+RyjwU+Gnd/aTJBPZVDNm903eXVjjqhbaR4Ypx3xYyY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
+github.com/hashicorp/terraform-json v0.4.0 h1:KNh29iNxozP5adfUFBJ4/fWd0Cu3taGgjHB38JYqOF4=
+github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
+github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=
+github.com/hashicorp/terraform-plugin-test v1.2.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -181,6 +185,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=
+github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -3,15 +3,16 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
-	"github.com/zclconf/go-cty/cty"
-
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // shimState takes a new *states.State and reverts it to a legacy state for the provider ACC tests
@@ -185,4 +186,280 @@ func shimmedAttributes(instance *states.ResourceInstanceObjectSrc, res *schema.R
 	}
 
 	return instanceState.Attributes, nil
+}
+
+type shimmedState struct {
+	state *terraform.State
+}
+
+func shimStateFromJson(jsonState *tfjson.State) (*terraform.State, error) {
+	state := terraform.NewState()
+	state.TFVersion = jsonState.TerraformVersion
+
+	if jsonState.Values == nil {
+		// the state is empty
+		return state, nil
+	}
+
+	for key, output := range jsonState.Values.Outputs {
+		os, err := shimOutputState(output)
+		if err != nil {
+			return nil, err
+		}
+		state.RootModule().Outputs[key] = os
+	}
+
+	ss := &shimmedState{state}
+	err := ss.shimStateModule(jsonState.Values.RootModule)
+	if err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+func shimOutputState(so *tfjson.StateOutput) (*terraform.OutputState, error) {
+	os := &terraform.OutputState{
+		Sensitive: so.Sensitive,
+	}
+
+	switch v := so.Value.(type) {
+	case string:
+		os.Type = "string"
+		os.Value = v
+		return os, nil
+	case []interface{}:
+		os.Type = "list"
+		if len(v) == 0 {
+			os.Value = v
+			return os, nil
+		}
+		switch firstElem := v[0].(type) {
+		case string:
+			elements := make([]interface{}, len(v))
+			for i, el := range v {
+				elements[i] = el.(string)
+			}
+			os.Value = elements
+		case bool:
+			elements := make([]interface{}, len(v))
+			for i, el := range v {
+				elements[i] = el.(bool)
+			}
+			os.Value = elements
+		// unmarshalled number from JSON will always be float64
+		case float64:
+			elements := make([]interface{}, len(v))
+			for i, el := range v {
+				elements[i] = el.(float64)
+			}
+			os.Value = elements
+		case []interface{}:
+			os.Value = v
+		case map[string]interface{}:
+			os.Value = v
+		default:
+			return nil, fmt.Errorf("unexpected output list element type: %T", firstElem)
+		}
+		return os, nil
+	case map[string]interface{}:
+		os.Type = "map"
+		os.Value = v
+		return os, nil
+	case bool:
+		os.Type = "string"
+		os.Value = strconv.FormatBool(v)
+		return os, nil
+	// unmarshalled number from JSON will always be float64
+	case float64:
+		os.Type = "string"
+		os.Value = strconv.FormatFloat(v, 'f', -1, 64)
+		return os, nil
+	}
+
+	return nil, fmt.Errorf("unexpected output type: %T", so.Value)
+}
+
+func (ss *shimmedState) shimStateModule(sm *tfjson.StateModule) error {
+	var path addrs.ModuleInstance
+
+	if sm.Address == "" {
+		path = addrs.RootModuleInstance
+	} else {
+		var diags tfdiags.Diagnostics
+		path, diags = addrs.ParseModuleInstanceStr(sm.Address)
+		if diags.HasErrors() {
+			return diags.Err()
+		}
+	}
+
+	mod := ss.state.AddModule(path)
+	for _, res := range sm.Resources {
+		resourceState, err := shimResourceState(res)
+		if err != nil {
+			return err
+		}
+
+		key, err := shimResourceStateKey(res)
+		if err != nil {
+			return err
+		}
+
+		mod.Resources[key] = resourceState
+	}
+
+	if len(sm.ChildModules) > 0 {
+		return fmt.Errorf("Modules are not supported. Found %d modules.",
+			len(sm.ChildModules))
+	}
+	return nil
+}
+
+func shimResourceStateKey(res *tfjson.StateResource) (string, error) {
+	if res.Index == nil {
+		return res.Address, nil
+	}
+
+	var mode terraform.ResourceMode
+	switch res.Mode {
+	case tfjson.DataResourceMode:
+		mode = terraform.DataResourceMode
+	case tfjson.ManagedResourceMode:
+		mode = terraform.ManagedResourceMode
+	default:
+		return "", fmt.Errorf("unexpected resource mode for %q", res.Address)
+	}
+
+	var index int
+	switch idx := res.Index.(type) {
+	case float64:
+		index = int(idx)
+	default:
+		return "", fmt.Errorf("unexpected index type (%T) for %q, "+
+			"for_each is not supported", res.Index, res.Address)
+	}
+
+	rsk := &terraform.ResourceStateKey{
+		Mode:  mode,
+		Type:  res.Type,
+		Name:  res.Name,
+		Index: index,
+	}
+
+	return rsk.String(), nil
+}
+
+func shimResourceState(res *tfjson.StateResource) (*terraform.ResourceState, error) {
+	sf := &shimmedFlatmap{}
+	err := sf.FromMap(res.AttributeValues)
+	if err != nil {
+		return nil, err
+	}
+	attributes := sf.Flatmap()
+
+	if _, ok := attributes["id"]; !ok {
+		return nil, fmt.Errorf("no %q found in attributes", "id")
+	}
+
+	return &terraform.ResourceState{
+		Provider: res.ProviderName,
+		Type:     res.Type,
+		Primary: &terraform.InstanceState{
+			ID:         attributes["id"],
+			Attributes: attributes,
+			Meta: map[string]interface{}{
+				"schema_version": int(res.SchemaVersion),
+			},
+			Tainted: res.Tainted,
+		},
+		Dependencies: res.DependsOn,
+	}, nil
+}
+
+type shimmedFlatmap struct {
+	m map[string]string
+}
+
+func (sf *shimmedFlatmap) FromMap(attributes map[string]interface{}) error {
+	if sf.m == nil {
+		sf.m = make(map[string]string, len(attributes))
+	}
+
+	return sf.AddMap("", attributes)
+}
+
+func (sf *shimmedFlatmap) AddMap(prefix string, m map[string]interface{}) error {
+	for key, value := range m {
+		k := key
+		if prefix != "" {
+			k = fmt.Sprintf("%s.%s", prefix, key)
+		}
+
+		err := sf.AddEntry(k, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	mapLength := "%"
+	if prefix != "" {
+		mapLength = fmt.Sprintf("%s.%s", prefix, "%")
+	}
+
+	sf.AddEntry(mapLength, strconv.Itoa(len(m)))
+
+	return nil
+}
+
+func (sf *shimmedFlatmap) AddSlice(name string, elements []interface{}) error {
+	for i, elem := range elements {
+		key := fmt.Sprintf("%s.%d", name, i)
+		err := sf.AddEntry(key, elem)
+		if err != nil {
+			return err
+		}
+	}
+
+	sliceLength := fmt.Sprintf("%s.#", name)
+	sf.AddEntry(sliceLength, strconv.Itoa(len(elements)))
+
+	return nil
+}
+
+func (sf *shimmedFlatmap) AddEntry(key string, value interface{}) error {
+	switch el := value.(type) {
+	case nil:
+		// omit the entry
+		return nil
+	case bool:
+		sf.m[key] = strconv.FormatBool(el)
+	case float64:
+		sf.m[key] = strconv.FormatFloat(el, 'f', -1, 64)
+	case string:
+		sf.m[key] = el
+	case map[string]interface{}:
+		err := sf.AddMap(key, el)
+		if err != nil {
+			return err
+		}
+	case []interface{}:
+		err := sf.AddSlice(key, el)
+		if err != nil {
+			return err
+		}
+	default:
+		// This should never happen unless terraform-json
+		// changes how attributes (types) are represented.
+		//
+		// We handle all types which the JSON unmarshaler
+		// can possibly produce
+		// https://golang.org/pkg/encoding/json/#Unmarshal
+
+		return fmt.Errorf("%q: unexpected type (%T)", key, el)
+	}
+	return nil
+}
+
+func (sf *shimmedFlatmap) Flatmap() map[string]string {
+	return sf.m
 }

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -328,6 +328,11 @@ type TestCase struct {
 	// IDRefreshIgnore is a list of configuration keys that will be ignored.
 	IDRefreshName   string
 	IDRefreshIgnore []string
+
+	// DisableBinaryDriver forces this test case to run using the legacy test
+	// driver, even if the binary test driver has been enabled.
+	// This property will be removed in version 2.0.0 of the SDK.
+	DisableBinaryDriver bool
 }
 
 // TestStep is a single apply sequence of a test, done within the
@@ -567,7 +572,7 @@ func Test(t TestT, c TestCase) {
 		providers[name] = p
 	}
 
-	if acctest.TestHelper != nil {
+	if acctest.TestHelper != nil && c.DisableBinaryDriver == false {
 		// inject providers for ImportStateVerify
 		RunNewTest(t.(*testing.T), c, providers)
 		return

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -1,0 +1,179 @@
+package resource
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-sdk/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	tftest "github.com/hashicorp/terraform-plugin-test"
+)
+
+func getState(t *testing.T, wd *tftest.WorkingDir) *terraform.State {
+	jsonState := wd.RequireState(t)
+	state, err := shimStateFromJson(jsonState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func RunNewTest(t *testing.T, c TestCase, providers map[string]terraform.ResourceProvider) {
+	spewConf := spew.NewDefaultConfig()
+	spewConf.SortKeys = true
+	wd := acctest.TestHelper.RequireNewWorkingDir(t)
+
+	defer func() {
+		wd.RequireDestroy(t)
+
+		if c.CheckDestroy != nil {
+			statePostDestroy := getState(t, wd)
+
+			if err := c.CheckDestroy(statePostDestroy); err != nil {
+				t.Fatal(err)
+			}
+		}
+		wd.Close()
+	}()
+
+	providerCfg := testProviderConfig(c)
+
+	wd.RequireSetConfig(t, providerCfg)
+	wd.RequireInit(t)
+
+	// use this to track last step succesfully applied
+	// acts as default for import tests
+	var appliedCfg string
+
+	for i, step := range c.Steps {
+
+		if step.PreConfig != nil {
+			step.PreConfig()
+		}
+
+		if step.SkipFunc != nil {
+			skip, err := step.SkipFunc()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if skip {
+				log.Printf("[WARN] Skipping step %d", i)
+				continue
+			}
+		}
+
+		if step.ImportState {
+			step.providers = providers
+			err := testStepNewImportState(t, c, wd, step, appliedCfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+
+		if step.Config != "" {
+			err := testStepNewConfig(t, c, wd, step)
+			if step.ExpectError != nil {
+				if err == nil {
+					t.Fatal("Expected an error but got none")
+				}
+				if !step.ExpectError.MatchString(err.Error()) {
+					t.Fatalf("Expected an error with pattern, no match on: %s", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			appliedCfg = step.Config
+			continue
+		}
+
+		t.Fatal("Unsupported test mode")
+	}
+}
+
+func planIsEmpty(plan *tfjson.Plan) bool {
+	for _, rc := range plan.ResourceChanges {
+		if rc.Mode == tfjson.DataResourceMode {
+			// Skip data sources as the current implementation ignores
+			// existing state and they are all re-read every time
+			continue
+		}
+
+		for _, a := range rc.Change.Actions {
+			if a != tfjson.ActionNoop {
+				return false
+			}
+		}
+	}
+	return true
+}
+func testIDRefresh(c TestCase, t *testing.T, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
+	spewConf := spew.NewDefaultConfig()
+	spewConf.SortKeys = true
+
+	// Build the state. The state is just the resource with an ID. There
+	// are no attributes. We only set what is needed to perform a refresh.
+	state := terraform.NewState()
+	state.RootModule().Resources = make(map[string]*terraform.ResourceState)
+	state.RootModule().Resources[c.IDRefreshName] = &terraform.ResourceState{}
+
+	// Temporarily set the config to a minimal provider config for the refresh
+	// test. After the refresh we can reset it.
+	cfg := testProviderConfig(c)
+	wd.RequireSetConfig(t, cfg)
+	defer wd.RequireSetConfig(t, step.Config)
+
+	// Refresh!
+	wd.RequireRefresh(t)
+	state = getState(t, wd)
+
+	// Verify attribute equivalence.
+	actualR := state.RootModule().Resources[c.IDRefreshName]
+	if actualR == nil {
+		return fmt.Errorf("Resource gone!")
+	}
+	if actualR.Primary == nil {
+		return fmt.Errorf("Resource has no primary instance")
+	}
+	actual := actualR.Primary.Attributes
+	expected := r.Primary.Attributes
+	// Remove fields we're ignoring
+	for _, v := range c.IDRefreshIgnore {
+		for k, _ := range actual {
+			if strings.HasPrefix(k, v) {
+				delete(actual, k)
+			}
+		}
+		for k, _ := range expected {
+			if strings.HasPrefix(k, v) {
+				delete(expected, k)
+			}
+		}
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		// Determine only the different attributes
+		for k, v := range expected {
+			if av, ok := actual[k]; ok && v == av {
+				delete(expected, k)
+				delete(actual, k)
+			}
+		}
+
+		spewConf := spew.NewDefaultConfig()
+		spewConf.SortKeys = true
+		return fmt.Errorf(
+			"Attributes not equivalent. Difference is shown below. Top is actual, bottom is expected."+
+				"\n\n%s\n\n%s",
+			spewConf.Sdump(actual), spewConf.Sdump(expected))
+	}
+
+	return nil
+}

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -1,0 +1,106 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	tftest "github.com/hashicorp/terraform-plugin-test"
+)
+
+func testStepNewConfig(t *testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+	spewConf := spew.NewDefaultConfig()
+	spewConf.SortKeys = true
+
+	var idRefreshCheck *terraform.ResourceState
+	idRefresh := c.IDRefreshName != ""
+
+	if !step.Destroy {
+		state := getState(t, wd)
+		if err := testStepTaint(state, step); err != nil {
+			t.Fatalf("Error when tainting resources: %s", err)
+		}
+	}
+
+	wd.RequireSetConfig(t, step.Config)
+
+	if !step.PlanOnly {
+		err := wd.Apply()
+		if err != nil {
+			return err
+		}
+
+		state := getState(t, wd)
+		if step.Check != nil {
+			if err := step.Check(state); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Test for perpetual diffs by performing a plan, a refresh, and another plan
+
+	// do a plan
+	wd.RequireCreatePlan(t)
+	plan := wd.RequireSavedPlan(t)
+
+	if !planIsEmpty(plan) {
+		if step.ExpectNonEmptyPlan {
+			t.Log("[INFO] Got non-empty plan, as expected")
+		} else {
+
+			t.Fatalf("After applying this test step, the plan was not empty. %s", spewConf.Sdump(plan))
+		}
+	}
+
+	// do a refresh
+	if !c.PreventPostDestroyRefresh {
+		wd.RequireRefresh(t)
+	}
+
+	// do another plan
+	wd.RequireCreatePlan(t)
+	plan = wd.RequireSavedPlan(t)
+
+	// check if plan is empty
+	if !planIsEmpty(plan) {
+		if step.ExpectNonEmptyPlan {
+			t.Log("[INFO] Got non-empty plan, as expected")
+		} else {
+
+			t.Fatalf("After applying this test step and performing a `terraform refresh`, the plan was not empty. %s", spewConf.Sdump(plan))
+		}
+	}
+
+	// ID-ONLY REFRESH
+	// If we've never checked an id-only refresh and our state isn't
+	// empty, find the first resource and test it.
+	state := getState(t, wd)
+	if idRefresh && idRefreshCheck == nil && !state.Empty() {
+		// Find the first non-nil resource in the state
+		for _, m := range state.Modules {
+			if len(m.Resources) > 0 {
+				if v, ok := m.Resources[c.IDRefreshName]; ok {
+					idRefreshCheck = v
+				}
+
+				break
+			}
+		}
+
+		// If we have an instance to check for refreshes, do it
+		// immediately. We do it in the middle of another test
+		// because it shouldn't affect the overall state (refresh
+		// is read-only semantically) and we want to fail early if
+		// this fails. If refresh isn't read-only, then this will have
+		// caught a different bug.
+		if idRefreshCheck != nil {
+			if err := testIDRefresh(c, t, wd, step, idRefreshCheck); err != nil {
+				t.Fatalf(
+					"[ERROR] Test: ID-only test failed: %s", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -1,0 +1,196 @@
+package resource
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	tftest "github.com/hashicorp/terraform-plugin-test"
+)
+
+func testStepNewImportState(t *testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep, cfg string) error {
+	spewConf := spew.NewDefaultConfig()
+	spewConf.SortKeys = true
+
+	if step.ResourceName == "" {
+		t.Fatal("ResourceName is required for an import state test")
+	}
+
+	// get state from check sequence
+	state := getState(t, wd)
+
+	// Determine the ID to import
+	var importId string
+	switch {
+	case step.ImportStateIdFunc != nil:
+		var err error
+		importId, err = step.ImportStateIdFunc(state)
+		if err != nil {
+			t.Fatal(err)
+		}
+	case step.ImportStateId != "":
+		importId = step.ImportStateId
+	default:
+		resource, err := testResource(step, state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		importId = resource.Primary.ID
+	}
+	importId = step.ImportStateIdPrefix + importId
+
+	// Create working directory for import tests
+	if step.Config == "" {
+		step.Config = cfg
+		if step.Config == "" {
+			t.Fatal("Cannot import state with no specified config")
+		}
+	}
+	importWd := acctest.TestHelper.RequireNewWorkingDir(t)
+	defer importWd.Close()
+	importWd.RequireSetConfig(t, step.Config)
+	importWd.RequireInit(t)
+	importWd.RequireImport(t, step.ResourceName, importId)
+	importState := getState(t, wd)
+
+	// Go through the imported state and verify
+	if step.ImportStateCheck != nil {
+		var states []*terraform.InstanceState
+		for _, r := range importState.RootModule().Resources {
+			if r.Primary != nil {
+				is := r.Primary.DeepCopy()
+				is.Ephemeral.Type = r.Type // otherwise the check function cannot see the type
+				states = append(states, is)
+			}
+		}
+		if err := step.ImportStateCheck(states); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Verify that all the states match
+	if step.ImportStateVerify {
+		new := importState.RootModule().Resources
+		old := state.RootModule().Resources
+
+		for _, r := range new {
+			// Find the existing resource
+			var oldR *terraform.ResourceState
+			for _, r2 := range old {
+				if r2.Primary != nil && r2.Primary.ID == r.Primary.ID && r2.Type == r.Type {
+					oldR = r2
+					break
+				}
+			}
+			if oldR == nil {
+				t.Fatalf(
+					"Failed state verification, resource with ID %s not found",
+					r.Primary.ID)
+			}
+
+			// We'll try our best to find the schema for this resource type
+			// so we can ignore Removed fields during validation. If we fail
+			// to find the schema then we won't ignore them and so the test
+			// will need to rely on explicit ImportStateVerifyIgnore, though
+			// this shouldn't happen in any reasonable case.
+			// KEM CHANGE FROM OLD FRAMEWORK: Fail test if this happens.
+			var rsrcSchema *schema.Resource
+			providerAddr, diags := addrs.ParseAbsProviderConfigStr("provider." + r.Provider + "." + r.Type)
+			if diags.HasErrors() {
+				t.Fatalf("Failed to find schema for resource with ID %s", r.Primary)
+			}
+
+			providerType := providerAddr.ProviderConfig.Type
+			if provider, ok := step.providers[providerType]; ok {
+				if provider, ok := provider.(*schema.Provider); ok {
+					rsrcSchema = provider.ResourcesMap[r.Type]
+				}
+			}
+
+			// don't add empty flatmapped containers, so we can more easily
+			// compare the attributes
+			skipEmpty := func(k, v string) bool {
+				if strings.HasSuffix(k, ".#") || strings.HasSuffix(k, ".%") {
+					if v == "0" {
+						return true
+					}
+				}
+				return false
+			}
+
+			// Compare their attributes
+			actual := make(map[string]string)
+			for k, v := range r.Primary.Attributes {
+				if skipEmpty(k, v) {
+					continue
+				}
+				actual[k] = v
+			}
+
+			expected := make(map[string]string)
+			for k, v := range oldR.Primary.Attributes {
+				if skipEmpty(k, v) {
+					continue
+				}
+				expected[k] = v
+			}
+
+			// Remove fields we're ignoring
+			for _, v := range step.ImportStateVerifyIgnore {
+				for k := range actual {
+					if strings.HasPrefix(k, v) {
+						delete(actual, k)
+					}
+				}
+				for k := range expected {
+					if strings.HasPrefix(k, v) {
+						delete(expected, k)
+					}
+				}
+			}
+
+			// Also remove any attributes that are marked as "Removed" in the
+			// schema, if we have a schema to check that against.
+			if rsrcSchema != nil {
+				for k := range actual {
+					for _, schema := range rsrcSchema.SchemasForFlatmapPath(k) {
+						if schema.Removed != "" {
+							delete(actual, k)
+							break
+						}
+					}
+				}
+				for k := range expected {
+					for _, schema := range rsrcSchema.SchemasForFlatmapPath(k) {
+						if schema.Removed != "" {
+							delete(expected, k)
+							break
+						}
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(actual, expected) {
+				// Determine only the different attributes
+				for k, v := range expected {
+					if av, ok := actual[k]; ok && v == av {
+						delete(expected, k)
+						delete(actual, k)
+					}
+				}
+
+				t.Fatalf(
+					"ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected."+
+						"\n\n%s\n\n%s",
+					spewConf.Sdump(actual), spewConf.Sdump(expected))
+			}
+		}
+	}
+
+	return nil
+}

--- a/helper/resource/testing_new_test.go
+++ b/helper/resource/testing_new_test.go
@@ -1,0 +1,1118 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestShimState(t *testing.T) {
+	type expectedError struct {
+		Prefix string
+	}
+
+	testCases := []struct {
+		Name          string
+		RawState      string
+		ExpectedState *terraform.State
+		ExpectedErr   *expectedError
+	}{
+		{
+			"empty",
+			`{
+  "format_version": "0.1"
+}`,
+			&terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:         []string{"root"},
+						Outputs:      map[string]*terraform.OutputState{},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"simple outputs",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {
+      "bool": {
+        "sensitive": false,
+        "value": true
+      },
+      "int": {
+        "sensitive": false,
+        "value": 42
+      },
+      "float": {
+        "sensitive": false,
+        "value": 1.4
+      },
+      "string": {
+        "sensitive": false,
+        "value": "test"
+      }
+    },
+    "root_module": {}
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Outputs: map[string]*terraform.OutputState{
+							"bool": {
+								Type:      "string",
+								Value:     "true",
+								Sensitive: false,
+							},
+							"int": {
+								Type:      "string",
+								Value:     "42",
+								Sensitive: false,
+							},
+							"float": {
+								Type:      "string",
+								Value:     "1.4",
+								Sensitive: false,
+							},
+							"string": {
+								Type:      "string",
+								Value:     "test",
+								Sensitive: false,
+							},
+						},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"complex outputs",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {
+      "empty_list": {
+        "sensitive": false,
+        "value": []
+      },
+      "list_of_strings": {
+        "sensitive": false,
+        "value": ["first", "second", "third"]
+      },
+      "map_of_strings": {
+        "sensitive": false,
+        "value": {
+        	"hello": "world",
+        	"foo": "bar"
+        }
+      },
+      "list_of_int": {
+        "sensitive": false,
+        "value": [1, 4, 9]
+      },
+      "list_of_float": {
+        "sensitive": false,
+        "value": [1.2, 4.2, 9.8]
+      },
+      "list_of_bool": {
+        "sensitive": false,
+        "value": [true, false, true]
+      }
+    },
+    "root_module": {}
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Outputs: map[string]*terraform.OutputState{
+							"empty_list": {
+								Type:      "list",
+								Value:     []interface{}{},
+								Sensitive: false,
+							},
+							"list_of_strings": {
+								Type: "list",
+								Value: []interface{}{
+									"first", "second", "third",
+								},
+								Sensitive: false,
+							},
+							"map_of_strings": {
+								Type: "map",
+								Value: map[string]interface{}{
+									"hello": "world",
+									"foo":   "bar",
+								},
+								Sensitive: false,
+							},
+							"list_of_int": {
+								Type: "list",
+								Value: []interface{}{
+									// TODO: Not sure if this is expectable
+									// but we have no way of distinguishing between int and float
+									// due outputs being schema-less and numbers
+									// always being unmarshaled into float64
+									1.0, 4.0, 9.0,
+								},
+								Sensitive: false,
+							},
+							"list_of_float": {
+								Type: "list",
+								Value: []interface{}{
+									1.2, 4.2, 9.8,
+								},
+								Sensitive: false,
+							},
+							"list_of_bool": {
+								Type: "list",
+								Value: []interface{}{
+									true, false, true,
+								},
+								Sensitive: false,
+							},
+						},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"output with slice of slices",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {
+      "list_of_lists": {
+        "sensitive": false,
+        "value": [
+          ["one", "two"],
+          ["blue", "green", "red"]
+        ]
+      }
+    },
+    "root_module": {}
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Outputs: map[string]*terraform.OutputState{
+							"list_of_lists": {
+								Type: "list",
+								Value: []interface{}{
+									[]interface{}{"one", "two"},
+									[]interface{}{"blue", "green", "red"},
+								},
+								Sensitive: false,
+							},
+						},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"output with slice of maps",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {
+      "list_of_maps": {
+        "sensitive": false,
+        "value": [
+          {
+            "rule": "allow",
+            "port": 443,
+            "allow_bool": true
+          },
+          {
+            "rule": "deny",
+            "port": 80,
+            "allow_bool": false
+          }
+        ]
+      }
+    },
+    "root_module": {}
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Outputs: map[string]*terraform.OutputState{
+							"list_of_maps": {
+								Type: "list",
+								Value: []interface{}{
+									map[string]interface{}{
+										"allow_bool": true,
+										"port":       float64(443),
+										"rule":       "allow",
+									},
+									map[string]interface{}{
+										"allow_bool": false,
+										"port":       float64(80),
+										"rule":       "deny",
+									},
+								},
+								Sensitive: false,
+							},
+						},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"output with nested map",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {
+      "map_of_maps": {
+        "sensitive": false,
+        "value": {
+        	"hello": {
+        	  "whole": "world"
+        	},
+        	"foo": "bar"
+        }
+      }
+    },
+    "root_module": {}
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Outputs: map[string]*terraform.OutputState{
+							"map_of_maps": {
+								Type: "map",
+								Value: map[string]interface{}{
+									"hello": map[string]interface{}{
+										"whole": "world",
+									},
+									"foo": "bar",
+								},
+								Sensitive: false,
+							},
+						},
+						Resources:    map[string]*terraform.ResourceState{},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"invalid address",
+			`{
+  "format_version": "0.1",
+  "values": {
+    "root_module": {
+      "address": "blah"
+    }
+  }
+}`,
+			nil,
+			&expectedError{Prefix: "Invalid module instance address"},
+		},
+		{
+			"resource with primitive attributes",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "123999",
+            "string_field": "hello world",
+            "bool_field_1": false,
+            "bool_field_2": true,
+            "null_field": null,
+            "empty_string": "",
+            "number_field": 42
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.main": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "123999",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "7",
+										"id": "123999",
+
+										"bool_field_2": "true",
+										"string_field": "hello world",
+										"bool_field_1": "false",
+										"empty_string": "",
+										"number_field": "42",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"resource with nested slice",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "123999",
+            "list_of_lists": [
+              ["one", "two", "three"],
+              ["red", "green", "blue"],
+              ["black", "white"]
+            ],
+            "list_of_maps": [
+              {
+                "action": "allow",
+                "port": 443,
+                "allow_bool": true
+              },
+              {
+                "action": "deny",
+                "port": 80,
+                "allow_bool": false
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.main": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "123999",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "3",
+										"id": "123999",
+
+										"list_of_lists.#":   "3",
+										"list_of_lists.0.#": "3",
+										"list_of_lists.0.0": "one",
+										"list_of_lists.0.1": "two",
+										"list_of_lists.0.2": "three",
+										"list_of_lists.1.#": "3",
+										"list_of_lists.1.0": "red",
+										"list_of_lists.1.1": "green",
+										"list_of_lists.1.2": "blue",
+										"list_of_lists.2.#": "2",
+										"list_of_lists.2.0": "black",
+										"list_of_lists.2.1": "white",
+
+										"list_of_maps.#":            "2",
+										"list_of_maps.0.%":          "3",
+										"list_of_maps.0.action":     "allow",
+										"list_of_maps.0.allow_bool": "true",
+										"list_of_maps.0.port":       "443",
+										"list_of_maps.1.%":          "3",
+										"list_of_maps.1.action":     "deny",
+										"list_of_maps.1.allow_bool": "false",
+										"list_of_maps.1.port":       "80",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"resource with nested map",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "123999",
+            "map_of_maps": {
+              "parent": {
+                "inner": "value"
+              },
+              "second": {
+                "inner2": "value2"
+              }
+            },
+            "map_of_lists": {
+              "parent": {
+                "inner": ["one", "two"]
+              },
+              "second": {
+                "inner2": [1, 4, 9]
+              }
+            },
+            "map_of_list_of_maps": {
+              "parent": [
+                {
+                  "action": "allow",
+                  "port": 443,
+                  "allow_bool": true
+                },
+                {
+                  "action": "deny",
+                  "port": 80,
+                  "allow_bool": false
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.main": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "123999",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "4",
+										"id": "123999",
+
+										"map_of_maps.%":             "2",
+										"map_of_maps.parent.%":      "1",
+										"map_of_maps.parent.inner":  "value",
+										"map_of_maps.second.%":      "1",
+										"map_of_maps.second.inner2": "value2",
+
+										"map_of_lists.%":               "2",
+										"map_of_lists.parent.%":        "1",
+										"map_of_lists.parent.inner.#":  "2",
+										"map_of_lists.parent.inner.0":  "one",
+										"map_of_lists.parent.inner.1":  "two",
+										"map_of_lists.second.%":        "1",
+										"map_of_lists.second.inner2.#": "3",
+										"map_of_lists.second.inner2.0": "1",
+										"map_of_lists.second.inner2.1": "4",
+										"map_of_lists.second.inner2.2": "9",
+
+										"map_of_list_of_maps.%":                   "1",
+										"map_of_list_of_maps.parent.#":            "2",
+										"map_of_list_of_maps.parent.0.%":          "3",
+										"map_of_list_of_maps.parent.0.action":     "allow",
+										"map_of_list_of_maps.parent.0.allow_bool": "true",
+										"map_of_list_of_maps.parent.0.port":       "443",
+										"map_of_list_of_maps.parent.1.%":          "3",
+										"map_of_list_of_maps.parent.1.action":     "deny",
+										"map_of_list_of_maps.parent.1.allow_bool": "false",
+										"map_of_list_of_maps.parent.1.port":       "80",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"data source",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.cloud_vpc.main",
+          "mode": "data",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 0,
+          "values": {
+          	"id": "123999",
+            "string_field": "hello world",
+            "bool_field_1": false,
+            "bool_field_2": true,
+            "null_field": null,
+            "empty_string": "",
+            "number_field": 42
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"data.cloud_vpc.main": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "123999",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "7",
+										"id": "123999",
+
+										"bool_field_2": "true",
+										"string_field": "hello world",
+										"bool_field_1": "false",
+										"empty_string": "",
+										"number_field": "42",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"resource with complex attributes",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "123999",
+            "map_field": {
+              "key": "val",
+              "foo": "bar"
+            },
+            "list_of_string": ["first", "second"],
+            "list_of_numbers": [1,2,3,4],
+            "list_of_bool": [true, false, true]
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.main": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "123999",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "5",
+										"id": "123999",
+
+										"map_field.%":   "2",
+										"map_field.key": "val",
+										"map_field.foo": "bar",
+
+										"list_of_string.#": "2",
+										"list_of_string.0": "first",
+										"list_of_string.1": "second",
+
+										"list_of_numbers.#": "4",
+										"list_of_numbers.0": "1",
+										"list_of_numbers.1": "2",
+										"list_of_numbers.2": "3",
+										"list_of_numbers.3": "4",
+
+										"list_of_bool.#": "3",
+										"list_of_bool.0": "true",
+										"list_of_bool.1": "false",
+										"list_of_bool.2": "true",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"indexed resource",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "index": 0,
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "11111"
+          }
+        },
+        {
+          "address": "cloud_vpc.main",
+          "index": 1,
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "22222"
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.main.0": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+							"cloud_vpc.main.1": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "22222",
+									Meta: map[string]interface{}{
+										"schema_version": 1,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "22222",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"indexed data source",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.cloud_vpc.main",
+          "index": 0,
+          "mode": "data",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 0,
+          "values": {
+          	"id": "11111"
+          }
+        },
+        {
+          "address": "data.cloud_vpc.main",
+          "index": 1,
+          "mode": "data",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 0,
+          "values": {
+          	"id": "22222"
+          }
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"data.cloud_vpc.main.0": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+							"data.cloud_vpc.main.1": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "22222",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "22222",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"for_each",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.main",
+          "index": "one",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "11111"
+          }
+        },
+        {
+          "address": "cloud_vpc.main",
+          "index": "two",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "main",
+          "provider_name": "cloud",
+          "schema_version": 1,
+          "values": {
+          	"id": "22222"
+          }
+        }
+      ]
+    }
+  }
+}`,
+			nil,
+			&expectedError{Prefix: "unexpected index type (string)"},
+		},
+		{
+			"depends on",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "outputs": {},
+    "root_module": {
+      "resources": [
+        {
+          "address": "cloud_vpc.primary",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "primary",
+          "provider_name": "cloud",
+          "values": {
+          	"id": "11111"
+          }
+        },
+        {
+          "address": "cloud_vpc.secondary",
+          "mode": "managed",
+          "type": "cloud_vpc",
+          "name": "secondary",
+          "provider_name": "cloud",
+          "values": {
+          	"id": "22222"
+          },
+          "depends_on": [
+            "cloud_vpc.primary"
+          ]
+        }
+      ]
+    }
+  }
+}`,
+			&terraform.State{
+				Version:   3,
+				TFVersion: "0.12.18",
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"cloud_vpc.primary": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "11111",
+									},
+								},
+							},
+							"cloud_vpc.secondary": {
+								Type:     "cloud_vpc",
+								Provider: "cloud",
+								Primary: &terraform.InstanceState{
+									ID: "22222",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":  "1",
+										"id": "22222",
+									},
+								},
+								Dependencies: []string{
+									"cloud_vpc.primary",
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"child modules",
+			`{
+  "format_version": "0.1",
+  "terraform_version": "0.12.18",
+  "values": {
+    "root_module": {
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "cloud_vpc.primary",
+              "mode": "managed",
+              "type": "cloud_vpc",
+              "name": "primary",
+              "provider_name": "cloud",
+              "values": {
+                "id": "11111"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}`,
+			nil,
+			&expectedError{Prefix: "Modules are not supported."},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			var rawState tfjson.State
+
+			err := json.Unmarshal([]byte(tc.RawState), &rawState)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			shimmedState, err := shimStateFromJson(&rawState)
+			if tc.ExpectedErr != nil {
+				if err == nil {
+					t.Fatalf("Expected error with prefix: %q\nGot no error.",
+						tc.ExpectedErr.Prefix)
+				}
+				if strings.HasPrefix(err.Error(), tc.ExpectedErr.Prefix) {
+					return
+				}
+				t.Fatalf("Error mismatch.\nExpected prefix: %q\nGot: %q\n",
+					tc.ExpectedErr.Prefix, err.Error())
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Lineage is randomly generated, so we wipe it to make comparing easier
+			shimmedState.Lineage = ""
+
+			if diff := deep.Equal(tc.ExpectedState, shimmedState); diff != nil {
+				t.Fatalf("state mismatch:\n%s", strings.Join(diff, "\n"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new optional test driver for Terraform provider acceptance tests that runs the Terraform CLI.

To minimise work for provider developers at this stage, the API follows as closely as possible the functionality of the legacy test driver, minimising changes needed to acceptance test code.

Since we are targeting a 1.x.x release of the provider SDK, no breaking changes will be made, and the legacy test driver will only be removed in version 2.0.0.

## Usage

The new test driver must be enabled by initialising the test helper in the [`TestMain()`](https://golang.org/pkg/testing/#hdr-Main) function in all provider packages that run acceptance tests. Most providers have only one package.

Import the new `"github.com/hashicorp/terraform-plugin-sdk/acctest"` package and add the following `TestMain` function to `provider_test.go`:

```
func TestMain(m *testing.M) {
	acctest.UseBinaryDriver("provider_name", Provider)
	resource.TestMain(m)
}
```

Some providers already have a `TestMain()` defined, usually for the purpose of enabling test sweepers (as described in [Extending Terraform: Sweepers](https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html)). These additional occurrences should be removed.

### Known issue: `TypeSet` attribute checks

A limitation of the binary acceptance test driver is that attribute checks addressing `TypeSet` elements will fail.

These attribute checks are rarely used in the legacy test framework, as the hashcode used for addressing Set elements in the flatmap representation must be calculated during the test. Please see https://github.com/hashicorp/terraform-plugin-sdk/issues/196.

A follow-up improvement to the SDK type system will fix this issue and provide an idiomatic way to check complex type attributes.

### Opt-out per `TestCase`

Initialising the binary test helper using `acctest.UseBinaryDriver()` causes all tests to be run using the new binary driver. Until SDK version 2.0.0, the `DisableBinaryDriver` boolean property can be used to use the legacy test driver for individual `TestCase`s. 

### Multi-provider testing

Providers that require resources from other providers during acceptance tests have two options:
  - _Standard provider discovery mechanism._ During acceptance test runs, Terraform CLI will attempt to locate providers on the local filesystem, and will download any missing providers in the usual way. **This is the default behaviour.**
  - _Binaries in the provider repo._ Relying on the Terraform CLI provider discovery mechanism can be avoided by including auxiliary provider binaries in `terraform.d/plugins/$GOOS_$GOARCH/$provider_name`, relative to the provider source code directory root. The environment variable `TF_ACC_PROVIDER_ROOT_DIR` must be set to the path of the source code directory root to use this feature. Providers can be included in binary or zip format.

It is no longer necessary to import other Terraform providers as Go modules: these imports should be removed.

Further examples will be added to this section as I raise PRs to enable the binary test driver in HashiCorp-owned providers.

Closes #13 