### PR TITLE
auto-configure providers during binary acctests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ DEPRECATED:
 
 * helper/schema: `ResourceData.GetOkExists` will not be removed in the next major version unless a suitable replacement or alternative can be prescribed [GH-350]
 
+BUG FIXES:
+
+* Binary acceptance test driver: auto-configure providers [GH-355]
+
 # 1.8.0 (March 11, 2020)
 
 FEATURES:

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -556,11 +556,6 @@ func Test(t TestT, c TestCase) {
 		return
 	}
 
-	// Run the PreCheck if we have it
-	if c.PreCheck != nil {
-		c.PreCheck()
-	}
-
 	// get instances of all providers, so we can use the individual
 	// resources to shim the state during the tests.
 	providers := make(map[string]terraform.ResourceProvider)
@@ -573,9 +568,29 @@ func Test(t TestT, c TestCase) {
 	}
 
 	if acctest.TestHelper != nil && c.DisableBinaryDriver == false {
+		// auto-configure all providers
+		for _, p := range providers {
+			err = p.Configure(terraform.NewResourceConfigRaw(nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Run the PreCheck if we have it.
+		// This is done after the auto-configure to allow providers
+		// to override the default auto-configure parameters.
+		if c.PreCheck != nil {
+			c.PreCheck()
+		}
+
 		// inject providers for ImportStateVerify
 		RunNewTest(t.(*testing.T), c, providers)
 		return
+	} else {
+		// run the PreCheck if we have it
+		if c.PreCheck != nil {
+			c.PreCheck()
+		}
 	}
 
 	providerResolver, err := testProviderResolver(c)


### PR DESCRIPTION
Fixes #352.

This runs `Configure()` on providers prior to the binary acctest run, so they can access `provider.Meta()` during tests.

The one nuance to be aware of here is that `PreCheck()` is called after the auto-configure, in case providers are already using this for custom configuration.

### Note

Once this is approved I'll generate CHANGELOG and raise another PR to the `version2` branch.