### PR TITLE
Context Aware CRUD funcs

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -291,7 +291,7 @@ func (p *Provider) Apply(
 		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
 	}
 
-	return r.Apply(s, d, p.meta)
+	return r.Apply(nil, s, d, p.meta)
 }
 
 // Diff implementation of terraform.ResourceProvider interface.
@@ -330,7 +330,7 @@ func (p *Provider) Refresh(
 		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
 	}
 
-	return r.Refresh(s, p.meta)
+	return r.Refresh(nil, s, p.meta)
 }
 
 // Resources implementation of terraform.ResourceProvider interface.
@@ -448,7 +448,7 @@ func (p *Provider) ReadDataApply(
 		return nil, fmt.Errorf("unknown data source: %s", info.Type)
 	}
 
-	return r.ReadDataApply(d, p.meta)
+	return r.ReadDataApply(nil, d, p.meta)
 }
 
 // DataSources implementation of terraform.ResourceProvider interface.

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -780,6 +780,23 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 		}
 	}
 
+	// Validate CRUD and Context aware CRUD funcs are never dually set
+	if r.ExistsContext != nil && r.Exists != nil {
+		return fmt.Errorf("only ExistsContext or Exists should be implemented, not both.")
+	}
+	if r.CreateContext != nil && r.Create != nil {
+		return fmt.Errorf("only CreateContext or Create should be implemented, not both.")
+	}
+	if r.ReadContext != nil && r.Read != nil {
+		return fmt.Errorf("only ReadContext or Read should be implemented, not both.")
+	}
+	if r.UpdateContext != nil && r.Update != nil {
+		return fmt.Errorf("only UpdateContext or Update should be implemented, not both.")
+	}
+	if r.DeleteContext != nil && r.Delete != nil {
+		return fmt.Errorf("only DeleteContext or Delete should be implemented, not both.")
+	}
+
 	return schemaMap(r.Schema).InternalValidate(tsm)
 }
 

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -44,7 +44,7 @@ func TestResourceApply_create(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -112,7 +112,7 @@ func TestResourceApply_Timeout_state(t *testing.T) {
 		t.Fatalf("Error encoding timeout to diff: %s", err)
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -178,7 +178,7 @@ func TestResourceApply_Timeout_destroy(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -313,7 +313,7 @@ func TestResourceApply_destroy(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -375,7 +375,7 @@ func TestResourceApply_destroyCreate(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -426,7 +426,7 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -477,7 +477,7 @@ func TestResourceApply_update(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -522,7 +522,7 @@ func TestResourceApply_updateNoCallback(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -574,7 +574,7 @@ func TestResourceApply_isNewResource(t *testing.T) {
 	// positive test
 	var s *terraform.InstanceState = nil
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -601,7 +601,7 @@ func TestResourceApply_isNewResource(t *testing.T) {
 		},
 	}
 
-	actual, err = r.Apply(s, d, nil)
+	actual, err = r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -918,7 +918,7 @@ func TestResourceRefresh(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -948,7 +948,7 @@ func TestResourceRefresh_blankId(t *testing.T) {
 		Attributes: map[string]string{},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -979,7 +979,7 @@ func TestResourceRefresh_delete(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1014,7 +1014,7 @@ func TestResourceRefresh_existsError(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err == nil {
 		t.Fatalf("should error")
 	}
@@ -1048,7 +1048,7 @@ func TestResourceRefresh_noExists(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1109,7 +1109,7 @@ func TestResourceRefresh_needsMigration(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, 42)
+	actual, err := r.Refresh(nil, s, 42)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1163,7 +1163,7 @@ func TestResourceRefresh_noMigrationNeeded(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, nil)
+	actual, err := r.Refresh(nil, s, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1215,7 +1215,7 @@ func TestResourceRefresh_stateSchemaVersionUnset(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Refresh(s, nil)
+	actual, err := r.Refresh(nil, s, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1266,7 +1266,7 @@ func TestResourceRefresh_migrateStateErr(t *testing.T) {
 		},
 	}
 
-	_, err := r.Refresh(s, nil)
+	_, err := r.Refresh(nil, s, nil)
 	if err == nil {
 		t.Fatal("expected error, but got none!")
 	}
@@ -1663,7 +1663,7 @@ func TestResource_migrateAndUpgrade(t *testing.T) {
 
 	for i, s := range testStates {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			newState, err := r.Refresh(s, nil)
+			newState, err := r.Refresh(nil, s, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -147,7 +147,7 @@ func TestShimResourceApply_create(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -226,7 +226,7 @@ func TestShimResourceApply_Timeout_state(t *testing.T) {
 		t.Fatalf("Error encoding timeout to diff: %s", err)
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -318,7 +318,7 @@ func TestShimResourceDiff_Timeout_diff(t *testing.T) {
 
 	// Shim
 	// apply this diff, so we have a state to compare
-	applied, err := r.Apply(s, actual, nil)
+	applied, err := r.Apply(nil, s, actual, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,7 +377,7 @@ func TestShimResourceApply_destroy(t *testing.T) {
 		Destroy: true,
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -449,7 +449,7 @@ func TestShimResourceApply_destroyCreate(t *testing.T) {
 		},
 	}
 
-	actual, err := r.Apply(s, d, nil)
+	actual, err := r.Apply(nil, s, d, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This PR allows a developer to switch a CRUD(E) (Yes including the not popular exists func) to one that receives a `context.Context` from GRPC. The context has a timeout added to it right before being passed to the CRUD func. `InternalValidate` will error if both a matching CRUD and Context CRUD func is set (ie, developer passed `Read` and `ReadContext`).

Overall this is not yet well tested and there are some known caveats.

1. Technically coded as is, this is a "breaking change". I have added a context onto a few `schema.Resource` methods. This all works because from `grpc_provider.go` we can call a Resource's `Apply/Refresh/DataApplyRead` directly (Did not break `schema.Provider` or the `terraform.ResourceProvider` interface). We have entered a grey area where we are breaking an "API surface" that was not really intended to be exposed outside Terraform internals. If we want to be dogmatic about the definition of a breaking change I believe this could still land in V1 with some copy paste/changes.
2. A provider developer needs to recognize that implementing a context aware CRUD method likely makes their provider incompatible with Terraform 0.11 (which goes through a different codepath `terraform.ResourceProvider` which does not pass along any context). With this in mind we can:
    * Just hope the provider developer adheres to this with clear documentation
    * Enforce it with the technique detailed in an RFC I wrote a few weeks ago
    * Land this in the `version2` branch instead, I think there is benefit to landing this in V1 if possible though.
    * We should make sure its not possible to enter the changed `Resource` paths with a `nil` context, but the developer has specified and expecting to use a context aware CRUD func.