### PR TITLE
helper/resource/testing_new: update import state testing

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -111,7 +111,7 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 					t.Fatalf("Step %d/%d error running import: expected an error but got none", i+1, len(c.Steps))
 				}
 				if !step.ExpectError.MatchString(err.Error()) {
-					t.Fatalf("Step %d/%d error running import, expected an error with pattern, no match on: %s", i+1, len(c.Steps), err)
+					t.Fatalf("Step %d/%d error running import, expected an error with pattern (%s), no match on: %s", i+1, len(c.Steps), step.ExpectError.String(), err)
 				}
 			} else {
 				if err != nil {

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -106,8 +106,17 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 
 		if step.ImportState {
 			err := testStepNewImportState(t, c, helper, wd, step, appliedCfg)
-			if err != nil {
-				t.Fatal(err)
+			if step.ExpectError != nil {
+				if err == nil {
+					t.Fatalf("Step %d/%d error running import: expected an error but got none", i+1, len(c.Steps))
+				}
+				if !step.ExpectError.MatchString(err.Error()) {
+					t.Fatalf("Step %d/%d error running import, expected an error with pattern, no match on: %s", i+1, len(c.Steps), err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Step %d/%d error running import: %s", i+1, len(c.Steps), err)
+				}
 			}
 			continue
 		}

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -71,11 +71,10 @@ func testStepNewImportState(t testing.T, c TestCase, helper *tftest.Helper, wd *
 	}
 
 	err = runProviderCommand(t, func() error {
-		importWd.RequireImport(t, step.ResourceName, importId)
-		return nil
+		return importWd.Import(step.ResourceName, importId)
 	}, importWd, c.ProviderFactories)
 	if err != nil {
-		t.Fatalf("Error running import: %s", err)
+		return err
 	}
 
 	var importState *terraform.State


### PR DESCRIPTION
Closes #532 

`testStepNewImportState` can now return the error (if any) of the underlying method that imports the resource, thus allowing for error handling w/in `runNewTest` when `step.ImportState` is set to `true`. Special error handling is needed here to account for provider acceptance tests that check for expected errors during `ImportState` test steps as illustrated in #532. 

Output of previously failing acceptance test:
```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_basic (303.34s)
```