### PR TITLE
Add various Map key and value validators

### DIFF
--- a/helper/validation/map.go
+++ b/helper/validation/map.go
@@ -1,0 +1,120 @@
+package validation
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// MapKeyLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type map and the length of all keys are between min and max (inclusive)
+func MapKeyLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %[1]q to be Map, got %[1]T", k))
+			return warnings, errors
+		}
+
+		for key := range v {
+			len := len(key)
+			if len < min || len > max {
+				errors = append(errors, fmt.Errorf("expected the length of all keys of %q to be in the range (%d - %d), got %q (length = %d)", k, min, max, key, len))
+				return warnings, errors
+			}
+		}
+
+		return warnings, errors
+	}
+}
+
+// MapValueLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type map and the length of all values are between min and max (inclusive)
+func MapValueLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %[1]q to be Map, got %[1]T", k))
+			return warnings, errors
+		}
+
+		for _, val := range v {
+			if _, ok := val.(string); !ok {
+				errors = append(errors, fmt.Errorf("expected all values of %[1]q to be strings, found %[2]v (type = %[2]T)", k, val))
+				return warnings, errors
+			}
+		}
+
+		for _, val := range v {
+			len := len(val.(string))
+			if len < min || len > max {
+				errors = append(errors, fmt.Errorf("expected the length of all values of %q to be in the range (%d - %d), got %q (length = %d)", k, min, max, val, len))
+				return warnings, errors
+			}
+		}
+
+		return warnings, errors
+	}
+}
+
+// MapKeyMatch returns a SchemaValidateFunc which tests if the provided value
+// is of type map and all keys match a given regexp. Optionally an error message
+// can be provided to return something friendlier than "expected to match some globby regexp".
+func MapKeyMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %[1]q to be Map, got %[1]T", k))
+			return warnings, errors
+		}
+
+		for key := range v {
+			if ok := r.MatchString(key); !ok {
+				if message != "" {
+					errors = append(errors, fmt.Errorf("invalid key %q for %q (%s)", key, k, message))
+					return warnings, errors
+				}
+
+				errors = append(errors, fmt.Errorf("invalid key %q for %q (expected to match regular expression %q)", key, k, r))
+				return warnings, errors
+			}
+		}
+
+		return warnings, errors
+	}
+}
+
+// MapValueMatch returns a SchemaValidateFunc which tests if the provided value
+// is of type map and all values match a given regexp. Optionally an error message
+// can be provided to return something friendlier than "expected to match some globby regexp".
+func MapValueMatch(r *regexp.Regexp, message string) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(map[string]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %[1]q to be Map, got %[1]T", k))
+			return warnings, errors
+		}
+
+		for _, val := range v {
+			if _, ok := val.(string); !ok {
+				errors = append(errors, fmt.Errorf("expected all values of %[1]q to be strings, found %[2]v (type = %[2]T)", k, val))
+				return warnings, errors
+			}
+		}
+
+		for _, val := range v {
+			if ok := r.MatchString(val.(string)); !ok {
+				if message != "" {
+					errors = append(errors, fmt.Errorf("invalid value %q for %q (%s)", val, k, message))
+					return warnings, errors
+				}
+
+				errors = append(errors, fmt.Errorf("invalid value %q for %q (expected to match regular expression %q)", val, k, r))
+				return warnings, errors
+			}
+		}
+
+		return warnings, errors
+	}
+}

