### PR TITLE
Refresh before applying test step.

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -34,6 +34,16 @@ func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step Test
 
 	wd.RequireSetConfig(t, step.Config)
 
+	// require a refresh before applying
+	// failing to do this will result in data sources not being updated
+	err := runProviderCommand(t, func() error {
+		wd.RequireRefresh(t)
+		return nil
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return err
+	}
+
 	if !step.PlanOnly {
 		err := runProviderCommand(t, func() error {
 			return wd.Apply()
@@ -61,7 +71,7 @@ func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step Test
 	// Test for perpetual diffs by performing a plan, a refresh, and another plan
 
 	// do a plan
-	err := runProviderCommand(t, func() error {
+	err = runProviderCommand(t, func() error {
 		wd.RequireCreatePlan(t)
 		return nil
 	}, wd, c.ProviderFactories)


### PR DESCRIPTION
Our test steps handle refreshes very explicitly, which is good. But we
don't actually refresh before applying the step, assuming the previous
step left our state in a good condition.

However, this means that if a config changes the value of a data
source--e.g., for a data source that generates JSON from HCL, as is
common in IAM resources--the data source's value in state won't be
updated before apply, meaning the resources depending on that data
source value will have a stale, incorrect value instead of the one in
the config.

As we advise users to not run Terraform with -refresh=false, this
doesn't mirror the user experience in production and is confusing--I
lost several hours to debugging it.

This PR explicitly runs refresh prior to applying or planning a test
step, so new data source values in the config can be accurately
reflected.