### PR TITLE
Restore test log splitting.

### DIFF
--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/hashicorp/logutils"
+	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // These are the environmental variables that determine if we log, and if
@@ -16,12 +18,14 @@ import (
 const (
 	EnvLog     = "TF_LOG"      // Set to True
 	EnvLogFile = "TF_LOG_PATH" // Set to a file
+	// EnvLogPathMask splits test log files by name.
+	EnvLogPathMask = "TF_LOG_PATH_MASK"
 )
 
 var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 
 // LogOutput determines where we should send logs (if anywhere) and the log level.
-func LogOutput() (logOutput io.Writer, err error) {
+func LogOutput(t testing.T) (logOutput io.Writer, err error) {
 	logOutput = ioutil.Discard
 
 	logLevel := LogLevel()
@@ -31,6 +35,18 @@ func LogOutput() (logOutput io.Writer, err error) {
 
 	logOutput = os.Stderr
 	if logPath := os.Getenv(EnvLogFile); logPath != "" {
+		var err error
+		logOutput, err = os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if logPathMask := os.Getenv(EnvLogPathMask); logPathMask != "" {
+		// Escape special characters which may appear if we have subtests
+		testName := strings.Replace(t.Name(), "/", "__", -1)
+
+		logPath := fmt.Sprintf(logPathMask, testName)
 		var err error
 		logOutput, err = os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
 		if err != nil {
@@ -51,8 +67,8 @@ func LogOutput() (logOutput io.Writer, err error) {
 // SetOutput checks for a log destination with LogOutput, and calls
 // log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
 // ioutil.Discard. Any error from LogOutout is fatal.
-func SetOutput() {
-	out, err := LogOutput()
+func SetOutput(t testing.T) {
+	out, err := LogOutput(t)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -94,7 +94,7 @@ func runProviderCommand(t testing.T, f func() error, wd *tftest.WorkingDir, fact
 
 		// plugin.DebugServe hijacks our log output location, so let's
 		// reset it
-		logging.SetOutput()
+		logging.SetOutput(t)
 
 		// when the provider exits, remove one from the waitgroup
 		// so we can track when everything is done

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -491,7 +491,7 @@ func Test(t testing.T, c TestCase) {
 		return
 	}
 
-	logging.SetOutput()
+	logging.SetOutput(t)
 
 	// Copy any explicitly passed providers to factories, this is for backwards compatibility.
 	if len(c.Providers) > 0 {


### PR DESCRIPTION
Restore the ability to split out logging by test name when using the
acceptance test framework.

Note: I'm not sure if this will have race conditions, given it's called
repeatedly.