### PR TITLE
Better description of SchemaDiffSuppressFund

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -257,12 +257,12 @@ const (
 	SchemaConfigModeBlock
 )
 
-// SchemaDiffSuppressFunc is a function which can be used to determine
-// whether a detected diff on a schema element is "valid" or not, and
-// suppress it from the plan if necessary.
+// SchemaDiffSuppressFunc is a function which can be used to analyze the diff
+// between the value of remote resource and stored state to suppress update of
+// schema element from the plan if necessary.
 //
 // Return true if the diff should be suppressed, false to retain it.
-type SchemaDiffSuppressFunc func(k, old, new string, d *ResourceData) bool
+type SchemaDiffSuppressFunc func(k, remote, state string, d *ResourceData) bool
 
 // SchemaDefaultFunc is a function called to return a default value for
 // a field.


### PR DESCRIPTION
I found that the notion of `old` and `new` arguments for `SchemaDiffSuppressFund` is confusing when the resource is changed outside of Terraform.

For example, I had changed GitLab remote branch to "master".
```
default_branch                                   = "master" -> null
```
Now Terraform want to change the value back to `null`. However, in this context, the `null` is the old value, but for SchemaDiffSuppressFund the `old` argument contains the string "master".

The suggested description could be improved. I tried to do my best from my current understanding of Terraform and lack of proper terminology.

https://www.terraform.io/docs/extend/schemas/schema-behaviors.html#diffsuppressfunc