### PR TITLE
github: Remove link to security vulnerability

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: ❓ Plugin SDK Questions
     url: https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk
     about: Please ask and answer SDK related questions through the Plugin SDK Community Forum.
-  - name: 🔓 Security Vulnerability
-    url: https://www.hashicorp.com/security.html
-    about: Please report security vulnerabilities responsibly.


### PR DESCRIPTION
This is already being added automatically due to repository having SECURITY.md so I'm just removing the duplicate.

<img width="737" alt="Screenshot 2019-11-29 at 15 48 14" src="https://user-images.githubusercontent.com/287584/69879668-f2378600-12bf-11ea-9cd0-4e6fe1a6d0f7.png">
