### PR TITLE
Makefile: Update fmt target to include gofmt -s flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ protobuf:
 	bash internal/tfplugin5/generate.sh
 
 fmt:
-	gofmt -w $(GOFMT_FILES)
+	gofmt -s -w $(GOFMT_FILES)
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"


### PR DESCRIPTION
The gofmtcheck.sh script uses the gofmt -s flag for reporting simplification issues, so the fixing command must also include this flag.