### PR TITLE
v2: allow releases from v1-maint branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,12 +91,16 @@ workflows:
       - trigger-release:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - v1-maint
           type: approval
       - "docker-go114 release":
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - v1-maint
           requires:
             - trigger-release
             - "docker-go114 test"

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 set -e
+set -x
 
-# Prepare will prepare the repository for release
+# release.sh will:
 # 1. Modify changelog
 # 2. Run changelog links script
-# 3. Commit changes
-# 4. Create a Git tag
+# 3. Modify version in meta/meta.go
+# 4. Commit and push changes
+# 5. Create a Git tag
 
 function pleaseUseGNUsed {
     echo "Please install GNU sed to your PATH as 'sed'."
@@ -72,7 +74,7 @@ function commitChanges {
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"
   fi
 
-  git push origin master
+  git push origin "${CIRCLE_BRANCH}"
   git push origin "v${TARGET_VERSION}"
 }
 


### PR DESCRIPTION
After `master` is switched to v2, we need to be able to release from both the v2 branch and the v1 branch (`v1-maint`).

 This PR updates the CircleCI config so that v1 releases can be triggered from `v1-maint` just as they are triggered from `master`. 

Please note that the version tagged and released is always parsed from the `(Unreleased)` line in the CHANGELOG. The v1 maintenance branch should have an up-to-date 1.x CHANGELOG that does not include any v2 versions. The internal release documentation has been updated to note this.