### PR TITLE
helper/resource: Use base 36 to generate incremental ids

### DIFF
--- a/helper/resource/id.go
+++ b/helper/resource/id.go
@@ -25,21 +25,23 @@ const UniqueIDSuffixLength = 26
 
 // Helper for a resource to generate a unique identifier w/ given prefix
 //
-// After the prefix, the ID consists of an incrementing 26 digit value (to match
-// previous timestamp output).  After the prefix, the ID consists of a timestamp
-// and an incrementing 8 hex digit value The timestamp means that multiple IDs
-// created with the same prefix will sort in the order of their creation, even
-// across multiple terraform executions, as long as the clock is not turned back
-// between calls, and as long as any given terraform execution generates fewer
-// than 4 billion IDs.
+// After the prefix, the ID consists of an incrementing base 36 value.
+// The value is made of the current timestamp in base 36 followed by an
+// incrementing base 36 counter.
+// This means that the identifier can grow in size depending on the number of
+// items handled by terraform.
+// Because the first part is using the timestamp, it is always possible to sort
+// the identifiers of multiple resources alphabetically (with numbers first)
+// to get the list of resources created from the oldest to the newest.
+// The timestamp means that multiple IDs created with the same prefix will sort
+// in the order of their creation, even across multiple terraform executions, as
+// long as the clock is not turned back between calls.
 func PrefixedUniqueId(prefix string) string {
-	// Be precise to 4 digits of fractional seconds, but remove the dot before the
-	// fractional seconds.
-	timestamp := strings.Replace(
-		time.Now().UTC().Format("20060102150405.0000"), ".", "", 1)
+	timestamp := strconv.FormatUint(uint64(time.Now().Unix()), 36)
 
 	idMutex.Lock()
 	defer idMutex.Unlock()
 	idCounter++
-	return fmt.Sprintf("%s%s%08x", prefix, timestamp, idCounter)
+	id := strconv.FormatUint(uint64(idCounter), 36)
+	return fmt.Sprintf("%s%s%s", prefix, timestamp, id)
 }

--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -4,20 +4,14 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 )
 
-var allDigits = regexp.MustCompile(`^\d+$`)
-var allHex = regexp.MustCompile(`^[a-f0-9]+$`)
+var all36 = regexp.MustCompile(`^[a-z0-9]+$`)
 
 func TestUniqueId(t *testing.T) {
-	split := func(rest string) (timestamp, increment string) {
-		return rest[:18], rest[18:]
-	}
-
 	iterations := 10000
 	ids := make(map[string]struct{})
-	var id, lastId string
+	var id string
 	for i := 0; i < iterations; i++ {
 		id = UniqueId()
 
@@ -31,36 +25,10 @@ func TestUniqueId(t *testing.T) {
 
 		rest := strings.TrimPrefix(id, UniqueIdPrefix)
 
-		if len(rest) != UniqueIDSuffixLength {
-			t.Fatalf("PrefixedUniqueId is out of sync with UniqueIDSuffixLength, post-prefix part has wrong length! %s", rest)
-		}
-
-		timestamp, increment := split(rest)
-
-		if !allDigits.MatchString(timestamp) {
-			t.Fatalf("Timestamp not all digits! %s", timestamp)
-		}
-
-		if !allHex.MatchString(increment) {
-			t.Fatalf("Increment part not all hex! %s", increment)
-		}
-
-		if lastId != "" && lastId >= id {
-			t.Fatalf("IDs not ordered! %s vs %s", lastId, id)
+		if !all36.MatchString(rest) {
+			t.Fatalf("Suffix isn't in base 36! %s", rest)
 		}
 
 		ids[id] = struct{}{}
-		lastId = id
-	}
-
-	id1 := UniqueId()
-	time.Sleep(time.Millisecond)
-	id2 := UniqueId()
-	timestamp1, _ := split(strings.TrimPrefix(id1, UniqueIdPrefix))
-	timestamp2, _ := split(strings.TrimPrefix(id2, UniqueIdPrefix))
-
-	if timestamp1 == timestamp2 {
-		t.Fatalf("Timestamp part should update at least once a millisecond %s %s",
-			id1, id2)
 	}
 }


### PR DESCRIPTION
This is a copy of the PR at https://github.com/hashicorp/terraform/pull/16997

The current implementation makes the `name_prefix` of some resources in AWS pretty much useless. This is intended to solve that problem.

### **What changes**
- Instead of using a human readable representation of a date (such as "201712280947212674") which doesn't fully use base 10 (months go only up to 12, days up to 31, minutes and seconds up to 60), use a timestamp which is an always incrementing value, which does not skip steps and is therefore more compact.
- Rather than using base 10 to represent the timestamp, use base 36 ([a-z0-9]) this gives a wider range of characters to express the number making the suffix even more compact. I went with 36 instead of the classic 64 or 62 ([a-zA-Z0-9]) because some systems do not care about the case or do not deal with 'special characters'.
- Instead of using a base16 incremental count, use base36 (same reasoning as above)
- Instead of having a fixed length which requires padding and leads to waste, concatenate the timestamp to the id and let the suffix grow.

This leads to these changes:

- `20171228094721267400000004` becomes `p1o0ix4`
- `20171228094721267400010000` becomes `p1o0ixcra`

### **Notes**
- The length of the suffix is not fixed
- The timestamp and the id have to be be converted independently to keep the same "prefix"
- The creation order of the resources across multiple runs is kept as the suffixes can be sorted alphabetically (note that `9 < a`).
- The creation order of the resources within the same run is not going to be easily accessible (as we're not padding with 0), for example `p1o0ix4` is the 4th object created, `p1o0ix5` is the 5th one and `p1o0ix40` is the 144th, ordering alphabetically will show the order p1o0ix4, p1o0ix40, p1o0ix5
- The milliseconds have been dropped from the timestamp. They could be added easily (we could even use nanoseconds, but it feels like a waste of space.
- The order of the resources will be less accessible when the timestamp grows by one order of magnitude. Today we got the timestamp as `p1o0ix`, the next move will be at `1000000` which is `2176782336` in base 10 or on the 24th of December 2038 (the following one being in the year 4453).
- If the above point is a concern, adding milliseconds change the timestamp into `jbqb2lgo` which moves the next order of magnitude change to `100000000` which is `2821109907456` base 10 which is the 25th of May 2059. I'm not sure that the minor inconvenience of not being able to sort warrants the extra length, but for two characters it isn't the end of the world either.