### PR TITLE
Restore step number in err msg

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -116,14 +116,14 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 			err := testStepNewConfig(t, c, wd, step)
 			if step.ExpectError != nil {
 				if err == nil {
-					t.Fatal("Expected an error but got none")
+					t.Fatal("Step %d, expected an error but got none")
 				}
 				if !step.ExpectError.MatchString(err.Error()) {
-					t.Fatalf("Expected an error with pattern, no match on: %s", err)
+					t.Fatalf("Step %d, expected an error with pattern, no match on: %s", err)
 				}
 			} else {
 				if err != nil {
-					t.Fatal(err)
+					t.Fatalf("Step %d error: %s", err)
 				}
 			}
 			appliedCfg = step.Config

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -99,7 +99,7 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 				t.Fatal(err)
 			}
 			if skip {
-				log.Printf("[WARN] Skipping step %d", i)
+				log.Printf("[WARN] Skipping step %d/%d", i+1, len(c.Steps))
 				continue
 			}
 		}
@@ -116,14 +116,14 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 			err := testStepNewConfig(t, c, wd, step)
 			if step.ExpectError != nil {
 				if err == nil {
-					t.Fatal("Step %d, expected an error but got none")
+					t.Fatalf("Step %d/%d, expected an error but got none", i+1, len(c.Steps))
 				}
 				if !step.ExpectError.MatchString(err.Error()) {
-					t.Fatalf("Step %d, expected an error with pattern, no match on: %s", err)
+					t.Fatalf("Step %d/%d, expected an error with pattern, no match on: %s", i+1, len(c.Steps), err)
 				}
 			} else {
 				if err != nil {
-					t.Fatalf("Step %d error: %s", err)
+					t.Fatalf("Step %d/%d error: %s", i+1, len(c.Steps), err)
 				}
 			}
 			appliedCfg = step.Config


### PR DESCRIPTION
Number now indexes starting from 1 and includes total count ex: `Step 1/3 error:...`.

Closes #520 