### PR TITLE
Port provider_meta functionality from core.

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -52,6 +52,14 @@ type Provider struct {
 	// and must *not* implement Create, Update or Delete.
 	DataSourcesMap map[string]*Resource
 
+	// ProviderMetaSchema is the schema for the configuration of the meta
+	// information for this provider. If this provider has no meta info,
+	// this can be omitted. This functionality is currently experimental
+	// and subject to change or break without warning; it should only be
+	// used by providers that are collaborating on its use with the
+	// Terraform team.
+	ProviderMetaSchema map[string]*Schema
+
 	// ConfigureFunc is a function for configuring the provider. If the
 	// provider doesn't need to be configured, this can be omitted.
 	//

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -330,6 +330,10 @@ func (r *Resource) Apply(
 		return s, append(diags, diag.FromErr(err))
 	}
 
+	if s != nil && data != nil {
+		data.providerMeta = s.ProviderMeta
+	}
+
 	// Instance Diff shoould have the timeout info, need to copy it over to the
 	// ResourceData meta
 	rt := ResourceTimeout{}
@@ -537,6 +541,10 @@ func (r *Resource) RefreshWithoutUpgrade(
 		}
 		data.timeouts = &rt
 
+		if s != nil {
+			data.providerMeta = s.ProviderMeta
+		}
+
 		exists, err := r.Exists(data, meta)
 		if err != nil {
 			return s, append(diags, diag.FromErr(err))
@@ -552,6 +560,10 @@ func (r *Resource) RefreshWithoutUpgrade(
 		return s, append(diags, diag.FromErr(err))
 	}
 	data.timeouts = &rt
+
+	if s != nil {
+		data.providerMeta = s.ProviderMeta
+	}
 
 	diags = append(diags, r.read(ctx, data, meta)...)
 

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-cty/cty/gocty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -19,12 +21,13 @@ import (
 // The most relevant methods to take a look at are Get and Set.
 type ResourceData struct {
 	// Settable (internally)
-	schema   map[string]*Schema
-	config   *terraform.ResourceConfig
-	state    *terraform.InstanceState
-	diff     *terraform.InstanceDiff
-	meta     map[string]interface{}
-	timeouts *ResourceTimeout
+	schema       map[string]*Schema
+	config       *terraform.ResourceConfig
+	state        *terraform.InstanceState
+	diff         *terraform.InstanceDiff
+	meta         map[string]interface{}
+	timeouts     *ResourceTimeout
+	providerMeta cty.Value
 
 	// Don't set
 	multiReader *MultiLevelFieldReader
@@ -505,4 +508,11 @@ func (d *ResourceData) get(addr []string, source getSource) getResult {
 		Exists:         result.Exists,
 		Schema:         schema,
 	}
+}
+
+func (d *ResourceData) GetProviderMeta(dst interface{}) error {
+	if d.providerMeta.IsNull() {
+		return nil
+	}
+	return gocty.FromCtyValue(d.providerMeta, &dst)
 }

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1356,6 +1356,8 @@ type InstanceState struct {
 	// and collections.
 	Meta map[string]interface{} `json:"meta"`
 
+	ProviderMeta cty.Value
+
 	// Tainted is used to mark a resource for recreation.
 	Tainted bool `json:"tainted"`
 


### PR DESCRIPTION
Port the functionality added in hashicorp/terraform#22583 that allows
providers to receive arbitrary, provider-definable module-scoped
information from configs.