### PR TITLE
[DO NOT MERGE] Experimental and Non-Breaking Cty API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
-	github.com/zclconf/go-cty v1.1.0
+	github.com/zclconf/go-cty v1.1.1
 	github.com/zclconf/go-cty-yaml v1.0.1
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.1.1 h1:Shl2p9Dat0cqJfXu0DZa+cOTRPhXQjK8IYWD6GVfiqo=
+github.com/zclconf/go-cty v1.1.1/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -208,7 +208,7 @@ type applyResourceChangeRequest struct {
 // due to the potentially concurrent nature of the grpc server
 // create unique channels for each instance ID
 // to be created instances (id == "") should push to a large buffer chan
-// as seen in SetPlannedState
+// as seen below
 var applyResoureChangeRequests map[string]chan applyResourceChangeRequest = make(map[string]chan applyResourceChangeRequest)
 
 // ApplyResourceChange passes the planned state to the correct channel

--- a/internal/helper/plugin/grpc_provider.go
+++ b/internal/helper/plugin/grpc_provider.go
@@ -882,7 +882,7 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 		}
 	}
 
-	respChan := schema.ApplyResourceChange(priorState.ID, plannedStateVal)
+	respChan := schema.ApplyResourceChange(info.Type, priorState.ID, plannedStateVal)
 	newInstanceState, err := s.provider.Apply(info, priorState, diff)
 	// we record the error here, but continue processing any returned state.
 	if err != nil {

--- a/internal/helper/plugin/grpc_provider_test.go
+++ b/internal/helper/plugin/grpc_provider_test.go
@@ -634,6 +634,14 @@ func TestApplyResourceChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	configVal, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.NumberIntVal(0),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := msgpack.Marshal(configVal, schema.ImpliedType())
+
 	testReq := &proto.ApplyResourceChange_Request{
 		TypeName: "test",
 		PriorState: &proto.DynamicValue{
@@ -641,6 +649,9 @@ func TestApplyResourceChange(t *testing.T) {
 		},
 		PlannedState: &proto.DynamicValue{
 			Msgpack: plannedState,
+		},
+		Config: &proto.DynamicValue{
+			Msgpack: config,
 		},
 	}
 


### PR DESCRIPTION
Whether or not we want to directly expose Cty onto the API surface is a separate discussion, this merely demonstrates how we can allow providers a way to rewrite their CRUD funcs with data aligning more closely with how the protocol works (receiving a planned state and returning a new state).

The new CRUD methods should be able to interoperate with old ones on the same resource, and all the shim logic should operate the same, assuming letting the developer set the `newStateVal` directly isn't meaningfully different than how that value turns out going through the shims. I have indicated things that need to be verified with TODOs. At the very least this doesn't cause any existing tests to fail.

#### Usage
```
func someResource() *schema.Resource {
	return &schema.Resource{
		Read: currentSDKReadFunc,
                Create: schema.ExperimentalCRUD("aws_ec2_instance",
                           func(req *schema.ApplyResourceChangeRequest, meta interface{}) {
                               
                               return &schema.ApplyResourceChangeResponse{
                                   NewState: req.PlannedState,
                               }, nil

                           } (cty.Value, error)
                ),

		Schema: map[string]*schema.Schema{
			"region": {
				Type:     schema.TypeString,
				Optional: true,
			},
			"arn": {
				Type:     schema.TypeString,
				Computed: true,
			},
		},
	}
}
```
One issue is distinguishing resources that need to be created (`d.Id() == ""`) (and in general trusting that ID's are unique globally) to fix this I quickly prepended the `resourceType` to the channel K/V store, unfortunately I don't think this data is currently available on `ResourceData`, therefore the `resourceType` needs to be passed into the `ExperimentalCRUD` helper. This isn't so bad as we need this string for a providers `ResourceMap` anyways, if we can somehow attach the `resourceType` to `ResourceData` then we could omit that field being passed into `ExperimentalCRUD`