### PR TITLE
Binary testing: omit test cleanup when state is empty

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -14,13 +14,18 @@ import (
 	tftest "github.com/hashicorp/terraform-plugin-test"
 )
 
-func getState(t *testing.T, wd *tftest.WorkingDir) *terraform.State {
-	jsonState := wd.RequireState(t)
-	state, err := shimStateFromJson(jsonState)
-	if err != nil {
-		t.Fatal(err)
+func runPostTestDestroy(t *testing.T, c TestCase, wd *tftest.WorkingDir) error {
+	wd.RequireDestroy(t)
+
+	if c.CheckDestroy != nil {
+		statePostDestroy := getState(t, wd)
+
+		if err := c.CheckDestroy(statePostDestroy); err != nil {
+			return err
+		}
 	}
-	return state
+
+	return nil
 }
 
 func RunNewTest(t *testing.T, c TestCase, providers map[string]terraform.ResourceProvider) {
@@ -29,15 +34,12 @@ func RunNewTest(t *testing.T, c TestCase, providers map[string]terraform.Resourc
 	wd := acctest.TestHelper.RequireNewWorkingDir(t)
 
 	defer func() {
-		wd.RequireDestroy(t)
+		statePreDestroy := getState(t, wd)
 
-		if c.CheckDestroy != nil {
-			statePostDestroy := getState(t, wd)
-
-			if err := c.CheckDestroy(statePostDestroy); err != nil {
-				t.Fatal(err)
-			}
+		if !stateIsEmpty(statePreDestroy) {
+			runPostTestDestroy(t, c, wd)
 		}
+
 		wd.Close()
 	}()
 
@@ -98,6 +100,19 @@ func RunNewTest(t *testing.T, c TestCase, providers map[string]terraform.Resourc
 	}
 }
 
+func getState(t *testing.T, wd *tftest.WorkingDir) *terraform.State {
+	jsonState := wd.RequireState(t)
+	state, err := shimStateFromJson(jsonState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func stateIsEmpty(state *terraform.State) bool {
+	return state.Empty() || !state.HasResources()
+}
+
 func planIsEmpty(plan *tfjson.Plan) bool {
 	for _, rc := range plan.ResourceChanges {
 		if rc.Mode == tfjson.DataResourceMode {
@@ -114,6 +129,7 @@ func planIsEmpty(plan *tfjson.Plan) bool {
 	}
 	return true
 }
+
 func testIDRefresh(c TestCase, t *testing.T, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-plugin-sdk/issues/347

The legacy test framework does not attempt a post-test destroy step when there is no state: https://github.com/hashicorp/terraform-plugin-sdk/blob/master/helper/resource/testing.go#L701

This was missed out of the new framework, with the consequence that successful tests that do not create resources would error during cleanup.

We add this check back, in new binary testing style - the nuance here being that our state may well contain modules but no resources.

Again, I'll raise a separate PR to the `version2` branch after review.