### PR TITLE
Consider resource provider when locating expected state in ImportState acceptance test case

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -111,7 +111,7 @@ func testStepNewImportState(t testing.T, c TestCase, helper *tftest.Helper, wd *
 			// Find the existing resource
 			var oldR *terraform.ResourceState
 			for _, r2 := range old {
-				if r2.Primary != nil && r2.Primary.ID == r.Primary.ID && r2.Type == r.Type {
+				if r2.Primary != nil && r2.Primary.ID == r.Primary.ID && r2.Type == r.Type && r2.Provider == r.Provider {
 					oldR = r2
 					break
 				}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-plugin-sdk/issues/521.

The AWS provider has not quite upgraded to v2.0.0 of the SDK yet so I haven't been able to test the fix against my failing acceptance test case although the same fix against v1.14.0 succeeded.

I see no suitable unit tests to add a test case to.