### PR TITLE
Remove protocol 5 feature flag

### DIFF
--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -82,18 +82,16 @@ func (r *ConfigFieldReader) readField(
 	k := strings.Join(address, ".")
 	schema := schemaList[len(schemaList)-1]
 
-	if protoVersion5 {
-		switch schema.Type {
-		case TypeList, TypeSet, TypeMap, typeObject:
-			// Check if the value itself is unknown.
-			// The new protocol shims will add unknown values to this list of
-			// ComputedKeys. This is the only way we have to indicate that a
-			// collection is unknown in the config
-			for _, unknown := range r.Config.ComputedKeys {
-				if k == unknown {
-					log.Printf("[DEBUG] setting computed for %q from ComputedKeys", k)
-					return FieldReadResult{Computed: true, Exists: true}, nil
-				}
+	switch schema.Type {
+	case TypeList, TypeSet, TypeMap, typeObject:
+		// Check if the value itself is unknown.
+		// The new protocol shims will add unknown values to this list of
+		// ComputedKeys. This is the only way we have to indicate that a
+		// collection is unknown in the config
+		for _, unknown := range r.Config.ComputedKeys {
+			if k == unknown {
+				log.Printf("[DEBUG] setting computed for %q from ComputedKeys", k)
+				return FieldReadResult{Computed: true, Exists: true}, nil
 			}
 		}
 	}

--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -198,16 +198,13 @@ func (s *Set) add(item interface{}, computed bool) string {
 	code := s.hash(item)
 	if computed {
 		code = "~" + code
-
-		if isProto5() {
-			tmpCode := code
-			count := 0
-			for _, exists := s.m[tmpCode]; exists; _, exists = s.m[tmpCode] {
-				count++
-				tmpCode = fmt.Sprintf("%s%d", code, count)
-			}
-			code = tmpCode
+		tmpCode := code
+		count := 0
+		for _, exists := s.m[tmpCode]; exists; _, exists = s.m[tmpCode] {
+			count++
+			tmpCode = fmt.Sprintf("%s%d", code, count)
 		}
+		code = tmpCode
 	}
 
 	if _, ok := s.m[code]; !ok {

--- a/internal/helper/plugin/grpc_provider.go
+++ b/internal/helper/plugin/grpc_provider.go
@@ -58,9 +58,6 @@ func (s *GRPCProviderServer) StopContext(ctx context.Context) context.Context {
 }
 
 func (s *GRPCProviderServer) GetSchema(_ context.Context, req *proto.GetProviderSchema_Request) (*proto.GetProviderSchema_Response, error) {
-	// Here we are certain that the provider is being called through grpc, so
-	// make sure the feature flag for helper/schema is set
-	schema.SetProto5()
 
 	resp := &proto.GetProviderSchema_Response{
 		ResourceSchemas:   make(map[string]*proto.Schema),


### PR DESCRIPTION
V2 of the SDK only runs through protocol 5. This is technically a breaking change since `schema.SetProto5()` was public, however it should never have been called by providers.