### PR TITLE
helper/schema: Introduce ResourceData GetResourceId and SetResourceId receiver methods and only passthrough id attribute state if present

### DIFF
--- a/helper/schema/data_source_resource_shim.go
+++ b/helper/schema/data_source_resource_shim.go
@@ -25,7 +25,7 @@ func DataSourceResourceShim(name string, dataSource *Resource) *Resource {
 
 	dataSource.Create = CreateFunc(dataSource.Read)
 	dataSource.Delete = func(d *ResourceData, meta interface{}) error {
-		d.SetId("")
+		d.SetResourceId("")
 		return nil
 	}
 	dataSource.Update = nil // should already be nil, but let's make sure

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -356,6 +356,9 @@ func (p *Provider) ImportState(
 
 	// Create the data
 	data := r.Data(nil)
+	// Deprecated id attribute handling
+	// Note this requires using SetId() with unsafeWriteField for backwards
+	// compatibility until a major version can switch to SetResourceId()
 	data.SetId(id)
 	data.SetType(info.Type)
 

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -633,7 +633,7 @@ func TestProviderImportState_default(t *testing.T) {
 	}
 }
 
-func TestProviderImportState_setsId(t *testing.T) {
+func TestProviderImportState_setsId_Id(t *testing.T) {
 	var val string
 	stateFunc := func(d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 		val = d.Id()
@@ -662,10 +662,69 @@ func TestProviderImportState_setsId(t *testing.T) {
 	}
 }
 
-func TestProviderImportState_setsType(t *testing.T) {
+func TestProviderImportState_setsId_GetResourceId(t *testing.T) {
+	var val string
+	stateFunc := func(d *ResourceData, meta interface{}) ([]*ResourceData, error) {
+		val = d.GetResourceId()
+		return []*ResourceData{d}, nil
+	}
+
+	p := &Provider{
+		ResourcesMap: map[string]*Resource{
+			"foo": {
+				Importer: &ResourceImporter{
+					State: stateFunc,
+				},
+			},
+		},
+	}
+
+	_, err := p.ImportState(context.Background(), &terraform.InstanceInfo{
+		Type: "foo",
+	}, "bar")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if val != "bar" {
+		t.Fatal("should set id")
+	}
+}
+
+func TestProviderImportState_setsType_SetId(t *testing.T) {
 	var tVal string
 	stateFunc := func(d *ResourceData, meta interface{}) ([]*ResourceData, error) {
 		d.SetId("foo")
+		tVal = d.State().Ephemeral.Type
+		return []*ResourceData{d}, nil
+	}
+
+	p := &Provider{
+		ResourcesMap: map[string]*Resource{
+			"foo": {
+				Importer: &ResourceImporter{
+					State: stateFunc,
+				},
+			},
+		},
+	}
+
+	_, err := p.ImportState(context.Background(), &terraform.InstanceInfo{
+		Type: "foo",
+	}, "bar")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if tVal != "foo" {
+		t.Fatal("should set type")
+	}
+}
+
+func TestProviderImportState_setsType_SetResourceId(t *testing.T) {
+	var tVal string
+	stateFunc := func(d *ResourceData, meta interface{}) ([]*ResourceData, error) {
+		d.SetResourceId("foo")
 		tVal = d.State().Ephemeral.Type
 		return []*ResourceData{d}, nil
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -362,7 +362,7 @@ func (r *Resource) Apply(
 			}
 
 			// Make sure the ID is gone.
-			data.SetId("")
+			data.SetResourceId("")
 		}
 
 		// If we're only destroying, and not creating, then return
@@ -381,7 +381,7 @@ func (r *Resource) Apply(
 		data.timeouts = &rt
 	}
 
-	if data.Id() == "" {
+	if data.GetResourceId() == "" {
 		// We're creating, it is a new resource.
 		data.MarkNewResource()
 		diags = append(diags, r.create(ctx, data, meta)...)
@@ -804,6 +804,6 @@ func NoopContext(context.Context, *ResourceData, interface{}) diag.Diagnostics {
 // which sets the resource ID to empty string (to remove it from state)
 // and returns no error.
 func RemoveFromState(d *ResourceData, _ interface{}) error {
-	d.SetId("")
+	d.SetResourceId("")
 	return nil
 }


### PR DESCRIPTION
Closes #541

Implements proposal 1 from the issue. This goes through the process of deprecating the existing functionality to support potential longer term goals with the SDK (treating the `id` attribute` like all others), but if that is not warranted happy to change up the implementation here.

This allows resources to decouple from the implicit `id` attribute by only working with the underlying resource identifier (`InstanceState.ID`). Any `id` attribute handling is omitted from these new receiver methods. For reference, the existing `Id()` receiver method always read the `id` attribute as a fallback if the resource identifier was missing and `SetId()` always set the `id` attribute to match the resource identifier.

Also part of this support, the `id` attribute is no longer always "promoted" using the resource identifier if the attribute is missing when retrieving the state, however it is always passed through if present in the previous or new state. Existing logic using `SetId()` and the existing import functionality are unaffected as they continue to set the `id` attribute.

Current changes:

```
* helper/schema: Add `ResourceData` `GetResourceId()` and `SetResourceId()` receiver methods
* helper/schema: `ResourceData` `Id()` and `SetId()` receiver methods have been deprecated
```

Potential major version changes in the future relating to this:

```
* helper/schema: `ResourceData` `Id()` and `SetId()` receiver methods have been removed
* helper/schema: Importing resources no longer automatically sets the `id` attribute (use `d.Set("id", ...)` to match previous behavior)
```