### PR TITLE
helper/schema: Mark Schema.Removed, SchemasForFlatmapPath(), and (Resource).SchemasForFlatmapPath() as Deprecated [v1]

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -44,6 +44,8 @@ func (r *FieldReadResult) ValueOrZero(s *Schema) interface{} {
 
 // SchemasForFlatmapPath tries its best to find a sequence of schemas that
 // the given dot-delimited attribute path traverses through.
+//
+// Deprecated: This function will be removed in version 2 without replacement.
 func SchemasForFlatmapPath(path string, schemaMap map[string]*Schema) []*Schema {
 	parts := strings.Split(path, ".")
 	return addrToSchema(parts, schemaMap)

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -770,6 +770,8 @@ func (r *Resource) TestResourceData() *ResourceData {
 // SchemasForFlatmapPath tries its best to find a sequence of schemas that
 // the given dot-delimited attribute path traverses through in the schema
 // of the receiving Resource.
+//
+// Deprecated: This function will be removed in version 2 without replacement.
 func (r *Resource) SchemasForFlatmapPath(path string) []*Schema {
 	return SchemasForFlatmapPath(path, r.Schema)
 }

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -239,6 +239,9 @@ type Schema struct {
 
 	// When Removed is set, this attribute has been removed from the schema
 	//
+	// Deprecated: This field will be removed in version 2 without replacement
+	// as the functionality is not necessary.
+	//
 	// Removed attributes can be left in the Schema to generate informative error
 	// messages for the user when they show up in resource configurations.
 	// This string is the message shown to the user with instructions on


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/414
Reference: https://github.com/golang/go/wiki/Deprecated

The `Removed` field and associated handling has been removed in version 2.