### PR TITLE
schema: Propagate "sensitive" into the core schema in all cases

### DIFF
--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -93,9 +93,14 @@ func (m schemaMap) CoreConfigSchema() *configschema.Block {
 		case SchemaConfigModeBlock:
 			ret.BlockTypes[name] = schema.coreConfigSchemaBlock()
 		default: // SchemaConfigModeAuto, or any other invalid value
-			if schema.Computed && !schema.Optional {
+			if schema.Computed && !schema.Optional && !schema.HasAnySensitive() {
 				// Computed-only schemas are always handled as attributes,
-				// because they never appear in configuration.
+				// because they never appear in configuration. However,
+				// we make an exception for computed schemas that are
+				// either themselves sensitive or contain sensitive attributes,
+				// because "sensitive" is a schema-level idea rather than a
+				// type-level idea and so we can't talk about it within the
+				// realm of value types.
 				ret.Attributes[name] = schema.coreConfigSchemaAttribute()
 				continue
 			}
@@ -160,7 +165,7 @@ func (s *Schema) coreConfigSchemaAttribute() *configschema.Attribute {
 		Optional:        opt,
 		Required:        reqd,
 		Computed:        s.Computed,
-		Sensitive:       s.Sensitive,
+		Sensitive:       s.HasAnySensitive(),
 		Description:     desc,
 		DescriptionKind: descKind,
 		Deprecated:      s.Deprecated != "",

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -360,6 +360,27 @@ func (s *Schema) ZeroValue() interface{} {
 	}
 }
 
+// HasAnySensitive returns true if either the receiving schema or any nested
+// schema within it is marked as "sensitive".
+func (s *Schema) HasAnySensitive() bool {
+	if s.Sensitive {
+		return true // easy case
+	}
+	switch elem := s.Elem.(type) {
+	case *Resource:
+		for _, childS := range elem.Schema {
+			if childS.HasAnySensitive() {
+				return true
+			}
+		}
+	case *Schema:
+		if elem.Sensitive {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Schema) finalizeDiff(d *terraform.ResourceAttrDiff, customized bool) *terraform.ResourceAttrDiff {
 	if d == nil {
 		return d


### PR DESCRIPTION
Previously we would translate the SDK's idea of "sensitive" to Terraform Core's idea of "sensitive" only in the case where a particular field we were translating into a core schema attribute were directly marked as sensitive.

However, that fails to cover situations where the mapping from SDK schema to core schema is inexact: nested resources that are marked as Computed and any situation where a provider forces a nested resource field to be represented as an attribute when there's a sensitive field inside it.

This change addresses those two situations in an effort to ensure that every `Sensitive: true` in the provider's schema is respected somehow, even if the handling of it is more conservative that what the provider schema requested.

The effect of this change should be _mostly_ cosmetic, though changing a nested resource to be a block will cause Terraform Core to use the different safety rules that apply to blocks when verifying that a provider is behaving correctly. However, those safety rules are already in effect for any nested resource that is both `Optional: true` and `Computed: true`, so we're already exercising that codepath in many existing resource types without any problems.

The two cosmetic changes this implies are:

* When rendering a plan containing a nested block that has `Optional: false, Computed: true` where that field or any of its nested fields are also `Sensitive: true`, the plan output will illustrate it as a sequence of nested blocks rather than as a single list/set attribute. That then allows the plan renderer to do the `(sensitive)` presentation to the individual nested fields that are sensitive.
* For a schema field which is using [the "attributes as blocks" hack](https://www.terraform.io/docs/configuration/attr-as-blocks.html), if any of its sub-fields are marked as `Sensitive: true` then the top-most field with attributes as blocks mode activated will be treated as _entirely_ sensitive, even if there are other nested fields inside that are not marked as sensitive in the schema, and so the entire substructure will be masked out as `(sensitive)` in the plan.

This is _potential_ short-term fix for #201, implementing both of the ideas I previously posted in [a comment on that issue](https://github.com/hashicorp/terraform-plugin-sdk/issues/201#issuecomment-543985389). Future changes to the provider protocol and core schema model might allow mapping the SDK model more directly, or future changes to the SDK model might make it more closely match the core schema model, but until one of those things happen it's better to err on the side of potentially marking more than necessary as sensitive rather than less than necessary.

With that said, I've not tested this against any of the real-world situations discussed in #201 because I don't have suitable credentials to run the acceptance tests for those providers, so I'd like some help to try this out and see whether there are any practical implications of it that I've not considered.
