### PR TITLE
remove local SECURITY.md in favor of org-wide policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,0 @@
-# Vulnerability Reporting
-
-Please disclose security vulnerabilities responsibly by following procedure
-described at https://www.hashicorp.com/security#vulnerability-reporting


### PR DESCRIPTION
Moving away from per-repository security policies, to an org-wide one defined at https://github.com/hashicorp/.github/blob/master/SECURITY.md and applied per https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file.