### PR TITLE
added a pointer-receiver accessor to RetryableError

### DIFF
--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -73,6 +73,13 @@ func Retry(timeout time.Duration, f RetryFunc) error {
 // RetryFunc is the function retried until it succeeds.
 type RetryFunc func() *RetryError
 
+func (e *RetryError) Error() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // RetryError is the required return type of RetryFunc. It forces client code
 // to choose whether or not a given error is retryable.
 type RetryError struct {

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -140,6 +140,27 @@ func TestRetryContext_cancel(t *testing.T) {
 	}
 }
 
+func TestRetryError_GetError(t *testing.T) {
+	t.Parallel()
+
+	var retryErr *RetryError
+	err := retryErr.Error()
+	if err != nil {
+		t.Fatalf("nil RetryError cast to non-nil error")
+	}
+
+	err = fmt.Errorf("test error")
+	retryErr = RetryableError(err)
+	if retryErr.Error() != err {
+		t.Fatalf("RetryableError did not return encapsulated error")
+	}
+
+	retryErr = NonRetryableError(err)
+	if retryErr.Error() != err {
+		t.Fatalf("RetryableError did not return encapsulated error")
+	}
+}
+
 func TestRetryContext_deadline(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
this makes for more convenient extraction of the error in cases where a provider would like it.

for example, when using the same function with and without `resource.Retry`, it's nice to be able to get to the base error without manually inspecting nullity