### PR TITLE
Create StopContext helper function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
 	github.com/zclconf/go-cty v1.2.1
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
-	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0
 	google.golang.org/genproto v0.0.0-20200310143817-43be25429f5a // indirect

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/configschema"
+	grpcpluginctx "github.com/hashicorp/terraform-plugin-sdk/v2/internal/helper/plugin/context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -22,6 +23,18 @@ const uaEnvVar = "TF_APPEND_USER_AGENT"
 var ReservedProviderFields = []string{
 	"alias",
 	"version",
+}
+
+// StopContext returns a context safe for global use that will cancel
+// when Terraform requests a stop. This function should only be called
+// within a ConfigureContextFunc, passing in the request scoped context
+// received in that method.
+//
+// Deprecated: The use of a global context is discouraged. Please use the new
+// context aware CRUD methods.
+func StopContext(ctx context.Context) (context.Context, bool) {
+	stopContext, ok := ctx.Value(grpcpluginctx.StopContextKey).(context.Context)
+	return stopContext, ok
 }
 
 // Provider represents a resource provider in Terraform, and properly
@@ -74,7 +87,7 @@ type Provider struct {
 	// ConfigureContextFunc is a function for configuring the provider. If the
 	// provider doesn't need to be configured, this can be omitted. This function
 	// receives a context.Context that will cancel when Terraform sends a
-	// cancellation signal. This function can yield Diagnostics
+	// cancellation signal. This function can yield Diagnostics.
 	ConfigureContextFunc ConfigureContextFunc
 
 	meta interface{}

--- a/internal/helper/plugin/context/context.go
+++ b/internal/helper/plugin/context/context.go
@@ -1,0 +1,7 @@
+package context
+
+type Key string
+
+var (
+	StopContextKey = Key("StopContext")
+)


### PR DESCRIPTION
Follows up on stop context work. This exposes a helper to be called within a provider configure function. The use is deprecated. A new nested packaged was created to for the key definition due to a circular import if `helper/schema` tried to import `internal/helper/plugin`

```
func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
    stopCtx, ok := schema.StopContext(ctx)
    ...
}
```