### PR TITLE
Port acctest docs from V1

### DIFF
--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -1,5 +1,3 @@
-package acctest
-
 // Package acctest provides the ability to opt in to the new binary test driver. The binary
 // test driver allows you to run your acceptance tests with a binary of Terraform instead of
 // an emulated version packaged inside the SDK. This allows for a number of important
@@ -19,6 +17,7 @@ package acctest
 //     acctest.UseBinaryDriver("provider_name", Provider)
 //     resource.TestMain(m)
 //   }
+//
 // Where `Provider` is the function that returns the instance of a configured `terraform.ResourceProvider`
 // Some providers already have a TestMain defined, usually for the purpose of enabling test
 // sweepers. These additional occurrences should be removed.
@@ -29,3 +28,4 @@ package acctest
 //
 // It is no longer necessary to import other Terraform providers as Go modules: these
 // imports should be removed.
+package acctest

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -1,0 +1,31 @@
+package acctest
+
+// Package acctest provides the ability to opt-in to the new binary test driver. The binary
+// test driver allows you to run your acceptance tests with a binary of Terraform instead of
+// a source code version included with the testing code. This allows for a number of important
+// enhancements, but most notably a more realistic testing experience and matrix testing
+// against multiple versions of Terraform CLI. This also allows the SDK to be completely
+// separated, at a dependency level, from the Terraform CLI.
+//
+// The new test driver must be enabled by initialising the test helper in your TestMain
+// function in all provider packages that run acceptance tests. Most providers have only
+// one package.
+//
+// In v2 of the SDK, the binary test driver will be mandatory.
+//
+// After importing this package, you can add code similar to the following:
+//
+//   func TestMain(m *testing.M) {
+//     acctest.UseBinaryDriver("provider_name", Provider)
+//     resource.TestMain(m)
+//   }
+//
+// Some providers already have a TestMain defined, usually for the purpose of enabling test
+// sweepers. These additional occurrences should be removed.
+//
+// Initialising the binary test helper using UseBinaryDriver causes all tests to be run using
+// the new binary driver. Until SDK v2, the DisableBinaryDriver boolean property can be used
+// to use the legacy test driver for an individual TestCase.
+//
+// It is no longer necessary to import other Terraform providers as Go modules: these
+// imports should be removed.

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -2,7 +2,7 @@ package acctest
 
 // Package acctest provides the ability to opt-in to the new binary test driver. The binary
 // test driver allows you to run your acceptance tests with a binary of Terraform instead of
-// a source code version included with the testing code. This allows for a number of important
+// an emulated version packaged inside the SDK. This allows for a number of important
 // enhancements, but most notably a more realistic testing experience and matrix testing
 // against multiple versions of Terraform CLI. This also allows the SDK to be completely
 // separated, at a dependency level, from the Terraform CLI.

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -5,7 +5,7 @@ package acctest
 // an emulated version packaged inside the SDK. This allows for a number of important
 // enhancements, but most notably a more realistic testing experience and matrix testing
 // against multiple versions of Terraform CLI. This also allows the SDK to be completely
-// separated, at a dependency level, from the Terraform CLI.
+// separated, at a dependency level, from the Terraform CLI, as long as it is >= 0.12.0
 //
 // The new test driver must be enabled by initialising the test helper in your TestMain
 // function in all provider packages that run acceptance tests. Most providers have only

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -1,30 +1,23 @@
-// Package acctest provides the ability to opt in to the new binary test driver. The binary
-// test driver allows you to run your acceptance tests with a binary of Terraform instead of
-// an emulated version packaged inside the SDK. This allows for a number of important
-// enhancements, but most notably a more realistic testing experience and matrix testing
-// against multiple versions of Terraform CLI. This also allows the SDK to be completely
-// separated, at a dependency level, from the Terraform CLI, as long as it is >= 0.12.0
+// Package acctest provides the ability to use the binary test driver. The binary
+// test driver allows you to run your acceptance tests with a binary of Terraform.
+// This is currently the only mechanism for driving tests. It provides a realistic testing
+// experience and matrix testing against multiple versions of Terraform CLI,
+// as long as they are >= 0.12.0
 //
-// The new test driver must be enabled by initialising the test helper in your TestMain
+// The driver must be enabled by initialising the test helper in your TestMain
 // function in all provider packages that run acceptance tests. Most providers have only
 // one package.
 //
-// In v2 of the SDK, the binary test driver will be mandatory.
-//
-// After importing this package, you can add code similar to the following:
+// After importing this package, you must define a TestMain and have the following:
 //
 //   func TestMain(m *testing.M) {
 //     acctest.UseBinaryDriver("provider_name", Provider)
 //     resource.TestMain(m)
 //   }
 //
-// Where `Provider` is the function that returns the instance of a configured `terraform.ResourceProvider`
+// Where `Provider` is the function that returns the instance of a configured `*schema.Provider`
 // Some providers already have a TestMain defined, usually for the purpose of enabling test
 // sweepers. These additional occurrences should be removed.
-//
-// Initialising the binary test helper using UseBinaryDriver causes all tests to be run using
-// the new binary driver. Until SDK v2, the DisableBinaryDriver boolean property can be used
-// to use the legacy test driver for an individual TestCase.
 //
 // It is no longer necessary to import other Terraform providers as Go modules: these
 // imports should be removed.

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -19,7 +19,7 @@ package acctest
 //     acctest.UseBinaryDriver("provider_name", Provider)
 //     resource.TestMain(m)
 //   }
-//
+// Where `Provider` is the function that returns the instance of a configured `terraform.ResourceProvider`
 // Some providers already have a TestMain defined, usually for the purpose of enabling test
 // sweepers. These additional occurrences should be removed.
 //

--- a/acctest/doc.go
+++ b/acctest/doc.go
@@ -1,6 +1,6 @@
 package acctest
 
-// Package acctest provides the ability to opt-in to the new binary test driver. The binary
+// Package acctest provides the ability to opt in to the new binary test driver. The binary
 // test driver allows you to run your acceptance tests with a binary of Terraform instead of
 // an emulated version packaged inside the SDK. This allows for a number of important
 // enhancements, but most notably a more realistic testing experience and matrix testing


### PR DESCRIPTION
Updated wording reflecting the mandatory nature of the binary driver in V2.