### PR TITLE
Unexpose testing pkg

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -574,7 +574,7 @@ func Test(t TestT, c TestCase) {
 		t.Fatal("Please configure the acctest binary driver")
 	}
 
-	RunNewTest(t.(*testing.T), c, providers)
+	RunNewTest(t, c, providers)
 }
 
 // testProviderConfig takes the list of Providers in a TestCase and returns a
@@ -983,10 +983,15 @@ func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
 // Users should just use a *testing.T object, which implements this.
 type TestT interface {
 	Error(args ...interface{})
+	FailNow()
 	Fatal(args ...interface{})
-	Skip(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+	Log(args ...interface{})
 	Name() string
 	Parallel()
+	Skip(args ...interface{})
+	SkipNow()
 }
 
 // modulePrimaryInstanceState returns the instance state for the given resource

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-	gotesting "testing"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/logutils"
@@ -538,7 +537,7 @@ func Test(t testing.T, c TestCase) {
 	log.SetOutput(logWriter)
 
 	// We require verbose mode so that the user knows what is going on.
-	if !gotesting.Verbose() && !c.IsUnitTest {
+	if !testing.Verbose() && !c.IsUnitTest {
 		t.Fatal("Acceptance tests must be run with the -v flag on tests")
 	}
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -12,13 +12,14 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-	"testing"
+	gotesting "testing"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/logutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/diagutils"
@@ -86,7 +87,7 @@ func AddTestSweepers(name string, s *Sweeper) {
 	sweeperFuncs[name] = s
 }
 
-func TestMain(m *testing.M) {
+func TestMain(m testing.M) {
 	flag.Parse()
 	if *flagSweep != "" {
 		// parse flagSweep contents for regions to run
@@ -458,7 +459,7 @@ type TestStep struct {
 // Set to a file mask in sprintf format where %s is test name
 const envLogPathMask = "TF_LOG_PATH_MASK"
 
-func logOutput(t TestT) (logOutput io.Writer, err error) {
+func logOutput(t testing.T) (logOutput io.Writer, err error) {
 	logOutput = ioutil.Discard
 
 	logLevel := logging.LogLevel()
@@ -504,7 +505,7 @@ func logOutput(t TestT) (logOutput io.Writer, err error) {
 // Tests will fail if they do not properly handle conditions to allow multiple
 // tests to occur against the same resource or service (e.g. random naming).
 // All other requirements of the Test function also apply to this function.
-func ParallelTest(t TestT, c TestCase) {
+func ParallelTest(t testing.T, c TestCase) {
 	t.Parallel()
 	Test(t, c)
 }
@@ -519,7 +520,7 @@ func ParallelTest(t TestT, c TestCase) {
 // the "-test.v" flag) is set. Because some acceptance tests take quite
 // long, we require the verbose flag so users are able to see progress
 // output.
-func Test(t TestT, c TestCase) {
+func Test(t testing.T, c TestCase) {
 	// We only run acceptance tests if an env var is set because they're
 	// slow and generally require some outside configuration. You can opt out
 	// of this with OverrideEnvVar on individual TestCases.
@@ -537,7 +538,7 @@ func Test(t TestT, c TestCase) {
 	log.SetOutput(logWriter)
 
 	// We require verbose mode so that the user knows what is going on.
-	if !testing.Verbose() && !c.IsUnitTest {
+	if !gotesting.Verbose() && !c.IsUnitTest {
 		t.Fatal("Acceptance tests must be run with the -v flag on tests")
 	}
 
@@ -592,7 +593,7 @@ func testProviderConfig(c TestCase) string {
 // UnitTest is a helper to force the acceptance testing harness to run in the
 // normal unit test suite. This should only be used for resource that don't
 // have any external dependencies.
-func UnitTest(t TestT, c TestCase) {
+func UnitTest(t testing.T, c TestCase) {
 	c.IsUnitTest = true
 	Test(t, c)
 }
@@ -976,22 +977,6 @@ func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
 
 		return nil
 	}
-}
-
-// TestT is the interface used to handle the test lifecycle of a test.
-//
-// Users should just use a *testing.T object, which implements this.
-type TestT interface {
-	Error(args ...interface{})
-	FailNow()
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Helper()
-	Log(args ...interface{})
-	Name() string
-	Parallel()
-	Skip(args ...interface{})
-	SkipNow()
 }
 
 // modulePrimaryInstanceState returns the instance state for the given resource

--- a/helper/resource/testing/testing.go
+++ b/helper/resource/testing/testing.go
@@ -3,6 +3,8 @@
 // importers of the SDK
 package testing
 
+import "testing"
+
 // T is the interface used to handle the test lifecycle of a test.
 //
 // Users should just use a *testing.T object, which implements this.
@@ -21,4 +23,11 @@ type T interface {
 
 type M interface {
 	Run() int
+}
+
+// Verbose just wraps the official testing package's helper of the same name.
+// This is the final reference to the testing package in non *_test.go files
+// in the SDK.
+func Verbose() bool {
+	return testing.Verbose()
 }

--- a/helper/resource/testing/testing.go
+++ b/helper/resource/testing/testing.go
@@ -1,0 +1,24 @@
+// Package testing aims to expose interfaces that mirror go's testing package
+// this prevents go's testing package from being imported or exposed to
+// importers of the SDK
+package testing
+
+// T is the interface used to handle the test lifecycle of a test.
+//
+// Users should just use a *testing.T object, which implements this.
+type T interface {
+	Error(args ...interface{})
+	FailNow()
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+	Log(args ...interface{})
+	Name() string
+	Parallel()
+	Skip(args ...interface{})
+	SkipNow()
+}
+
+type M interface {
+	Run() int
+}

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -11,11 +11,12 @@ import (
 	tftest "github.com/hashicorp/terraform-plugin-test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func runPostTestDestroy(t TestT, c TestCase, wd *tftest.WorkingDir) error {
+func runPostTestDestroy(t testing.T, c TestCase, wd *tftest.WorkingDir) error {
 	wd.RequireDestroy(t)
 
 	if c.CheckDestroy != nil {
@@ -29,7 +30,7 @@ func runPostTestDestroy(t TestT, c TestCase, wd *tftest.WorkingDir) error {
 	return nil
 }
 
-func RunNewTest(t TestT, c TestCase, providers map[string]*schema.Provider) {
+func RunNewTest(t testing.T, c TestCase, providers map[string]*schema.Provider) {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 	wd := acctest.TestHelper.RequireNewWorkingDir(t)
@@ -101,7 +102,7 @@ func RunNewTest(t TestT, c TestCase, providers map[string]*schema.Provider) {
 	}
 }
 
-func getState(t TestT, wd *tftest.WorkingDir) *terraform.State {
+func getState(t testing.T, wd *tftest.WorkingDir) *terraform.State {
 	jsonState := wd.RequireState(t)
 	state, err := shimStateFromJson(jsonState)
 	if err != nil {
@@ -131,7 +132,7 @@ func planIsEmpty(plan *tfjson.Plan) bool {
 	return true
 }
 
-func testIDRefresh(c TestCase, t TestT, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
+func testIDRefresh(c TestCase, t testing.T, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"reflect"
 	"strings"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -16,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func runPostTestDestroy(t *testing.T, c TestCase, wd *tftest.WorkingDir) error {
+func runPostTestDestroy(t TestT, c TestCase, wd *tftest.WorkingDir) error {
 	wd.RequireDestroy(t)
 
 	if c.CheckDestroy != nil {
@@ -30,7 +29,7 @@ func runPostTestDestroy(t *testing.T, c TestCase, wd *tftest.WorkingDir) error {
 	return nil
 }
 
-func RunNewTest(t *testing.T, c TestCase, providers map[string]*schema.Provider) {
+func RunNewTest(t TestT, c TestCase, providers map[string]*schema.Provider) {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 	wd := acctest.TestHelper.RequireNewWorkingDir(t)
@@ -102,7 +101,7 @@ func RunNewTest(t *testing.T, c TestCase, providers map[string]*schema.Provider)
 	}
 }
 
-func getState(t *testing.T, wd *tftest.WorkingDir) *terraform.State {
+func getState(t TestT, wd *tftest.WorkingDir) *terraform.State {
 	jsonState := wd.RequireState(t)
 	state, err := shimStateFromJson(jsonState)
 	if err != nil {
@@ -132,7 +131,7 @@ func planIsEmpty(plan *tfjson.Plan) bool {
 	return true
 }
 
-func testIDRefresh(c TestCase, t *testing.T, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
+func testIDRefresh(c TestCase, t TestT, wd *tftest.WorkingDir, step TestStep, r *terraform.ResourceState) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -1,15 +1,13 @@
 package resource
 
 import (
-	"testing"
-
 	"github.com/davecgh/go-spew/spew"
 	tftest "github.com/hashicorp/terraform-plugin-test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testStepNewConfig(t *testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+func testStepNewConfig(t TestT, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -4,10 +4,11 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	tftest "github.com/hashicorp/terraform-plugin-test"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testStepNewConfig(t TestT, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"reflect"
 	"strings"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	tftest "github.com/hashicorp/terraform-plugin-test"
@@ -14,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testStepNewImportState(t *testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep, cfg string) error {
+func testStepNewImportState(t TestT, c TestCase, wd *tftest.WorkingDir, step TestStep, cfg string) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -8,12 +8,13 @@ import (
 	tftest "github.com/hashicorp/terraform-plugin-test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testStepNewImportState(t TestT, c TestCase, wd *tftest.WorkingDir, step TestStep, cfg string) error {
+func testStepNewImportState(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep, cfg string) error {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -173,6 +173,10 @@ func (t *mockT) Error(args ...interface{}) {
 	t.f = true
 }
 
+func (t *mockT) FailNow() {
+	panic("mockT.FailNow")
+}
+
 func (t *mockT) Fatal(args ...interface{}) {
 	t.FatalCalled = true
 	t.FatalArgs = args
@@ -180,6 +184,14 @@ func (t *mockT) Fatal(args ...interface{}) {
 
 	panic("mockT.Fatal")
 }
+
+func (t *mockT) Fatalf(format string, args ...interface{}) {
+	t.Fatal(format, args)
+}
+
+func (t *mockT) Helper() {}
+
+func (t *mockT) Log(args ...interface{}) {}
 
 func (t *mockT) Parallel() {
 	t.ParallelCalled = true
@@ -189,6 +201,10 @@ func (t *mockT) Skip(args ...interface{}) {
 	t.SkipCalled = true
 	t.SkipArgs = args
 	t.f = true
+}
+
+func (t *mockT) SkipNow() {
+	t.Skip()
 }
 
 func (t *mockT) Name() string {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -174,6 +174,8 @@ func (t *mockT) Error(args ...interface{}) {
 }
 
 func (t *mockT) FailNow() {
+	t.f = true
+
 	panic("mockT.FailNow")
 }
 
@@ -186,7 +188,7 @@ func (t *mockT) Fatal(args ...interface{}) {
 }
 
 func (t *mockT) Fatalf(format string, args ...interface{}) {
-	t.Fatal(format, args)
+	t.Fatal(fmt.Sprintf(format, args...))
 }
 
 func (t *mockT) Helper() {}

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -2,14 +2,14 @@ package schema
 
 import (
 	"context"
-	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // TestResourceDataRaw creates a ResourceData from a raw configuration map.
 func TestResourceDataRaw(
-	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	t testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
 	t.Helper()
 
 	c := terraform.NewResourceConfigRaw(raw)

--- a/helper/validation/testing.go
+++ b/helper/validation/testing.go
@@ -2,8 +2,8 @@ package validation
 
 import (
 	"regexp"
-	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource/testing"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -13,7 +13,7 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
-func runTestCases(t *testing.T, cases []testCase) {
+func runTestCases(t testing.T, cases []testCase) {
 	matchErr := func(errs []error, r *regexp.Regexp) bool {
 		// err must match one provided
 		for _, err := range errs {


### PR DESCRIPTION
This PR scrubs the SDK surface of uses of Go's `testing` package, `testing.T` and `testing.M` were exposed to the SDK surface as an oversight in V1. It instead propagates the interface previously known as `resource.TestT` with a few added signatures so it can be compatible with a testing interface present in `terraform-plugin-test` (the driver library for acceptance tests). The interface had to be moved to its own package (now `helper/resource/testing`) to avoid circular imports.

Ideally we could remove any imports of Go's`testing` in non `_test.go` files from the SDK. However the acceptance test framework checks if `go test` was called with verbose enabled. This reference could not be removed unless we remove that requirement.