### PR TITLE
Fix plugin.Serve

### DIFF
--- a/plugin/grpc_provider.go
+++ b/plugin/grpc_provider.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"errors"
+	"net/rpc"
 
 	plugin "github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
@@ -9,16 +11,28 @@ import (
 	proto "github.com/hashicorp/terraform-plugin-sdk/v2/internal/tfplugin5"
 )
 
-// GRPCProviderPlugin implements plugin.GRPCPlugin for the go-plugin package.
+var (
+	_ plugin.GRPCPlugin = (*gRPCProviderPlugin)(nil)
+	_ plugin.Plugin     = (*gRPCProviderPlugin)(nil)
+)
+
+// gRPCProviderPlugin implements plugin.GRPCPlugin and plugin.Plugin for the go-plugin package.
+// the only real implementation is GRPCSServer, the other methods are only satisfied
+// for compatibility with go-plugin
 type gRPCProviderPlugin struct {
-	plugin.Plugin
 	GRPCProvider func() proto.ProviderServer
 }
 
-// this exists only to satisfy the go-plugin.GRPCPlugin interface
-// that interface should likely be split
-func (p *gRPCProviderPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
-	return nil, nil
+func (p *gRPCProviderPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return nil, errors.New("terraform-plugin-sdk only implements grpc servers")
+}
+
+func (p *gRPCProviderPlugin) Client(*plugin.MuxBroker, *rpc.Client) (interface{}, error) {
+	return nil, errors.New("terraform-plugin-sdk only implements grpc servers")
+}
+
+func (p *gRPCProviderPlugin) GRPCClient(context.Context, *plugin.GRPCBroker, *grpc.ClientConn) (interface{}, error) {
+	return nil, errors.New("terraform-plugin-sdk only implements grpc servers")
 }
 
 func (p *gRPCProviderPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -53,7 +53,7 @@ func Serve(opts *ServeOpts) {
 		HandshakeConfig: Handshake,
 		VersionedPlugins: map[int]plugin.PluginSet{
 			5: {
-				ProviderPluginName: gRPCProviderPlugin{
+				ProviderPluginName: &gRPCProviderPlugin{
 					GRPCProvider: func() proto.ProviderServer {
 						return provider
 					},


### PR DESCRIPTION
A missed `&` causes the struct to be passed by value and thus it no longer implements the `plugin.GRPCPlugin`. Tracing the code through `go-plugin`, a default for netrpc is selected if the grpc interface is not implemented.. which caused an initial handshake error. The struct also previously embedded the `plugin.Plugin` interface... which allows it to satisfy the interface even though calling a method would panic? (I'm not sure how that works..) for clarity the implementation was made explicit but now the "dummy" methods return an error if they are ever called, the SDKv2 will ONLY implement GRPC server plugins.