### PR TITLE
Fix TestIDRefresh to not timeout.

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -163,9 +163,9 @@ func testIDRefresh(c TestCase, t testing.T, wd *tftest.WorkingDir, step TestStep
 	// Refresh!
 	runProviderCommand(func() error {
 		wd.RequireRefresh(t)
+		state = getState(t, wd)
 		return nil
 	}, wd, defaultPluginServeOpts(wd, step.providers))
-	state = getState(t, wd)
 
 	// Verify attribute equivalence.
 	actualR := state.RootModule().Resources[c.IDRefreshName]


### PR DESCRIPTION
We had a call to `getState` outside the `runProviderCommand` helper
function, which timed out, as it couldn't connect to the provider it was
looking for.

Moving it inside the provider makes TestIDRefresh work again.