--- a/helper/validation/map.go
+++ b/helper/validation/map.go
@@ -13,19 +13,22 @@ import (
 // is of type map and the length of all keys are between min and max (inclusive)
 func MapKeyLenBetween(min, max int) schema.SchemaValidateDiagFunc {
 	return func(v interface{}, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+
 		for key := range v.(map[string]interface{}) {
 			len := len(key)
 			if len < min || len > max {
-				return diag.Diagnostics{{
+				diags = append(diags, diag.Diagnostic{
 					Severity:      diag.Error,
-					Summary:       fmt.Sprintf("expected the length of all keys to be in the range (%d - %d)", min, max),
-					Detail:        fmt.Sprintf("length = %d", len),
+					Summary:       "Bad key length",
+					Detail:        fmt.Sprintf("Key length should be in the range (%d - %d): %s (length = %d)", min, max, key, len),
 					AttributePath: append(path, cty.IndexStep{Key: cty.StringVal(key)}),
-				}}
+				})
+				break
 			}
 		}
 
-		return nil
+		return diags
 	}
 }
 

--- a/helper/validation/map_test.go
+++ b/helper/validation/map_test.go
@@ -1,0 +1,194 @@
+package validation
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestValidationMapKeyLenBetween(t *testing.T) {
+	cases := map[string]struct {
+		Value interface{}
+		Error bool
+	}{
+		"NotMap": {
+			Value: "the map is a lie",
+			Error: true,
+		},
+		"TooLong": {
+			Value: map[string]interface{}{
+				"ABC":    "123",
+				"UVWXYZ": "123456",
+			},
+			Error: true,
+		},
+		"TooShort": {
+			Value: map[string]interface{}{
+				"ABC": "123",
+				"U":   "1",
+			},
+			Error: true,
+		},
+		"AllGood": {
+			Value: map[string]interface{}{
+				"AB":    "12",
+				"UVWXY": "12345",
+			},
+			Error: false,
+		},
+	}
+
+	fn := MapKeyLenBetween(2, 5)
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			_, errors := fn(tc.Value, tn)
+
+			if len(errors) > 0 && !tc.Error {
+				t.Errorf("MapKeyLenBetween(%s) produced an unexpected error", tc.Value)
+			} else if len(errors) == 0 && tc.Error {
+				t.Errorf("MapKeyLenBetween(%s) did not error", tc.Value)
+			}
+		})
+	}
+}
+
+func TestValidationMapValueLenBetween(t *testing.T) {
+	cases := map[string]struct {
+		Value interface{}
+		Error bool
+	}{
+		"NotMap": {
+			Value: "the map is a lie",
+			Error: true,
+		},
+		"NotStringValue": {
+			Value: map[string]interface{}{
+				"ABC":    "123",
+				"UVWXYZ": 123456,
+			},
+			Error: true,
+		},
+		"TooLong": {
+			Value: map[string]interface{}{
+				"ABC":    "123",
+				"UVWXYZ": "123456",
+			},
+			Error: true,
+		},
+		"TooShort": {
+			Value: map[string]interface{}{
+				"ABC": "123",
+				"U":   "1",
+			},
+			Error: true,
+		},
+		"AllGood": {
+			Value: map[string]interface{}{
+				"AB":    "12",
+				"UVWXY": "12345",
+			},
+			Error: false,
+		},
+	}
+
+	fn := MapValueLenBetween(2, 5)
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			_, errors := fn(tc.Value, tn)
+
+			if len(errors) > 0 && !tc.Error {
+				t.Errorf("MapValueLenBetween(%s) produced an unexpected error", tc.Value)
+			} else if len(errors) == 0 && tc.Error {
+				t.Errorf("MapValueLenBetween(%s) did not error", tc.Value)
+			}
+		})
+	}
+}
+
+func TestValidationMapKeyMatch(t *testing.T) {
+	cases := map[string]struct {
+		Value interface{}
+		Error bool
+	}{
+		"NotMap": {
+			Value: "the map is a lie",
+			Error: true,
+		},
+		"NoMatch": {
+			Value: map[string]interface{}{
+				"ABC":    "123",
+				"UVWXYZ": "123456",
+			},
+			Error: true,
+		},
+		"AllGood": {
+			Value: map[string]interface{}{
+				"AB":    "12",
+				"UVABY": "12345",
+			},
+			Error: false,
+		},
+	}
+
+	fn := MapKeyMatch(regexp.MustCompile(".*AB.*"), "")
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			_, errors := fn(tc.Value, tn)
+
+			if len(errors) > 0 && !tc.Error {
+				t.Errorf("MapKeyMatch(%s) produced an unexpected error", tc.Value)
+			} else if len(errors) == 0 && tc.Error {
+				t.Errorf("MapKeyMatch(%s) did not error", tc.Value)
+			}
+		})
+	}
+}
+
+func TestValidationValueKeyMatch(t *testing.T) {
+	cases := map[string]struct {
+		Value interface{}
+		Error bool
+	}{
+		"NotMap": {
+			Value: "the map is a lie",
+			Error: true,
+		},
+		"NotStringValue": {
+			Value: map[string]interface{}{
+				"MNO":    "123",
+				"UVWXYZ": 123456,
+			},
+			Error: true,
+		},
+		"NoMatch": {
+			Value: map[string]interface{}{
+				"MNO":    "ABC",
+				"UVWXYZ": "UVWXYZ",
+			},
+			Error: true,
+		},
+		"AllGood": {
+			Value: map[string]interface{}{
+				"MNO":    "ABC",
+				"UVWXYZ": "UVABY",
+			},
+			Error: false,
+		},
+	}
+
+	fn := MapValueMatch(regexp.MustCompile(".*AB.*"), "")
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			_, errors := fn(tc.Value, tn)
+
+			if len(errors) > 0 && !tc.Error {
+				t.Errorf("MapValueMatch(%s) produced an unexpected error", tc.Value)
+			} else if len(errors) == 0 && tc.Error {
+				t.Errorf("MapValueMatch(%s) did not error", tc.Value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add various validators for Map keys and values:
* `MapKeyLenBetween` validates that the provided value is of type map and the length of all keys are between `min` and `max`
* `MapValueLenBetween` validates that the provided value is of type map and the length of all values are between `min` and `max`
* `MapKeyMatch` validates that the provided value is of type map and all keys match a given regex
* `MapValueMatch` validates that the provided value is of type map and all values match a given regex

```console
$ make test
==> Checking that code complies with gofmt requirements...
go generate ./...
go test ./...
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/acctest	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/customdiff	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/encryption	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/hashcode	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/resource	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/structure	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/validation	0.012s
ok  	github.com/hashicorp/terraform-plugin-sdk/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/addrs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/command/format	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/dag	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/flatmap	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/config	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/experiment	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/initwd	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/modsdir	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plans/internal/planproto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/planfile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/providers	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/provisioners	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/response	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/registry/test	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/version	[no test files]
?   	github.com/hashicorp/terraform-plugin-sdk/meta	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/terraform	(cached)
```