### PR TITLE
Update Issue template instructions to query v2 package

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,13 +8,14 @@ labels: bug
 <!---
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk")'
+go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk/v2")'
 
 If you are not running the latest version of the SDK, please try upgrading
 because your bug may have already been fixed.
 
-If the command above doesn't yield any results, it means you may not have migrated
-to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html for more.
+If the command above doesn't yield any results, it means you may either be using v1 of the SDK or
+have not have migrated to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html
+for more.
 -->
 
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,14 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk")'
+go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk/v2")'
 
 If you are not running the latest version of the SDK, please try upgrading
 because your feature may have already been implemented.
 
-If the command above doesn't yield any results, it means you may not have migrated
-to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html for more.
+If the command above doesn't yield any results, it means you may either be using v1 of the SDK or
+have not have migrated to the standalone SDK yet. See https://www.terraform.io/docs/extend/plugin-sdk.html
+for more.
 -->
 ```
 ...


### PR DESCRIPTION
Updates the Issue templates to use the v2 package path for querying the version