### PR TITLE
Make mockT.Fatal halt execution

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -558,7 +558,6 @@ func Test(t TestT, c TestCase) {
 	// We require verbose mode so that the user knows what is going on.
 	if !testTesting && !testing.Verbose() && !c.IsUnitTest {
 		t.Fatal("Acceptance tests must be run with the -v flag on tests")
-		return
 	}
 
 	// get instances of all providers, so we can use the individual

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -509,22 +509,22 @@ func TestTest_stepError(t *testing.T) {
 
 func TestTest_factoryError(t *testing.T) {
 	resourceFactoryError := fmt.Errorf("resource factory error")
-
 	factory := func() (terraform.ResourceProvider, error) {
 		return nil, resourceFactoryError
 	}
-
 	mt := new(mockT)
-	Test(mt, TestCase{
-		ProviderFactories: map[string]terraform.ResourceProviderFactory{
-			"test": factory,
-		},
-		Steps: []TestStep{
-			{
-				ExpectError: regexp.MustCompile("resource factory error"),
+
+	func() {
+		defer func() {
+			recover()
+		}()
+		Test(mt, TestCase{
+			ProviderFactories: map[string]terraform.ResourceProviderFactory{
+				"test": factory,
 			},
-		},
-	})
+			IsUnitTest: true,
+		})
+	}()
 
 	if !mt.failed() {
 		t.Fatal("test should've failed")
@@ -751,6 +751,8 @@ func (t *mockT) Fatal(args ...interface{}) {
 	t.FatalCalled = true
 	t.FatalArgs = args
 	t.f = true
+
+	panic("mockT.Fatal")
 }
 
 func (t *mockT) Parallel() {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -516,7 +516,11 @@ func TestTest_factoryError(t *testing.T) {
 
 	func() {
 		defer func() {
-			recover()
+			if r := recover(); r != nil {
+				if !strings.HasPrefix(r.(string), "mockT") {
+					panic(r)
+				}
+			}
 		}()
 		Test(mt, TestCase{
 			ProviderFactories: map[string]terraform.ResourceProviderFactory{


### PR DESCRIPTION
The current `mockT` did not halt execution on `Fatal`, this led to a test failure as the SDK code expects `t.Fatal` to halt execution. This introduces a panic and recover to fix the unit test. Future use of the mock (if there are any) should follow the same pattern