### PR TITLE
Adding PairedWith Validation Check

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -225,7 +225,7 @@ type Schema struct {
 	// the keys in that list must be specified.
 	//
 	// PairedWith is a set of schema keys that when one key is set, the rest
-	// of the keys in the set must also be set.
+	// of the keys in the set must also be specified.
 	ConflictsWith []string
 	ExactlyOneOf  []string
 	AtLeastOneOf  []string

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1573,7 +1573,6 @@ func validateAtLeastOneAttribute(
 	return fmt.Errorf("%q: one of `%s` must be specified", k, strings.Join(allKeys, ","))
 }
 
-
 func validatePairedWithAttribute(
 	k string,
 	schema *Schema,
@@ -1603,13 +1602,12 @@ func validatePairedWithAttribute(
 		return nil
 	}
 
-	if count + unknownVariableValueCount != len(allKeys) {
+	if count+unknownVariableValueCount != len(allKeys) {
 		return fmt.Errorf("all of `%s` must be specified when using %q", strings.Join(allKeys, ","), k)
 	}
 
 	return nil
 }
-
 
 func (m schemaMap) validateList(
 	k string,

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6636,7 +6636,6 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 	}
 }
 
-
 func TestValidatePairedWithAttributes(t *testing.T) {
 	cases := map[string]struct {
 		Key    string
@@ -6649,13 +6648,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist"},
 				},
 			},
@@ -6671,13 +6670,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist"},
 				},
 			},
@@ -6692,18 +6691,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -6719,18 +6718,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -6745,18 +6744,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -6769,18 +6768,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -6795,18 +6794,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -6822,18 +6821,18 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "whitelist",
 			Schema: map[string]*Schema{
 				"whitelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"blacklist", "purplelist"},
 				},
 				"blacklist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "purplelist"},
 				},
 				"purplelist": {
-					Type:         TypeBool,
-					Optional:     true,
+					Type:       TypeBool,
+					Optional:   true,
 					PairedWith: []string{"whitelist", "blacklist"},
 				},
 			},
@@ -7207,15 +7206,15 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 				"purplelist": {
@@ -7241,15 +7240,15 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 			},
@@ -7270,15 +7269,15 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
-					Elem:         &Schema{Type: TypeString},
+					Type:       TypeList,
+					Optional:   true,
+					Elem:       &Schema{Type: TypeString},
 					PairedWith: []string{"allow", "deny"},
 				},
 			},
@@ -7298,13 +7297,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeMap,
-					Optional:     true,
+					Type:       TypeMap,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
+					Type:       TypeList,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"purplelist": {
@@ -7328,13 +7327,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeMap,
-					Optional:     true,
+					Type:       TypeMap,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
+					Type:       TypeList,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"purplelist": {
@@ -7358,13 +7357,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeMap,
-					Optional:     true,
+					Type:       TypeMap,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
+					Type:       TypeList,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"purplelist": {
@@ -7390,13 +7389,13 @@ func TestValidatePairedWithAttributes(t *testing.T) {
 			Key: "allow",
 			Schema: map[string]*Schema{
 				"allow": {
-					Type:         TypeMap,
-					Optional:     true,
+					Type:       TypeMap,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 				"deny": {
-					Type:         TypeList,
-					Optional:     true,
+					Type:       TypeList,
+					Optional:   true,
 					PairedWith: []string{"allow", "deny"},
 				},
 			},


### PR DESCRIPTION
Adding a new validation check for a use case where attributes must be specified together but they don't fit in the List/Set model.

```
go test ./helper/schema/ -run TestValidatePairedWithAttributes
ok  	github.com/hashicorp/terraform-plugin-sdk/helper/schema	1.670s
```

Also, I'm open to a different name. `ContigentOn` seems like a viable option as well.