### PR TITLE
Don't crash when dependent test sweeper is missing

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -191,8 +191,13 @@ func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
 // Since filterSweepers performs fuzzy matching, this function is used
 // to perform exact sweeper and dependency lookup.
 func filterSweeperWithDependencies(name string, source map[string]*Sweeper) map[string]*Sweeper {
-	currentSweeper := source[name]
 	result := make(map[string]*Sweeper)
+
+	currentSweeper, ok := source[name]
+	if !ok {
+		log.Printf("[DEBUG] Sweeper has dependency (%s), but that sweeper was not found", name)
+		return result
+	}
 
 	result[name] = currentSweeper
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -1213,6 +1213,64 @@ func TestFilterSweeperWithDependencies(t *testing.T) {
 			StartingSweeper:  "matching_level3",
 			ExpectedSweepers: []string{"matching_level3"},
 		},
+		{
+			Name: "one level missing dependency",
+			Sweepers: map[string]*Sweeper{
+				"matching_level1": &Sweeper{
+					Name:         "matching_level1",
+					Dependencies: []string{"matching_level2a", "matching_level2c"},
+					F:            mockSweeperFunc,
+				},
+				"matching_level2a": &Sweeper{
+					Name: "matching_level2a",
+					F:    mockSweeperFunc,
+				},
+				"matching_level2b": &Sweeper{
+					Name: "matching_level2b",
+					F:    mockSweeperFunc,
+				},
+			},
+			StartingSweeper:  "matching_level1",
+			ExpectedSweepers: []string{"matching_level1", "matching_level2a"},
+		},
+		{
+			Name: "multiple level missing dependencies",
+			Sweepers: map[string]*Sweeper{
+				"matching_level1": &Sweeper{
+					Name:         "matching_level1",
+					Dependencies: []string{"matching_level2a", "matching_level2b", "matching_level2c"},
+					F:            mockSweeperFunc,
+				},
+				"matching_level2a": &Sweeper{
+					Name:         "matching_level2a",
+					Dependencies: []string{"matching_level3a", "matching_level3e"},
+					F:            mockSweeperFunc,
+				},
+				"matching_level2b": &Sweeper{
+					Name:         "matching_level2b",
+					Dependencies: []string{"matching_level3c", "matching_level3f"},
+					F:            mockSweeperFunc,
+				},
+				"matching_level3a": &Sweeper{
+					Name: "matching_level3a",
+					F:    mockSweeperFunc,
+				},
+				"matching_level3b": &Sweeper{
+					Name: "matching_level3b",
+					F:    mockSweeperFunc,
+				},
+				"matching_level3c": &Sweeper{
+					Name: "matching_level3c",
+					F:    mockSweeperFunc,
+				},
+				"matching_level3d": &Sweeper{
+					Name: "matching_level3d",
+					F:    mockSweeperFunc,
+				},
+			},
+			StartingSweeper:  "matching_level1",
+			ExpectedSweepers: []string{"matching_level1", "matching_level2a", "matching_level2b", "matching_level3a", "matching_level3c"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-plugin-sdk/issues/278.

Without the fix the new test cases cause a crash:

```console
$ go test ./helper/resource/...
2019/12/12 07:57:21 [DEBUG] New state was assigned lineage "7d80f5ca-2c51-4290-c29e-0df3b7ff4e30"
2019/12/12 07:57:21 [DEBUG] Waiting for state to become: [done]
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [DEBUG] Waiting for state to become: [done]
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:21 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [WARN] WaitForState timeout after 85ms
2019/12/12 07:57:22 [WARN] WaitForState starting 30s refresh grace period
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: [running]
2019/12/12 07:57:22 [WARN] WaitForState timeout after 1ms
2019/12/12 07:57:22 [WARN] WaitForState starting 5ms refresh grace period
2019/12/12 07:57:22 [ERROR] WaitForState exceeded refresh grace period
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: [running]
2019/12/12 07:57:22 [WARN] WaitForState timeout after 10ms
2019/12/12 07:57:22 [WARN] WaitForState starting 30s refresh grace period
2019/12/12 07:57:22 [TRACE] Waiting 10s before next try
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: [running]
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: [done]
2019/12/12 07:57:22 [TRACE] Waiting 200ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 400ms before next try
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: []
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: []
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [TRACE] Waiting 10ms before next try
2019/12/12 07:57:22 [WARN] WaitForState timeout after 100ms
2019/12/12 07:57:22 [WARN] WaitForState starting 30s refresh grace period
2019/12/12 07:57:22 [DEBUG] Waiting for state to become: [running]
	- aws_dummy
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xf762dc]

goroutine 94 [running]:
testing.tRunner.func1(0xc000475e00)
	/usr/local/go/src/testing/testing.go:874 +0x3a3
panic(0x10ed6a0, 0x1d8a6c0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/hashicorp/terraform-plugin-sdk/helper/resource.filterSweeperWithDependencies(0x127c99a, 0x10, 0xc000486de0, 0x10)
	/home/kit/wrk/src/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go:199 +0xcc
github.com/hashicorp/terraform-plugin-sdk/helper/resource.filterSweeperWithDependencies(0x127b6b1, 0xf, 0xc000486de0, 0x0)
	/home/kit/wrk/src/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go:200 +0x1b0
github.com/hashicorp/terraform-plugin-sdk/helper/resource.TestFilterSweeperWithDependencies.func1(0xc000475e00)
	/home/kit/wrk/src/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_test.go:1243 +0x5d
testing.tRunner(0xc000475e00, 0xc000496640)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350
FAIL	github.com/hashicorp/terraform-plugin-sdk/helper/resource	0.907s
FAIL
```