### PR TITLE
Allow specifying external providers in a TestCase.

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -301,6 +301,14 @@ type TestCase struct {
 	// Deprecated: Providers is deprecated, please use ProviderFactories
 	Providers map[string]*schema.Provider
 
+	// ExternalProviders are providers the TestCase relies on that should
+	// be downloaded from the registry during init. This is only really
+	// necessary to set if you're using import, as providers in your config
+	// will be automatically retrieved during init. Import doesn't use a
+	// config, however, so we allow manually specifying them here to be
+	// downloaded for import tests.
+	ExternalProviders []string
+
 	// PreventPostDestroyRefresh can be set to true for cases where data sources
 	// are tested alongside real resources
 	PreventPostDestroyRefresh bool
@@ -536,6 +544,9 @@ func Test(t testing.T, c TestCase) {
 func testProviderConfig(c TestCase) string {
 	var lines []string
 	for p := range c.Providers {
+		lines = append(lines, fmt.Sprintf("provider %q {}\n", p))
+	}
+	for p := range c.ExternalProviders {
 		lines = append(lines, fmt.Sprintf("provider %q {}\n", p))
 	}
 

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -69,10 +69,13 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 		wd.Close()
 	}()
 
-	providerCfg := testProviderConfig(c)
+	providerCfg, err := testProviderConfig(c)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wd.RequireSetConfig(t, providerCfg)
-	err := runProviderCommand(t, func() error {
+	err = runProviderCommand(t, func() error {
 		wd.RequireInit(t)
 		return nil
 	}, wd, c.ProviderFactories)
@@ -177,12 +180,15 @@ func testIDRefresh(c TestCase, t testing.T, wd *tftest.WorkingDir, step TestStep
 
 	// Temporarily set the config to a minimal provider config for the refresh
 	// test. After the refresh we can reset it.
-	cfg := testProviderConfig(c)
+	cfg, err := testProviderConfig(c)
+	if err != nil {
+		return err
+	}
 	wd.RequireSetConfig(t, cfg)
 	defer wd.RequireSetConfig(t, step.Config)
 
 	// Refresh!
-	err := runProviderCommand(t, func() error {
+	err = runProviderCommand(t, func() error {
 		wd.RequireRefresh(t)
 		state = getState(t, wd)
 		return nil


### PR DESCRIPTION
Users used to specify third-party providers they relied on for
tests--usually utility providers like random--by importing the provider
and specifying it in resource.TestCase.Providers or
resource.TestCase.ProviderFactories. With binary testing, this is no
longer necessary, as the providers can be downloaded from the registry
using Terraform init. This allows for more up-to-date providers with
fewer Go dependencies, which is a nicer system all around.

The acceptance testing framework will run `terraform init`, which will
automatically notice these providers being used in the configuration
files and download them, just like in production.

However, there's a wrinkle; tests that import don't have the resources
set in the configuration, which means they're not downloaded during
init, which causes test failures.

To resolve this, this PR adds a new property to TestCase, which lets
developers list the third party providers their test relies on. This
list is then added to the list of provider blocks auto-generated by the
test framework, allowing them to be inited during import tests.

Arguably, we should have this new property take a map of blocks to
either their version, their source block, or both, so users can control
specifically which version of the provider they're using and where it's
downloaded from. I'm open to thoughts and opinions on that.