### PR TITLE
Remove spammy warnings

### DIFF
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -276,6 +276,5 @@ func (conf *StateChangeConf) WaitForStateContext(ctx context.Context) (interface
 //
 // Deprecated: Please use WaitForStateContext to ensure proper plugin shutdown
 func (conf *StateChangeConf) WaitForState() (interface{}, error) {
-	log.Printf("[WARN] WaitForState is deprecated, please use WaitForStateContext")
 	return conf.WaitForStateContext(context.Background())
 }

--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"context"
 	"errors"
-	"log"
 	"sync"
 	"time"
 )
@@ -66,7 +65,6 @@ func RetryContext(ctx context.Context, timeout time.Duration, f RetryFunc) error
 //
 // Deprecated: Please use RetryContext to ensure proper plugin shutdown
 func Retry(timeout time.Duration, f RetryFunc) error {
-	log.Printf("[WARN] Retry is deprecated, please use RetryContext")
 	return RetryContext(context.Background(), timeout, f)
 }
 

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -148,11 +148,6 @@ func (p *Provider) InternalValidate() error {
 		}
 	}
 
-	// Warn of deprecations
-	if p.ConfigureFunc != nil && p.ConfigureContextFunc == nil {
-		log.Printf("[WARN] ConfigureFunc is deprecated, please use ConfigureContextFunc")
-	}
-
 	return validationErrors
 }
 

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -705,26 +705,6 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 		return fmt.Errorf("DeleteContext and Delete should not both be set")
 	}
 
-	// Warn of deprecations
-	if r.Exists != nil {
-		log.Printf("[WARN] Exists is deprecated, please encapsulate the logic in ReadContext")
-	}
-	if r.Create != nil && r.CreateContext == nil {
-		log.Printf("[WARN] Create is deprecated, please use CreateContext")
-	}
-	if r.Read != nil && r.ReadContext == nil {
-		log.Printf("[WARN] Read is deprecated, please use ReadContext")
-	}
-	if r.Update != nil && r.UpdateContext == nil {
-		log.Printf("[WARN] Update is deprecated, please use UpdateContext")
-	}
-	if r.Delete != nil && r.DeleteContext == nil {
-		log.Printf("[WARN] Delete is deprecated, please use DeleteContext")
-	}
-	if r.MigrateState != nil {
-		log.Printf("[WARN] MigrateState is deprecated, please use StateUpgraders")
-	}
-
 	return schemaMap(r.Schema).InternalValidate(tsm)
 }
 

--- a/helper/schema/resource_importer.go
+++ b/helper/schema/resource_importer.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"context"
 	"errors"
-	"log"
 )
 
 // ResourceImporter defines how a resource is imported in Terraform. This
@@ -61,9 +60,6 @@ func (r *ResourceImporter) InternalValidate() error {
 	if r.State != nil && r.StateContext != nil {
 		return errors.New("Both State and StateContext cannot be set.")
 	}
-	if r.State != nil && r.StateContext == nil {
-		log.Printf("[WARN] State is deprecated, please use StateContext")
-	}
 	return nil
 }
 
@@ -72,7 +68,6 @@ func (r *ResourceImporter) InternalValidate() error {
 //
 // Deprecated: Please use the context aware ImportStatePassthroughContext instead
 func ImportStatePassthrough(d *ResourceData, m interface{}) ([]*ResourceData, error) {
-	log.Printf("[WARN] ImportStatePassthrough is deprecated, please use ImportStatePassthroughContext")
 	return []*ResourceData{d}, nil
 }
 

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -864,12 +864,6 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 				return fmt.Errorf("%s: Field name may only contain lowercase alphanumeric characters & underscores.", k)
 			}
 		}
-
-		// Warn of deprecations
-		if v.ValidateFunc != nil && v.ValidateDiagFunc == nil {
-			log.Printf("[WARN] ValidateFunc is deprecated, please use ValidateDiagFunc")
-		}
-
 	}
 
 	return nil


### PR DESCRIPTION
Large providers will experience warning spam, this actually overloads our acceptance testing setup on some larger tests with nesting. All these methods have been marked deprecated in the godoc anyways.