### PR TITLE
RequiredWith schema check and changes in validation for optional schema fields 

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1400,6 +1400,16 @@ func (m schemaMap) validate(
 		ok = raw != nil
 	}
 
+	err := validateExactlyOneAttribute(k, schema, c)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	err = validateAtLeastOneAttribute(k, schema, c)
+	if err != nil {
+		return nil, []error{err}
+	}
+
 	if !ok {
 		if schema.Required {
 			return nil, []error{fmt.Errorf(
@@ -1414,17 +1424,7 @@ func (m schemaMap) validate(
 			"%q: this field cannot be set", k)}
 	}
 
-	err := validateRequiredWithAttribute(k, schema, c)
-	if err != nil {
-		return nil, []error{err}
-	}
-
-	err = validateExactlyOneAttribute(k, schema, c)
-	if err != nil {
-		return nil, []error{err}
-	}
-
-	err = validateAtLeastOneAttribute(k, schema, c)
+	err = validateRequiredWithAttribute(k, schema, c)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -223,13 +223,13 @@ type Schema struct {
 	//
 	// AtLeastOneOf is a set of schema keys that, when set, at least one of
 	// the keys in that list must be specified.
-	// 
-	// AllOf is a set of schema keys that must be set simultaneously. This 
+	//
+	// AllOf is a set of schema keys that must be set simultaneously. This
 	// setting conflicts with ExactlyOneOf or AtLeastOneOf
 	ConflictsWith []string
 	ExactlyOneOf  []string
 	AtLeastOneOf  []string
-	AllOf 		  []string
+	AllOf         []string
 
 	// When Deprecated is set, this attribute is deprecated.
 	//
@@ -1521,7 +1521,7 @@ func validateAllOfAttribute(
 	if len(schema.AllOf) == 0 {
 		return nil
 	}
-	
+
 	allKeys := removeDuplicates(append(schema.AllOf, k))
 	sort.Strings(allKeys)
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6537,7 +6537,7 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 			},
 
 			Config: map[string]interface{}{},
-			Err:    true,
+			Err:    false,
 		},
 
 		"Only Unknown Variable Value": {
@@ -6614,6 +6614,277 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 			},
 
 			Err: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			c := terraform.NewResourceConfigRaw(tc.Config)
+			_, es := schemaMap(tc.Schema).Validate(c)
+			if len(es) > 0 != tc.Err {
+				if len(es) == 0 {
+					t.Fatalf("expected error")
+				}
+
+				for _, e := range es {
+					t.Fatalf("didn't expect error, got error: %+v", e)
+				}
+
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func TestValidateAllOfAttributes(t *testing.T) {
+	cases := map[string]struct {
+		Key    string
+		Schema map[string]*Schema
+		Config map[string]interface{}
+		Err    bool
+	}{
+
+		"two attributes specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"blacklist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": true,
+				"blacklist": true,
+			},
+			Err: false,
+		},
+
+		"one attributes specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"blacklist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": true,
+			},
+			Err: true,
+		},
+
+		"no attributes specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"blacklist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist"},
+				},
+			},
+
+			Config: map[string]interface{}{},
+			Err:    false,
+		},
+
+		"two attributes of three specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist":  true,
+				"purplelist": true,
+			},
+			Err: false,
+		},
+
+		"three attributes of three specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"blacklist", "purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist":  true,
+				"purplelist": true,
+				"blacklist":  true,
+			},
+			Err: false,
+		},
+
+		"one attributes of three specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"blacklist", "purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"purplelist": true,
+			},
+			Err: true,
+		},
+
+		"no attributes of three specified": {
+			Key: "whitelist",
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+			},
+
+			Config: map[string]interface{}{},
+			Err:    false,
+		},
+
+		"Only Unknown Variable Value": {
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": hcl2shim.UnknownVariableValue,
+			},
+
+			Err: true,
+		},
+
+		"only unknown list value": {
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+					AllOf:    []string{"whitelist", "blacklist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+					AllOf:    []string{"whitelist", "blacklist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": []interface{}{hcl2shim.UnknownVariableValue},
+			},
+
+			Err: true,
+		},
+
+		"Unknown Variable Value and Known Value": {
+			Schema: map[string]*Schema{
+				"whitelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"blacklist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+				"purplelist": &Schema{
+					Type:     TypeBool,
+					Optional: true,
+					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"whitelist": hcl2shim.UnknownVariableValue,
+				"blacklist": true,
+			},
+
+			Err: true,
 		},
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6636,7 +6636,7 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 	}
 }
 
