### PR TITLE
Remove TF_SCHEMA_PANIC_ON_ERR

### DIFF
--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -18,11 +18,6 @@ import (
 )
 
 func init() {
-	// TODO: Remove when we remove the guard on id checks
-	if err := os.Setenv("TF_ACC_IDONLY", "1"); err != nil {
-		panic(err)
-	}
-
 	if err := os.Setenv(testEnvVar, "1"); err != nil {
 		panic(err)
 	}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -167,8 +167,12 @@ func (d *ResourceData) Set(key string, value interface{}) error {
 	}
 
 	err := d.setWriter.WriteField(strings.Split(key, "."), value)
-	if err != nil && d.panicOnError {
-		panic(err)
+	if err != nil {
+		if d.panicOnError {
+			panic(err)
+		} else {
+			log.Printf("[ERROR] setting state: %s", err)
+		}
 	}
 	return err
 }

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"fmt"
 	"math"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -2230,10 +2229,6 @@ func TestResourceDataSet(t *testing.T) {
 			},
 		},
 	}
-
-	oldEnv := os.Getenv(PanicOnErr)
-	os.Setenv(PanicOnErr, "false")
-	defer os.Setenv(PanicOnErr, oldEnv)
 
 	for i, tc := range cases {
 		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -31,9 +31,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// Name of ENV variable which (if not empty) prefers panic over error
-const PanicOnErr = "TF_SCHEMA_PANIC_ON_ERROR"
-
 // Schema is used to describe the structure of a value.
 //
 // Read the documentation of the struct elements for important details.
@@ -471,18 +468,7 @@ type InternalMap = schemaMap
 type schemaMap map[string]*Schema
 
 func (m schemaMap) panicOnError() bool {
-	if env := os.Getenv(PanicOnErr); env == "" {
-		// default to true
-		return true
-	} else if b, err := strconv.ParseBool(env); err == nil {
-		// allow opt out
-		return b
-	} else {
-		// default to true for anything set, this is backwards compatible
-		// with the previous implementation
-		log.Printf("[WARN] %s=%s not parsable: %s, defaulting to true", PanicOnErr, env, err)
-		return true
-	}
+	return os.Getenv("TF_ACC") != ""
 }
 
 // Data returns a ResourceData for the given schema, state, and diff.

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -8209,48 +8209,26 @@ func TestValidateAtLeastOneOfAttributes(t *testing.T) {
 	}
 }
 
-func Test_panicOnErrDefaultTrue(t *testing.T) {
-	oldEnv := os.Getenv(PanicOnErr)
+func TestPanicOnErrorDefaultsFalse(t *testing.T) {
+	oldEnv := os.Getenv("TF_ACC")
 
-	os.Setenv(PanicOnErr, "")
-	if !schemaMap(nil).panicOnError() {
-		t.Fatalf("Empty %s should default to true", PanicOnErr)
-	}
-
-	os.Setenv(PanicOnErr, oldEnv)
-}
-
-func Test_panicOnErrParsableTrue(t *testing.T) {
-	oldEnv := os.Getenv(PanicOnErr)
-
-	os.Setenv(PanicOnErr, "true")
-	if !schemaMap(nil).panicOnError() {
-		t.Fatalf("Parsable truthy %s should return true", PanicOnErr)
-	}
-
-	os.Setenv(PanicOnErr, oldEnv)
-}
-
-func Test_panicOnErrParsableFalse(t *testing.T) {
-	oldEnv := os.Getenv(PanicOnErr)
-
-	os.Setenv(PanicOnErr, "false")
+	os.Setenv("TF_ACC", "")
 	if schemaMap(nil).panicOnError() {
-		t.Fatalf("Parsable falsy %s should return false", PanicOnErr)
+		t.Fatalf("panicOnError should be false when TF_ACC is empty")
 	}
 
-	os.Setenv(PanicOnErr, oldEnv)
+	os.Setenv("TF_ACC", oldEnv)
 }
 
-func Test_panicOnErrUnparsableDefaultTrue(t *testing.T) {
-	oldEnv := os.Getenv(PanicOnErr)
+func TestPanicOnErrorTF_ACCSet(t *testing.T) {
+	oldEnv := os.Getenv("TF_ACC")
 
-	os.Setenv(PanicOnErr, "FOO")
+	os.Setenv("TF_ACC", "1")
 	if !schemaMap(nil).panicOnError() {
-		t.Fatalf("Any set value for %s should return true", PanicOnErr)
+		t.Fatalf("panicOnError should be true when TF_ACC is not empty")
 	}
 
-	os.Setenv(PanicOnErr, oldEnv)
+	os.Setenv("TF_ACC", oldEnv)
 }
 
 func TestValidateRequiredWithAttributes(t *testing.T) {


### PR DESCRIPTION
Schema errors will panic if TF_ACC is set, panicking is no longer on by default
but cannot be opted out of when running acceptance tests. This does not address #455 .

Technically a breaking change `schema.PanicOnErr` is no longer an exported var

Closes #451 