### PR TITLE
TF_SCHEMA_PANIC_ON_ERROR on by default

### DIFF
--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -2232,7 +2232,7 @@ func TestResourceDataSet(t *testing.T) {
 	}
 
 	oldEnv := os.Getenv(PanicOnErr)
-	os.Setenv(PanicOnErr, "")
+	os.Setenv(PanicOnErr, "false")
 	defer os.Setenv(PanicOnErr, oldEnv)
 
 	for i, tc := range cases {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"regexp"
@@ -411,10 +412,18 @@ type InternalMap = schemaMap
 type schemaMap map[string]*Schema
 
 func (m schemaMap) panicOnError() bool {
-	if os.Getenv(PanicOnErr) != "" {
+	if env := os.Getenv(PanicOnErr); env == "" {
+		// default to true
+		return true
+	} else if b, err := strconv.ParseBool(env); err == nil {
+		// allow opt out
+		return b
+	} else {
+		// default to true for anything set, this is backwards compatible
+		// with the previous implementation
+		log.Printf("[WARN] %s=%s not parsable: %s, defaulting to true", PanicOnErr, env, err)
 		return true
 	}
-	return false
 }
 
 // Data returns a ResourceData for the given schema, state, and diff.

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6457,3 +6457,47 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 		})
 	}
 }
+
+func Test_panicOnErrDefaultTrue(t *testing.T) {
+	oldEnv := os.Getenv(PanicOnErr)
+
+	os.Setenv(PanicOnErr, "")
+	if !schemaMap(nil).panicOnError() {
+		t.Fatalf("Empty %s should default to true", PanicOnErr)
+	}
+
+	os.Setenv(PanicOnErr, oldEnv)
+}
+
+func Test_panicOnErrParsableTrue(t *testing.T) {
+	oldEnv := os.Getenv(PanicOnErr)
+
+	os.Setenv(PanicOnErr, "true")
+	if !schemaMap(nil).panicOnError() {
+		t.Fatalf("Parsable truthy %s should return true", PanicOnErr)
+	}
+
+	os.Setenv(PanicOnErr, oldEnv)
+}
+
+func Test_panicOnErrParsableFalse(t *testing.T) {
+	oldEnv := os.Getenv(PanicOnErr)
+
+	os.Setenv(PanicOnErr, "false")
+	if schemaMap(nil).panicOnError() {
+		t.Fatalf("Parsable falsy %s should return false", PanicOnErr)
+	}
+
+	os.Setenv(PanicOnErr, oldEnv)
+}
+
+func Test_panicOnErrUnparsableDefaultTrue(t *testing.T) {
+	oldEnv := os.Getenv(PanicOnErr)
+
+	os.Setenv(PanicOnErr, "FOO")
+	if !schemaMap(nil).panicOnError() {
+		t.Fatalf("Any set value for %s should return true", PanicOnErr)
+	}
+
+	os.Setenv(PanicOnErr, oldEnv)
+}


### PR DESCRIPTION
opt out with Go parsable boolean (False, false, FALSE, 0). In the case where a value is set but is not a parsable boolean, a warning is logged but true is the default to remain backwards compatible with the previous implementation (where opt in involved setting the env var to anything).