### PR TITLE
TypeSet Check Heuristic

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1439,18 +1439,20 @@ func indexesIntoTypeSet(key string) bool {
 
 func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
-		if s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
-			return fmt.Errorf("Test check address %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", key)
+		err := f(s)
+		if err != nil && s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
+			return fmt.Errorf("Error in test check: %s\nTest check address %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", err, key)
 		}
-		return f(s)
+		return err
 	}
 }
 
 func checkIfIndexesIntoTypeSetPair(keyFirst, keySecond string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
-		if s.IsBinaryDrivenTest && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
-			return fmt.Errorf("Test check address %q or %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", keyFirst, keySecond)
+		err := f(s)
+		if err != nil && s.IsBinaryDrivenTest && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
+			return fmt.Errorf("Error in test check: %s\nTest check address %q or %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", err, keyFirst, keySecond)
 		}
-		return f(s)
+		return err
 	}
 }

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -1020,28 +1021,28 @@ func ComposeAggregateTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 // testing that computed values were set, when it is not possible to
 // know ahead of time what the values will be.
 func TestCheckResourceAttrSet(name, key string) TestCheckFunc {
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckResourceAttrSet(is, name, key)
-	}
+	})
 }
 
 // TestCheckModuleResourceAttrSet - as per TestCheckResourceAttrSet but with
 // support for non-root modules
 func TestCheckModuleResourceAttrSet(mp []string, name string, key string) TestCheckFunc {
 	mpt := addrs.Module(mp).UnkeyedInstanceShim()
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := modulePathPrimaryInstanceState(s, mpt, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckResourceAttrSet(is, name, key)
-	}
+	})
 }
 
 func testCheckResourceAttrSet(is *terraform.InstanceState, name string, key string) error {
@@ -1055,28 +1056,28 @@ func testCheckResourceAttrSet(is *terraform.InstanceState, name string, key stri
 // TestCheckResourceAttr is a TestCheckFunc which validates
 // the value in state for the given name/key combination.
 func TestCheckResourceAttr(name, key, value string) TestCheckFunc {
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckResourceAttr(is, name, key, value)
-	}
+	})
 }
 
 // TestCheckModuleResourceAttr - as per TestCheckResourceAttr but with
 // support for non-root modules
 func TestCheckModuleResourceAttr(mp []string, name string, key string, value string) TestCheckFunc {
 	mpt := addrs.Module(mp).UnkeyedInstanceShim()
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := modulePathPrimaryInstanceState(s, mpt, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckResourceAttr(is, name, key, value)
-	}
+	})
 }
 
 func testCheckResourceAttr(is *terraform.InstanceState, name string, key string, value string) error {
@@ -1110,28 +1111,28 @@ func testCheckResourceAttr(is *terraform.InstanceState, name string, key string,
 // TestCheckNoResourceAttr is a TestCheckFunc which ensures that
 // NO value exists in state for the given name/key combination.
 func TestCheckNoResourceAttr(name, key string) TestCheckFunc {
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckNoResourceAttr(is, name, key)
-	}
+	})
 }
 
 // TestCheckModuleNoResourceAttr - as per TestCheckNoResourceAttr but with
 // support for non-root modules
 func TestCheckModuleNoResourceAttr(mp []string, name string, key string) TestCheckFunc {
 	mpt := addrs.Module(mp).UnkeyedInstanceShim()
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := modulePathPrimaryInstanceState(s, mpt, name)
 		if err != nil {
 			return err
 		}
 
 		return testCheckNoResourceAttr(is, name, key)
-	}
+	})
 }
 
 func testCheckNoResourceAttr(is *terraform.InstanceState, name string, key string) error {
@@ -1158,28 +1159,28 @@ func testCheckNoResourceAttr(is *terraform.InstanceState, name string, key strin
 // TestMatchResourceAttr is a TestCheckFunc which checks that the value
 // in state for the given name/key combination matches the given regex.
 func TestMatchResourceAttr(name, key string, r *regexp.Regexp) TestCheckFunc {
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
 		if err != nil {
 			return err
 		}
 
 		return testMatchResourceAttr(is, name, key, r)
-	}
+	})
 }
 
 // TestModuleMatchResourceAttr - as per TestMatchResourceAttr but with
 // support for non-root modules
 func TestModuleMatchResourceAttr(mp []string, name string, key string, r *regexp.Regexp) TestCheckFunc {
 	mpt := addrs.Module(mp).UnkeyedInstanceShim()
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
 		is, err := modulePathPrimaryInstanceState(s, mpt, name)
 		if err != nil {
 			return err
 		}
 
 		return testMatchResourceAttr(is, name, key, r)
-	}
+	})
 }
 
 func testMatchResourceAttr(is *terraform.InstanceState, name string, key string, r *regexp.Regexp) error {
@@ -1215,7 +1216,7 @@ func TestCheckModuleResourceAttrPtr(mp []string, name string, key string, value 
 // TestCheckResourceAttrPair is a TestCheckFunc which validates that the values
 // in state for a pair of name/key combinations are equal.
 func TestCheckResourceAttrPair(nameFirst, keyFirst, nameSecond, keySecond string) TestCheckFunc {
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSetPair(keyFirst, keySecond, func(s *terraform.State) error {
 		isFirst, err := primaryInstanceState(s, nameFirst)
 		if err != nil {
 			return err
@@ -1227,7 +1228,7 @@ func TestCheckResourceAttrPair(nameFirst, keyFirst, nameSecond, keySecond string
 		}
 
 		return testCheckResourceAttrPair(isFirst, nameFirst, keyFirst, isSecond, nameSecond, keySecond)
-	}
+	})
 }
 
 // TestCheckModuleResourceAttrPair - as per TestCheckResourceAttrPair but with
@@ -1235,7 +1236,7 @@ func TestCheckResourceAttrPair(nameFirst, keyFirst, nameSecond, keySecond string
 func TestCheckModuleResourceAttrPair(mpFirst []string, nameFirst string, keyFirst string, mpSecond []string, nameSecond string, keySecond string) TestCheckFunc {
 	mptFirst := addrs.Module(mpFirst).UnkeyedInstanceShim()
 	mptSecond := addrs.Module(mpSecond).UnkeyedInstanceShim()
-	return func(s *terraform.State) error {
+	return checkIfIndexesIntoTypeSetPair(keyFirst, keySecond, func(s *terraform.State) error {
 		isFirst, err := modulePathPrimaryInstanceState(s, mptFirst, nameFirst)
 		if err != nil {
 			return err
@@ -1247,7 +1248,7 @@ func TestCheckModuleResourceAttrPair(mpFirst []string, nameFirst string, keyFirs
 		}
 
 		return testCheckResourceAttrPair(isFirst, nameFirst, keyFirst, isSecond, nameSecond, keySecond)
-	}
+	})
 }
 
 func testCheckResourceAttrPair(isFirst *terraform.InstanceState, nameFirst string, keyFirst string, isSecond *terraform.InstanceState, nameSecond string, keySecond string) error {
@@ -1421,5 +1422,38 @@ func detailedErrorMessage(err error) string {
 		return tErr.ErrorDetail()
 	default:
 		return err.Error()
+	}
+}
+
+// indexesIntoTypeSet is a heuristic to try and identify if a flatmap style
+// string address uses a precalculated TypeSet hash, which are always 10 digits
+// long and are a number
+func indexesIntoTypeSet(key string) bool {
+	for _, part := range strings.Split(key, ".") {
+		if len(part) == 10 {
+			if _, err := strconv.Atoi(part); err == nil {
+				log.Printf("[WARN] Check likely indexes into TypeSet: '%s'\nThis is not possible in V1 of the SDK while using the binary driver, this check will be skipped.\nPlease disable the driver for this TestCase with DisableBinaryDriver: true.", key)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
+	return func(s *terraform.State) error {
+		if s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
+			return nil
+		}
+		return f(s)
+	}
+}
+
+func checkIfIndexesIntoTypeSetPair(keyFirst, keySecond string, f TestCheckFunc) TestCheckFunc {
+	return func(s *terraform.State) error {
+		if s.IsBinaryDrivenTest && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
+			return nil
+		}
+		return f(s)
 	}
 }

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1426,15 +1426,12 @@ func detailedErrorMessage(err error) string {
 }
 
 // indexesIntoTypeSet is a heuristic to try and identify if a flatmap style
-// string address uses a precalculated TypeSet hash, which are always 10 digits
-// long and are a number
+// string address uses a precalculated TypeSet hash, which are integers and
+// typically are large and obviously not a list index
 func indexesIntoTypeSet(key string) bool {
 	for _, part := range strings.Split(key, ".") {
-		if len(part) == 10 {
-			if _, err := strconv.Atoi(part); err == nil {
-				log.Printf("[WARN] Check likely indexes into TypeSet: '%s'\nThis is not possible in V1 of the SDK while using the binary driver, this check will be skipped.\nPlease disable the driver for this TestCase with DisableBinaryDriver: true.", key)
-				return true
-			}
+		if i, err := strconv.Atoi(part); err == nil && i > 100 {
+			return true
 		}
 	}
 	return false
@@ -1443,7 +1440,7 @@ func indexesIntoTypeSet(key string) bool {
 func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
 		if s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
-			return nil
+			return fmt.Errorf("Test check address %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", key)
 		}
 		return f(s)
 	}
@@ -1452,7 +1449,7 @@ func checkIfIndexesIntoTypeSet(key string, f TestCheckFunc) TestCheckFunc {
 func checkIfIndexesIntoTypeSetPair(keyFirst, keySecond string, f TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
 		if s.IsBinaryDrivenTest && (indexesIntoTypeSet(keyFirst) || indexesIntoTypeSet(keySecond)) {
-			return nil
+			return fmt.Errorf("Test check address %q or %q likely indexes into TypeSet\nThis is not possible in V1 of the SDK while using the binary driver\nPlease disable the driver for this TestCase with DisableBinaryDriver: true", keyFirst, keySecond)
 		}
 		return f(s)
 	}

--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -32,6 +32,7 @@ func testStepNewConfig(t *testing.T, c TestCase, wd *tftest.WorkingDir, step Tes
 
 		state := getState(t, wd)
 		if step.Check != nil {
+			state.IsBinaryDrivenTest = true
 			if err := step.Check(state); err != nil {
 				t.Fatal(err)
 			}

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -112,6 +112,10 @@ type State struct {
 	Modules []*ModuleState `json:"modules"`
 
 	mu sync.Mutex
+
+	// IsBinaryDrivenTest is a special flag that assists with a binary driver
+	// heuristic, it should not be set externally
+	IsBinaryDrivenTest bool
 }
 
 func (s *State) Lock()   { s.mu.Lock() }


### PR DESCRIPTION
This change can assist users when enabling the binary driver. Previously any checks that addressed through TypeSet hashes would error confusingly (just claim the resource does not exist) as the binary driver's shimmed state did not represent TypeSet addresses.

A small hack/flag needed to be added onto `terraform.State`, but the docs clearly state it's not for external use.