### PR TITLE
Binary testing: Fix cleanup of temporary directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.1 (Unreleased)
+
+BUG FIXES:
+
+* Binary acceptance test driver: fix cleanup of temporary directories [GH-378]
+
 # 1.9.0 (March 26, 2020)
 
 DEPRECATED:

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -108,10 +108,15 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 	} else {
+		exitCode := m.Run()
+
 		if acctest.TestHelper != nil {
-			defer acctest.TestHelper.Close()
+			err := acctest.TestHelper.Close()
+			if err != nil {
+				log.Printf("Error cleaning up temporary test files: %s", err)
+			}
 		}
-		os.Exit(m.Run())
+		os.Exit(exitCode)
 	}
 }
 


### PR DESCRIPTION
Fix a bug in which temporary directories created during a binary test run were not cleaned up at the end of the run.