### PR TITLE
Deprecate GetOkExists

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -108,16 +108,11 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
-// GetOkExists returns the data for a given key and whether or not the key
-// has been set to a non-zero value. This is only useful for determining
-// if boolean attributes have been set, if they are Optional but do not
-// have a Default value.
+// GetOkExists can check if TypeBool attributes that are Optional with
+// no Default value have been set.
 //
-// This is nearly the same function as GetOk, yet it does not check
-// for the zero value of the attribute's type. This allows for attributes
-// without a default, to fully check for a literal assignment, regardless
-// of the zero-value for that type.
-// This should only be used if absolutely required/needed.
+// Deprecated: usage is discouraged due to undefined behaviors and may be
+// removed in a future version of the SDK
 func (d *ResourceData) GetOkExists(key string) (interface{}, bool) {
 	r := d.getRaw(key, getSourceSet)
 	exists := r.Exists && !r.Computed


### PR DESCRIPTION
Taking a harder stance and really discouraging the use of this method. It will be deprecated but I would not remove it in V2.

closes #283 