### PR TITLE
Cleanup imports

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -14,9 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/apparentlymart/go-cidr/cidr"
+	"golang.org/x/crypto/ssh"
 )
 
 func init() {

--- a/helper/customdiff/compose.go
+++ b/helper/customdiff/compose.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 

--- a/helper/encryption/encryption.go
+++ b/helper/encryption/encryption.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/errwrap"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys"
 )
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -3,8 +3,9 @@ package schema
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 // The functions and methods in this file are concerned with the conversion

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // ConfigFieldReader reads fields out of an untyped map[string]string to the

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // DiffFieldReader reads fields out of a diff structures.

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -7,8 +7,9 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 var ReservedDataSourceFields = []string{

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestResourceApply_create(t *testing.T) {

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/mitchellh/copystructure"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/mitchellh/copystructure"
 )
 
 const TimeoutKey = "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0"

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // Name of ENV variable which (if not empty) prefers panic over error

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/zclconf/go-cty/cty"
 )
 
 var (

--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )
 

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )
 
 func TestParseRef(t *testing.T) {

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -3,9 +3,9 @@ package addrs
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )
 

--- a/internal/addrs/parse_target_test.go
+++ b/internal/addrs/parse_target_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )
 

--- a/internal/addrs/provider_config.go
+++ b/internal/addrs/provider_config.go
@@ -3,10 +3,10 @@ package addrs
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )
 
 // ProviderConfig is the address of a provider configuration.

--- a/internal/addrs/provider_config_test.go
+++ b/internal/addrs/provider_config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )

--- a/internal/configs/configschema/decoder_spec_test.go
+++ b/internal/configs/configschema/decoder_spec_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/apparentlymart/go-dump/dump"
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hcltest"

--- a/internal/configs/configschema/internal_validate.go
+++ b/internal/configs/configschema/internal_validate.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/zclconf/go-cty/cty"
-
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/zclconf/go-cty/cty"
 )
 
 var validName = regexp.MustCompile(`^[a-z0-9_]+$`)

--- a/internal/configs/configschema/internal_validate_test.go
+++ b/internal/configs/configschema/internal_validate_test.go
@@ -3,9 +3,8 @@ package configschema
 import (
 	"testing"
 
-	"github.com/zclconf/go-cty/cty"
-
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestBlockInternalValidate(t *testing.T) {

--- a/internal/configs/hcl2shim/flatmap.go
+++ b/internal/configs/hcl2shim/flatmap.go
@@ -5,9 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/zclconf/go-cty/cty/convert"
-
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // FlatmapValueFromHCL2 converts a value from HCL2 (really, from the cty dynamic

--- a/internal/configs/hcl2shim/flatmap_test.go
+++ b/internal/configs/hcl2shim/flatmap_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/configs/hcl2shim/paths_test.go
+++ b/internal/configs/hcl2shim/paths_test.go
@@ -7,10 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-cmp/cmp"
-
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/internal/configs/hcl2shim/values_test.go
+++ b/internal/configs/hcl2shim/values_test.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 func TestConfigValueFromHCL2Block(t *testing.T) {

--- a/internal/helper/plugin/grpc_provider_test.go
+++ b/internal/helper/plugin/grpc_provider_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/msgpack"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/msgpack"
 )
 
 // The GRPCProviderServer will directly implement the go protobuf server

--- a/internal/helper/plugin/unknown.go
+++ b/internal/helper/plugin/unknown.go
@@ -3,8 +3,9 @@ package plugin
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 // SetUnknowns takes a cty.Value, and compares it to the schema setting any null

--- a/internal/helper/plugin/unknown_test.go
+++ b/internal/helper/plugin/unknown_test.go
@@ -3,8 +3,9 @@ package plugin
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 func TestSetUnknowns(t *testing.T) {

--- a/internal/plans/objchange/normalize_obj.go
+++ b/internal/plans/objchange/normalize_obj.go
@@ -1,8 +1,9 @@
 package objchange
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 // NormalizeObjectFromLegacySDK takes an object that may have been generated

--- a/internal/plans/objchange/normalize_obj_test.go
+++ b/internal/plans/objchange/normalize_obj_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/apparentlymart/go-dump/dump"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 )
 
 func TestNormalizeObjectFromLegacySDK(t *testing.T) {

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -1,9 +1,10 @@
 package convert
 
 import (
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // WarnsAndErrorsToProto converts the warnings and errors return by the legacy

--- a/internal/plugin/convert/diagnostics_test.go
+++ b/internal/plugin/convert/diagnostics_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestProtoDiagnostics(t *testing.T) {

--- a/internal/plugin/convert/schema_test.go
+++ b/internal/plugin/convert/schema_test.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
-	"github.com/zclconf/go-cty/cty"
 )
 
 var (

--- a/internal/tfdiags/diagnostics_test.go
+++ b/internal/tfdiags/diagnostics_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 )
 

--- a/internal/tfdiags/rpc_friendly_test.go
+++ b/internal/tfdiags/rpc_friendly_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hashicorp/hcl/v2"
 )
 

--- a/internal/vault/helper/pgpkeys/keybase.go
+++ b/internal/vault/helper/pgpkeys/keybase.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil"
 	"github.com/keybase/go-crypto/openpgp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil"
 )
 
 const (

--- a/internal/vault/sdk/helper/jsonutil/json.go
+++ b/internal/vault/sdk/helper/jsonutil/json.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/errwrap"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil"
 )
 

--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	plugin "github.com/hashicorp/go-plugin"
-	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"google.golang.org/grpc"
+
+	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 )
 
 // GRPCProviderPlugin implements plugin.GRPCPlugin for the go-plugin package.

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-plugin"
+
 	grpcplugin "github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
 
 	grpcplugin "github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin"
 	proto "github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"google.golang.org/grpc"
 )
 
 const (

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/mitchellh/copystructure"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/zclconf/go-cty/cty"
-
-	"github.com/mitchellh/copystructure"
 )
 
 // diffChangeType is an enum with the kind of changes a diff has planned.

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
+	"github.com/mitchellh/reflectwalk"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
-	"github.com/mitchellh/reflectwalk"
 )
 
 func TestResourceConfigGet(t *testing.T) {

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -21,12 +21,13 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/mitchellh/copystructure"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 	tfversion "github.com/hashicorp/terraform-plugin-sdk/internal/version"
-	"github.com/mitchellh/copystructure"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const (

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"
 )


### PR DESCRIPTION
Imports should now be broken into 3 blocks

```
import (
  "stdlib"

  "third-party"

  "sdk-itself"
)
```

Landing this onto V2 is much easier as there are less files and landing this on V1 might cause a painful interactive rebase for V2.