### PR TITLE
helper/schema: Additional Schema validation for TypeMap with Elem *Resource

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -749,6 +749,14 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 			}
 		}
 
+		if v.Type == TypeMap && v.Elem != nil {
+			switch v.Elem.(type) {
+			case *Resource:
+				return fmt.Errorf("%s: TypeMap with Elem *Resource not supported,"+
+					"use TypeList/TypeSet with Elem *Resource or TypeMap with Elem *Schema", k)
+			}
+		}
+
 		if computedOnly {
 			if len(v.AtLeastOneOf) > 0 {
 				return fmt.Errorf("%s: AtLeastOneOf is for configurable attributes,"+

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3636,6 +3636,24 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			},
 			true, // in *schema.Resource with ConfigMode of attribute, so must also have ConfigMode of attribute
 		},
+
+		"TypeMap with Elem *Resource": {
+			map[string]*Schema{
+				"map": &Schema{
+					Type:     TypeMap,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"keynothandled": &Schema{
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Reference: https://github.com/bflad/tfproviderlint/blob/master/passes/S022/README.md

The current behavior of these attributes in Terraform Plugin SDK v1.7.0 is similar to `map[string]string`, which is confusing for nested schema with multiple types.

For example, the following schema:

```go
"permissions": {
	Type:     schema.TypeMap,
	Optional: true,
	Elem: &schema.Resource{
		Schema: map[string]*schema.Schema{
			"type": {
				Type:     schema.TypeString,
				Required: true,
				ValidateFunc: validation.StringInSlice([]string{
					ssm.DocumentPermissionTypeShare,
				}, false),
			},
			"account_ids": {
				Type:     schema.TypeString,
				Required: true,
			},
		},
	},
},
```

Results in the following potential configuration:

```hcl
  permissions = {
    type        = "Share"
    account_ids = "all"
  }
```

Which works fine, but also allows (which Terraform perpetually reports the difference of the extra key, but does not return an error) :

```hcl
  permissions = {
    thisisfine  = "yesreally"
    type        = "Share"
    account_ids = "all"
  }
```

And also confusingly does not validate the `type` value (which causes an API error and bug report to be filed):

```hcl
  permissions = {
    type        = "hmmmm"
    account_ids = "all"
  }
```

In complex nested attribute usage:

```go
"config": {
    Type:     schema.TypeMap,
    Optional: true,
    Elem: &schema.Resource{
      Schema: map[string]*schema.Schema{
        "attributes": {
          Type:     schema.TypeList,
          Optional: true,
          Elem: &schema.Schema{
            Type: schema.TypeString,
          },
        },
​
        // other fields
      },
    },
  },
```

Calling Terraform gives an (unexpected) error (`config is invalid: Incorrect attribute value type: Inappropriate value for attribute "config": element "attributes": string required.`) when using the following configuration:

```hcl
  config = {
    attributes = ["a","b"]
  }
```

Provider developers only using string nested attributes can switch out the `Elem: &schema.Resource{}` for `Elem: &schema.Schema{Type: schema.TypeString}` to retain the same configuration syntax for operators without breaking change. However, to get the benefits of a real configuration block (such as nested key/value validation and complex nested types), a new attribute will need to be created in the resource.