### PR TITLE
fix importStateCheck to read from import workspace

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -80,9 +80,9 @@ func testStepNewImportState(t testing.T, c TestCase, helper *tftest.Helper, wd *
 
 	var importState *terraform.State
 	err = runProviderCommand(t, func() error {
-		importState = getState(t, wd)
+		importState = getState(t, importWd)
 		return nil
-	}, wd, c.ProviderFactories)
+	}, importWd, c.ProviderFactories)
 	if err != nil {
 		t.Fatalf("Error getting state: %s", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-plugin-sdk/issues/531

Update importStateCheck to ready from the import workspace