### PR TITLE
Fix regex in release.sh to accept prereleases.

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -34,7 +34,7 @@ function init {
 
 function getTargetVersion {
   # parse target version from CHANGELOG
-  sed -n 's/^# \([0-9]\+\.[0-9]\+\.[0-9]\+\) (Unreleased)$/\1/p' CHANGELOG.md || \
+  sed -n 's/^# \([0-9]\+\.[0-9]\+\.[0-9]\+\(-[0-9a-zA-Z.]\+\)\?\) (Unreleased)$/\1/p' CHANGELOG.md || \
      (echo "\nTarget version not found in changelog, exiting" && \
        exit 1)
 }


### PR DESCRIPTION
Our regexp used to only accept [0-9].[0-9].[0-9] release numbers. This
change updates the regexp to allow an optional -[0-9a-zA-Z.] suffix to
the release, for prereleases.