### PR TITLE
Fix a Fatal to a Fatalf when using replacers.

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -506,7 +506,7 @@ func Test(t testing.T, c TestCase) {
 	for _, p := range providers {
 		diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if diags.HasError() {
-			t.Fatal("error configuring provider: %s", diagutils.ErrorDiags(diags))
+			t.Fatalf("error configuring provider: %s", diagutils.ErrorDiags(diags))
 		}
 	}
 


### PR DESCRIPTION
We were calling t.Fatal but using %s, which was resulting in weird
output. Fix to use Fatalf.