### PR TITLE
helper/schema: InternalValidate fix for configuration block type checking

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -894,7 +894,7 @@ func checkKeysAgainstSchemaFlags(k string, keys []string, topSchemaMap schemaMap
 		parts := strings.Split(key, ".")
 		sm := topSchemaMap
 		var target *Schema
-		for _, part := range parts {
+		for idx, part := range parts {
 			// Skip index fields if 0
 			partInt, err := strconv.Atoi(part)
 
@@ -917,7 +917,8 @@ func checkKeysAgainstSchemaFlags(k string, keys []string, topSchemaMap schemaMap
 				continue
 			}
 
-			if target.Type == TypeSet || target.MaxItems != 1 {
+			// Skip Type/MaxItems check if not the last element
+			if (target.Type == TypeSet || target.MaxItems != 1) && idx+1 != len(parts) {
 				return fmt.Errorf("%s configuration block reference (%s) can only be used with TypeList and MaxItems: 1 configuration blocks", k, key)
 			}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3546,6 +3546,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"AtLeastOneOf string syntax with list attribute": {
+			map[string]*Schema{
+				"list_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					AtLeastOneOf: []string{"list_attr"},
+				},
+			},
+			false,
+		},
+
+		"AtLeastOneOf string syntax with list configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					AtLeastOneOf: []string{"config_block_attr"},
+				},
+			},
+			false,
+		},
+
 		"AtLeastOneOf string syntax with map attribute": {
 			map[string]*Schema{
 				"map_attr": {
@@ -3557,6 +3596,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 					Type:         TypeBool,
 					Optional:     true,
 					AtLeastOneOf: []string{"map_attr"},
+				},
+			},
+			false,
+		},
+
+		"AtLeastOneOf string syntax with set attribute": {
+			map[string]*Schema{
+				"set_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					AtLeastOneOf: []string{"set_attr"},
+				},
+			},
+			false,
+		},
+
+		"AtLeastOneOf string syntax with set configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					AtLeastOneOf: []string{"config_block_attr"},
 				},
 			},
 			false,
@@ -3808,6 +3886,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"ConflictsWith string syntax with list attribute": {
+			map[string]*Schema{
+				"list_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"list_attr"},
+				},
+			},
+			false,
+		},
+
+		"ConflictsWith string syntax with list configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"config_block_attr"},
+				},
+			},
+			false,
+		},
+
 		"ConflictsWith string syntax with map attribute": {
 			map[string]*Schema{
 				"map_attr": {
@@ -3819,6 +3936,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 					Type:          TypeBool,
 					Optional:      true,
 					ConflictsWith: []string{"map_attr"},
+				},
+			},
+			false,
+		},
+
+		"ConflictsWith string syntax with set attribute": {
+			map[string]*Schema{
+				"set_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"set_attr"},
+				},
+			},
+			false,
+		},
+
+		"ConflictsWith string syntax with set configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:          TypeBool,
+					Optional:      true,
+					ConflictsWith: []string{"config_block_attr"},
 				},
 			},
 			false,
@@ -4071,6 +4227,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"ExactlyOneOf string syntax with list attribute": {
+			map[string]*Schema{
+				"list_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					ExactlyOneOf: []string{"list_attr"},
+				},
+			},
+			false,
+		},
+
+		"ExactlyOneOf string syntax with list configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					ExactlyOneOf: []string{"config_block_attr"},
+				},
+			},
+			false,
+		},
+
 		"ExactlyOneOf string syntax with map attribute": {
 			map[string]*Schema{
 				"map_attr": {
@@ -4082,6 +4277,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 					Type:         TypeBool,
 					Optional:     true,
 					ExactlyOneOf: []string{"map_attr"},
+				},
+			},
+			false,
+		},
+
+		"ExactlyOneOf string syntax with set attribute": {
+			map[string]*Schema{
+				"set_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					ExactlyOneOf: []string{"set_attr"},
+				},
+			},
+			false,
+		},
+
+		"ExactlyOneOf string syntax with set configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					ExactlyOneOf: []string{"config_block_attr"},
 				},
 			},
 			false,
@@ -4334,6 +4568,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"RequiredWith string syntax with list attribute": {
+			map[string]*Schema{
+				"list_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"list_attr"},
+				},
+			},
+			false,
+		},
+
+		"RequiredWith string syntax with list configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"config_block_attr"},
+				},
+			},
+			false,
+		},
+
 		"RequiredWith string syntax with map attribute": {
 			map[string]*Schema{
 				"map_attr": {
@@ -4345,6 +4618,45 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 					Type:         TypeBool,
 					Optional:     true,
 					RequiredWith: []string{"map_attr"},
+				},
+			},
+			false,
+		},
+
+		"RequiredWith string syntax with set attribute": {
+			map[string]*Schema{
+				"set_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"set_attr"},
+				},
+			},
+			false,
+		},
+
+		"RequiredWith string syntax with set configuration block": {
+			map[string]*Schema{
+				"config_block_attr": {
+					Type:     TypeSet,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"nested_attr": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"test": {
+					Type:         TypeBool,
+					Optional:     true,
+					RequiredWith: []string{"config_block_attr"},
 				},
 			},
 			false,


### PR DESCRIPTION
The validation for `AtLeastOneOf`, `ConflictsWith`, `ExactlyOneOf`, and `RequiredWith` should not flag configuration block attributes without `Type: TypeList` and `MaxItems: 1` if they are the last part of the reference.

Previously:

```
    --- FAIL: TestSchemaMap_InternalValidate/RequiredWith_string_syntax_with_list_configuration_block (0.00s)
        schema_test.go:5037: "RequiredWith string syntax with list configuration block": Unexpected error occurred: RequiredWith: test configuration block reference (config_block_attr) can only be used with TypeList and MaxItems: 1 configuration blocks
    --- FAIL: TestSchemaMap_InternalValidate/AtLeastOneOf_string_syntax_with_set_configuration_block (0.00s)
        schema_test.go:5037: "AtLeastOneOf string syntax with set configuration block": Unexpected error occurred: AtLeastOneOf: test configuration block reference (config_block_attr) can only be used with TypeList and MaxItems: 1 configuration blocks
...
```