### PR TITLE
Removing deprecation for Partial mode

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -157,9 +157,6 @@ func (d *ResourceData) HasChange(key string) bool {
 // When partial state mode is enabled, then only key prefixes specified
 // by SetPartial will be in the final state. This allows providers to return
 // partial states for partially applied resources (when errors occur).
-//
-// Deprecated: Partial state has very limited benefit given Terraform refreshes
-// before operations by default.
 func (d *ResourceData) Partial(on bool) {
 	d.partial = on
 	if on {


### PR DESCRIPTION
The key specific partial flagging though is still deprecated. 

This method may still be renamed in v2.0.0, but the functionality will be retained.