### PR TITLE
helper/schema: Support serialization of bool values in TypeMap values [v1]

### DIFF
--- a/helper/schema/serialize.go
+++ b/helper/schema/serialize.go
@@ -51,6 +51,8 @@ func SerializeValueForHash(buf *bytes.Buffer, val interface{}, schema *Schema) {
 			buf.WriteRune(':')
 
 			switch innerVal := innerVal.(type) {
+			case bool:
+				buf.WriteString(strconv.FormatBool(innerVal))
 			case int:
 				buf.WriteString(strconv.Itoa(innerVal))
 			case float64:

--- a/helper/schema/serialize_test.go
+++ b/helper/schema/serialize_test.go
@@ -157,10 +157,12 @@ func TestSerializeForHash(t *testing.T) {
 				},
 			},
 			Value: map[string]interface{}{
-				"foo": "bar",
-				"baz": "foo",
+				"bool":   true,
+				"float":  1.2,
+				"int":    1,
+				"string": "value",
 			},
-			Expected: "[baz:foo;foo:bar;];",
+			Expected: "[bool:true;float:1.2;int:1;string:value;];",
 		},
 
 		{


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/13549

This may only be an issue with Terraform 0.11 and earlier with an obscure schema of:

```go
"attr": {
	Type:     schema.TypeSet,
	Optional: true,
	Elem: &schema.Schema{
		Type: schema.TypeMap,
		Elem: &schema.Schema{
			Type: schema.TypeString,
		},
	},
},
```

And having the following Terraform configuration:

```hcl
resource "example_thing" "example" {
  attr = [{
    somekey = true
  }]
}
```

Previously, this would panic (with updated test):

```console
$ go test ./helper/schema -run=TestSerializeForHash
--- FAIL: TestSerializeForHash (0.00s)
panic: unknown value type in TypeMap bool [recovered]
  panic: unknown value type in TypeMap bool

goroutine 5 [running]:
testing.tRunner.func1.1(0x1a4a5e0, 0xc0004b9920)
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc000372c60)
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:943 +0x3f9
panic(0x1a4a5e0, 0xc0004b9920)
  /usr/local/Cellar/go/1.14.3/libexec/src/runtime/panic.go:969 +0x166
github.com/hashicorp/terraform-plugin-sdk/helper/schema.SerializeValueForHash(0xc000085bb8, 0x1aaef40, 0xc000528450, 0xc000531400)
  /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/serialize.go:61 +0x8c9
github.com/hashicorp/terraform-plugin-sdk/helper/schema.TestSerializeForHash(0xc000372c60)
  /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/serialize_test.go:230 +0x1520
testing.tRunner(0xc000372c60, 0x1c2e848)
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
  /usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:1042 +0x357
FAIL  github.com/hashicorp/terraform-plugin-sdk/helper/schema 5.797s
```