### PR TITLE
Context aware StateChangeConf

### DIFF
--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"sync/atomic"
@@ -326,4 +327,59 @@ func TestWaitForState_failure(t *testing.T) {
 	if obj != nil {
 		t.Fatalf("should not return obj")
 	}
+}
+
+func TestWaitForStateContext_cancel(t *testing.T) {
+	// make this refresh func block until we cancel it
+	ctx, cancel := context.WithCancel(context.Background())
+	refresh := func() (interface{}, string, error) {
+		<-ctx.Done()
+		return nil, "pending", nil
+	}
+	conf := &StateChangeConf{
+		Pending:      []string{"pending", "incomplete"},
+		Target:       []string{"running"},
+		Refresh:      refresh,
+		Timeout:      10 * time.Millisecond,
+		PollInterval: 10 * time.Second,
+	}
+
+	var obj interface{}
+	var err error
+
+	waitDone := make(chan struct{})
+	go func() {
+		defer close(waitDone)
+		obj, err = conf.WaitForStateContext(ctx)
+	}()
+
+	// make sure WaitForState is blocked
+	select {
+	case <-waitDone:
+		t.Fatal("WaitForState returned too early")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// unlock the refresh function
+	cancel()
+	// make sure WaitForState returns
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("WaitForState didn't return after refresh finished")
+	}
+
+	if err == nil {
+		t.Fatal("Expected timeout error. No error returned.")
+	}
+
+	expectedErr := "timeout while waiting for state to become 'running'"
+	if !strings.HasPrefix(err.Error(), expectedErr) {
+		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
+	}
+
+	if obj != nil {
+		t.Fatalf("should not return obj")
+	}
+
 }

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -337,20 +337,18 @@ func TestWaitForStateContext_cancel(t *testing.T) {
 		return nil, "pending", nil
 	}
 	conf := &StateChangeConf{
-		Pending:      []string{"pending", "incomplete"},
-		Target:       []string{"running"},
-		Refresh:      refresh,
-		Timeout:      10 * time.Millisecond,
-		PollInterval: 10 * time.Second,
+		Pending: []string{"pending", "incomplete"},
+		Target:  []string{"running"},
+		Refresh: refresh,
+		Timeout: 10 * time.Second,
 	}
 
-	var obj interface{}
 	var err error
 
 	waitDone := make(chan struct{})
 	go func() {
 		defer close(waitDone)
-		obj, err = conf.WaitForStateContext(ctx)
+		_, err = conf.WaitForStateContext(ctx)
 	}()
 
 	// make sure WaitForState is blocked
@@ -369,17 +367,7 @@ func TestWaitForStateContext_cancel(t *testing.T) {
 		t.Fatal("WaitForState didn't return after refresh finished")
 	}
 
-	if err == nil {
-		t.Fatal("Expected timeout error. No error returned.")
+	if err != context.Canceled {
+		t.Fatalf("Expected canceled context error, got: %s", err)
 	}
-
-	expectedErr := "timeout while waiting for state to become 'running'"
-	if !strings.HasPrefix(err.Error(), expectedErr) {
-		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
-	}
-
-	if obj != nil {
-		t.Fatalf("should not return obj")
-	}
-
 }

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -124,10 +124,12 @@ func TestRetry_nilRetryableError(t *testing.T) {
 func TestRetryContext_cancel(t *testing.T) {
 	t.Parallel()
 
+	waitForever := make(chan struct{})
+	defer close(waitForever)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	f := func() *RetryError {
-		<-ctx.Done()
+		<-waitForever
 		return nil
 	}
 
@@ -141,11 +143,13 @@ func TestRetryContext_cancel(t *testing.T) {
 func TestRetryContext_deadline(t *testing.T) {
 	t.Parallel()
 
+	waitForever := make(chan struct{})
+	defer close(waitForever)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	f := func() *RetryError {
-		<-ctx.Done()
+		<-waitForever
 		return nil
 	}
 

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -117,5 +118,23 @@ func TestRetry_nilRetryableError(t *testing.T) {
 	err := Retry(1*time.Second, f)
 	if err == nil {
 		t.Fatal("should error")
+	}
+}
+
+func TestRetryContext_cancel(t *testing.T) {
+	t.Parallel()
+
+	var ran bool
+	f := func() *RetryError {
+		ran = true
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := RetryContext(ctx, 10*time.Millisecond, f); err != nil {
+		t.Fatal("should not error")
+	} else if ran {
+		t.Fatal("should not have run RetryFunc")
 	}
 }


### PR DESCRIPTION
Creates a context aware `resource.RetryContext` and `resource.StateChangeConf.WaitForStateContext`.

Cancellation/deadline of the passed in context is respected. If `WaitForStateContext` returns due to context cancellation/deadline the resulting `context.DeadlineExceeded` or `context.Canceled` error is returned but the LastResult is not returned. If the passed in timeout is exceeded and we are in the graceful shutdown period, context cancelation will exit the grace period early, however the returned error will still be of type `*resource.TimeoutError`.

Context was not pulled through to the `Refresh` functions, these functions are often (if not always?) closed over within a CRUD method and if the context is needed within that scope it is in scope (much like `meta`).

### Proposed Usage
```
func create(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
    // StateChangeConf
    conf := &StateChangeConf{
		Pending:      []string{"pending", "incomplete"},
		Target:       []string{"running"},
		Refresh:      func() (interface{}, string, error) {
		    // ...
	        },
		Timeout:      10 * time.Second,
    }
    state, err := conf.WaitForStateContext(ctx)

    // Retry
    resource.RetryContext(ctx, 10 * time.Second, func() *RetryError {
        // ...
    })
}
```

Closes #73 