### PR TITLE
privatize RunNewTest

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -573,7 +573,7 @@ func Test(t testing.T, c TestCase) {
 		t.Fatal("Please configure the acctest binary driver")
 	}
 
-	RunNewTest(t, c, providers)
+	runNewTest(t, c, providers)
 }
 
 // testProviderConfig takes the list of Providers in a TestCase and returns a

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -30,7 +30,7 @@ func runPostTestDestroy(t testing.T, c TestCase, wd *tftest.WorkingDir) error {
 	return nil
 }
 
-func RunNewTest(t testing.T, c TestCase, providers map[string]*schema.Provider) {
+func runNewTest(t testing.T, c TestCase, providers map[string]*schema.Provider) {
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 	wd := acctest.TestHelper.RequireNewWorkingDir(t)


### PR DESCRIPTION
This was a minor oversight in V1, no reason for this to be public at this time.