### PR TITLE
helper/schema: Additional validation for non-configurable attributes

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -758,15 +758,51 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 		}
 
 		// Computed-only field
-		if v.Computed && !v.Optional {
-			if v.ValidateFunc != nil {
-				return fmt.Errorf("%s: ValidateFunc is for validating user input, "+
-					"there's nothing to validate on computed-only field", k)
+		if computedOnly {
+			if len(v.AtLeastOneOf) > 0 {
+				return fmt.Errorf("%s: AtLeastOneOf is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if len(v.ConflictsWith) > 0 {
+				return fmt.Errorf("%s: ConflictsWith is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.Default != nil {
+				return fmt.Errorf("%s: Default is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.DefaultFunc != nil {
+				return fmt.Errorf("%s: DefaultFunc is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
 			}
 			if v.DiffSuppressFunc != nil {
 				return fmt.Errorf("%s: DiffSuppressFunc is for suppressing differences"+
 					" between config and state representation. "+
 					"There is no config for computed-only field, nothing to compare.", k)
+			}
+			if len(v.ExactlyOneOf) > 0 {
+				return fmt.Errorf("%s: ExactlyOneOf is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.InputDefault != "" {
+				return fmt.Errorf("%s: InputDefault is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.MaxItems > 0 {
+				return fmt.Errorf("%s: MaxItems is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.MinItems > 0 {
+				return fmt.Errorf("%s: MinItems is for configurable attributes,"+
+					"there's nothing to configure on computed-only field", k)
+			}
+			if v.StateFunc != nil {
+				return fmt.Errorf("%s: StateFunc is extraneous, "+
+					"value should just be changed before setting on computed-only field", k)
+			}
+			if v.ValidateFunc != nil {
+				return fmt.Errorf("%s: ValidateFunc is for validating user input, "+
+					"there's nothing to validate on computed-only field", k)
 			}
 		}
 

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -757,7 +757,6 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 			}
 		}
 
-		// Computed-only field
 		if computedOnly {
 			if len(v.AtLeastOneOf) > 0 {
 				return fmt.Errorf("%s: AtLeastOneOf is for configurable attributes,"+

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3419,29 +3419,155 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
-		"computed-only field with validateFunc": {
+		"Computed-only with AtLeastOneOf": {
 			map[string]*Schema{
-				"string": &Schema{
+				"string_one": &Schema{
 					Type:     TypeString,
 					Computed: true,
-					ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-						es = append(es, fmt.Errorf("this is not fine"))
-						return
+					AtLeastOneOf: []string{
+						"string_one",
+						"string_two",
+					},
+				},
+				"string_two": &Schema{
+					Type:     TypeString,
+					Computed: true,
+					AtLeastOneOf: []string{
+						"string_one",
+						"string_two",
 					},
 				},
 			},
 			true,
 		},
 
-		"computed-only field with diffSuppressFunc": {
+		"Computed-only with ConflictsWith": {
+			map[string]*Schema{
+				"string_one": &Schema{
+					Type:     TypeString,
+					Computed: true,
+					ConflictsWith: []string{
+						"string_two",
+					},
+				},
+				"string_two": &Schema{
+					Type:     TypeString,
+					Computed: true,
+					ConflictsWith: []string{
+						"string_one",
+					},
+				},
+			},
+			true,
+		},
+
+		"Computed-only with Default": {
 			map[string]*Schema{
 				"string": &Schema{
 					Type:     TypeString,
 					Computed: true,
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
-						// Always suppress any diff
-						return false
+					Default:  "test",
+				},
+			},
+			true,
+		},
+
+		"Computed-only with DefaultFunc": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:        TypeString,
+					Computed:    true,
+					DefaultFunc: func() (interface{}, error) { return nil, nil },
+				},
+			},
+			true,
+		},
+
+		"Computed-only with DiffSuppressFunc": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:             TypeString,
+					Computed:         true,
+					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool { return false },
+				},
+			},
+			true,
+		},
+
+		"Computed-only with ExactlyOneOf": {
+			map[string]*Schema{
+				"string_one": &Schema{
+					Type:     TypeString,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"string_one",
+						"string_two",
 					},
+				},
+				"string_two": &Schema{
+					Type:     TypeString,
+					Computed: true,
+					ExactlyOneOf: []string{
+						"string_one",
+						"string_two",
+					},
+				},
+			},
+			true,
+		},
+
+		"Computed-only with InputDefault": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:         TypeString,
+					Computed:     true,
+					InputDefault: "test",
+				},
+			},
+			true,
+		},
+
+		"Computed-only with MaxItems": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:     TypeList,
+					Elem:     &Schema{Type: TypeString},
+					Computed: true,
+					MaxItems: 1,
+				},
+			},
+			true,
+		},
+
+		"Computed-only with MinItems": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:     TypeList,
+					Elem:     &Schema{Type: TypeString},
+					Computed: true,
+					MinItems: 1,
+				},
+			},
+			true,
+		},
+
+		"Computed-only with StateFunc": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:      TypeString,
+					Computed:  true,
+					StateFunc: func(v interface{}) string { return "" },
+				},
+			},
+			true,
+		},
+
+		"Computed-only with ValidateFunc": {
+			map[string]*Schema{
+				"string": &Schema{
+					Type:         TypeString,
+					Computed:     true,
+					ValidateFunc: func(v interface{}, k string) ([]string, []error) { return nil, nil },
 				},
 			},
 			true,


### PR DESCRIPTION
Reference: https://github.com/bflad/tfproviderlint#standard-schema-checks

These `Schema` fields are only intended for configurable attributes.