### PR TITLE
Mark method as helper

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -10,6 +10,8 @@ import (
 )
 
 func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+	t.Helper()
+	
 	spewConf := spew.NewDefaultConfig()
 	spewConf.SortKeys = true
 


### PR DESCRIPTION
Need to mark all SDK internal helpers so they don't show up in test messaging over user test code:

Example bad log:

```
=== RUN   TestAccResourceID
    TestAccResourceID: testing_new_config.go:54: Check 1/2 error: base64 string length is 0; want 6
--- FAIL: TestAccResourceID (2.15s)
```