### PR TITLE
Add 'StringNotInSlice' validation function

### DIFF
--- a/helper/validation/strings.go
+++ b/helper/validation/strings.go
@@ -148,6 +148,28 @@ func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
 	}
 }
 
+// StringNotInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and does not match the value of any element in the invalid slice
+// will test with in lower case if ignoreCase is true
+func StringNotInSlice(invalid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		for _, str := range invalid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				errors = append(errors, fmt.Errorf("expected %s to not be any of %v, got %s", k, invalid, v))
+				return warnings, errors
+			}
+		}
+
+		return warnings, errors
+	}
+}
+
 // StringDoesNotContainAny returns a SchemaValidateFunc which validates that the
 // provided value does not contain any of the specified Unicode code points in chars.
 func StringDoesNotContainAny(chars string) schema.SchemaValidateFunc {

--- a/helper/validation/strings_test.go
+++ b/helper/validation/strings_test.go
@@ -305,6 +305,36 @@ func TestValidationStringInSlice(t *testing.T) {
 	})
 }
 
+func TestValidationStringNotInSlice(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val: "ValidValue",
+			f:   StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, false),
+		},
+		// ignore case
+		{
+			val: "VALIDVALUE",
+			f:   StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, true),
+		},
+		{
+			val:         "AnotherInvalidValue",
+			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, false),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got AnotherInvalidValue"),
+		},
+		// ignore case
+		{
+			val:         "INVALIDVALUE",
+			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, true),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got INVALIDVALUE"),
+		},
+		{
+			val:         1,
+			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, false),
+			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
+		},
+	})
+}
+
 func TestValidationStringMatch(t *testing.T) {
 	runTestCases(t, []testCase{
 		{


### PR DESCRIPTION
Add `StringNotInSlice()`, a validator to ensure that the provided value does NOT match the value of any element in the specified string slice.

```console
$ make test
==> Checking that code complies with gofmt requirements...
go generate ./...
go test ./...
?   	github.com/hashicorp/terraform-plugin-sdk/acctest	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/acctest	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/customdiff	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/encryption	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/hashcode	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/helper/logging	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/resource	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/structure	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/validation	0.011s
ok  	github.com/hashicorp/terraform-plugin-sdk/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/addrs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/command/format	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/dag	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/flatmap	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/config	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/experiment	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/httpclient	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/initwd	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/modsdir	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plans/internal/planproto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plans/planfile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/plugin/mock_proto	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/providers	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/provisioners	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/registry/response	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/registry/test	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/helper/pgpkeys	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/compressutil	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/internal/vault/sdk/helper/jsonutil	(cached)
?   	github.com/hashicorp/terraform-plugin-sdk/internal/version	[no test files]
?   	github.com/hashicorp/terraform-plugin-sdk/meta	[no test files]
ok  	github.com/hashicorp/terraform-plugin-sdk/plugin	(cached)
ok  	github.com/hashicorp/terraform-plugin-sdk/terraform	(cached)
```