-func TestValidateAllOfAttributes(t *testing.T) {
+func TestValidateRequiredWithAttributes(t *testing.T) {
 	cases := map[string]struct {
 		Key    string
 		Schema map[string]*Schema
@@ -6648,14 +6648,14 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"blacklist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"blacklist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist"},
 				},
 			},
 
@@ -6670,14 +6670,14 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"blacklist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"blacklist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist"},
 				},
 			},
 
@@ -6691,14 +6691,14 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"blacklist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"blacklist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist"},
 				},
 			},
 
@@ -6710,19 +6710,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist"},
 				},
 			},
 
@@ -6737,19 +6737,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist"},
 				},
 			},
 
@@ -6765,19 +6765,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist"},
 				},
 			},
 
@@ -6791,19 +6791,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 			},
 
@@ -6814,19 +6814,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"Only Unknown Variable Value": {
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 			},
 
@@ -6840,16 +6840,16 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"only unknown list value": {
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeList,
-					Optional: true,
-					Elem:     &Schema{Type: TypeString},
-					AllOf:    []string{"whitelist", "blacklist"},
+					Type:         TypeList,
+					Optional:     true,
+					Elem:         &Schema{Type: TypeString},
+					RequiredWith: []string{"whitelist", "blacklist"},
 				},
 				"blacklist": {
-					Type:     TypeList,
-					Optional: true,
-					Elem:     &Schema{Type: TypeString},
-					AllOf:    []string{"whitelist", "blacklist"},
+					Type:         TypeList,
+					Optional:     true,
+					Elem:         &Schema{Type: TypeString},
+					RequiredWith: []string{"whitelist", "blacklist"},
 				},
 			},
 
@@ -6863,19 +6863,19 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"Unknown Variable Value and Known Value": {
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 				"purplelist": {
-					Type:     TypeBool,
-					Optional: true,
-					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"whitelist", "blacklist", "purplelist"},
 				},
 			},
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6537,7 +6537,7 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 			},
 
 			Config: map[string]interface{}{},
-			Err:    false,
+			Err:    true,
 		},
 
 		"Only Unknown Variable Value": {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6647,12 +6647,12 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"two attributes specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"blacklist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist"},
@@ -6669,12 +6669,12 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"one attributes specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"blacklist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist"},
@@ -6690,12 +6690,12 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"no attributes specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"blacklist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist"},
@@ -6709,17 +6709,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"two attributes of three specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist"},
@@ -6736,17 +6736,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"three attributes of three specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"blacklist", "purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist"},
@@ -6764,17 +6764,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"one attributes of three specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"blacklist", "purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist"},
@@ -6790,17 +6790,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 		"no attributes of three specified": {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
@@ -6813,17 +6813,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 
 		"Only Unknown Variable Value": {
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
@@ -6839,13 +6839,13 @@ func TestValidateAllOfAttributes(t *testing.T) {
 
 		"only unknown list value": {
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeList,
 					Optional: true,
 					Elem:     &Schema{Type: TypeString},
 					AllOf:    []string{"whitelist", "blacklist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeList,
 					Optional: true,
 					Elem:     &Schema{Type: TypeString},
@@ -6862,17 +6862,17 @@ func TestValidateAllOfAttributes(t *testing.T) {
 
 		"Unknown Variable Value and Known Value": {
 			Schema: map[string]*Schema{
-				"whitelist": &Schema{
+				"whitelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"blacklist": &Schema{
+				"blacklist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},
 				},
-				"purplelist": &Schema{
+				"purplelist": {
 					Type:     TypeBool,
 					Optional: true,
 					AllOf:    []string{"whitelist", "blacklist", "purplelist"},


### PR DESCRIPTION
This PR contains 

the new `RequiredWith` schema validation check (including unit tests), and

## RequiredWith validation check

The new `RequiredWith` schema validation check, complements the existing `ExactlyOneOf`and `AtLeastOneOf` in the way that when the schema field has an assigned value, **all** fields listed must have assigned values as well.

The new `RequiredWith` validation check allows building (mutual) dependencies over multiple schema fields, whereas the existing `ExactlyOneOf` and `AtLeastOneOf` checks only ensure fulfilled dependencies with only one other schema field.