### PR TITLE
helper/resource: Skip data sources in ImportStateVerify testing

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -110,7 +110,15 @@ func testStepNewImportState(t testing.T, c TestCase, helper *tftest.Helper, wd *
 		for _, r := range new {
 			// Find the existing resource
 			var oldR *terraform.ResourceState
-			for _, r2 := range old {
+			for r2Key, r2 := range old {
+				// Ensure that we do not match against data sources as they
+				// cannot be imported and are not what we want to verify.
+				// Mode is not present in ResourceState so we use the
+				// stringified ResourceStateKey for comparison.
+				if strings.HasPrefix(r2Key, "data.") {
+					continue
+				}
+
 				if r2.Primary != nil && r2.Primary.ID == r.Primary.ID && r2.Type == r.Type && r2.Provider == r.Provider {
 					oldR = r2
 					break


### PR DESCRIPTION
Closes #533

I have a feeling that #552 probably fixed #533, but this is an optimization and could prevent bugs if the old state contains a matching managed resource and data source of the same exact type.

Please let me know if you would prefer a different solution here or would like me to create issues for and implement any of these:

- Splitting this `ImportStateVerify` handling into its own unit test-able function
- Adding the `Mode` field to `ResourceState`