### PR TITLE
Add 'helper/resource' error helpers

### DIFF
--- a/helper/resource/error.go
+++ b/helper/resource/error.go
@@ -83,3 +83,11 @@ func (e *TimeoutError) Error() string {
 	return fmt.Sprintf("timeout while waiting for %s%s",
 		expectedState, suffix)
 }
+
+// IsTimeoutErrorWithoutLastError returns true if the error matches all these conditions:
+//  * err is of type resource.TimeoutError
+//  * TimeoutError.LastError is nil
+func IsTimeoutErrorWithoutLastError(err error) bool {
+	timeoutErr, ok := err.(*TimeoutError)
+	return ok && timeoutErr.LastError == nil
+}

--- a/helper/resource/error.go
+++ b/helper/resource/error.go
@@ -26,6 +26,12 @@ func (e *NotFoundError) Error() string {
 	return "couldn't find resource"
 }
 
+// IsNotFoundError returns true if the error is of type resource.NotFoundError.
+func IsNotFoundError(err error) bool {
+	_, ok := err.(*NotFoundError)
+	return ok
+}
+
 // UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
 type UnexpectedStateError struct {
 	LastError     error

--- a/helper/resource/error_test.go
+++ b/helper/resource/error_test.go
@@ -45,3 +45,51 @@ func TestIsNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTimeoutErrorWithoutLastError(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:     "timeout error",
+			Err:      &TimeoutError{},
+			Expected: true,
+		},
+		{
+			Name: "timeout error non-nil last error",
+			Err:  &TimeoutError{LastError: errors.New("test")},
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped timeout error",
+			Err:  fmt.Errorf("test: %w", &TimeoutError{}),
+		},
+		{
+			Name: "wrapped timeout error non-nil last error",
+			Err:  fmt.Errorf("test: %w", &TimeoutError{LastError: errors.New("test")}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsTimeoutErrorWithoutLastError(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}

--- a/helper/resource/error_test.go
+++ b/helper/resource/error_test.go
@@ -1,0 +1,47 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:     "not found error",
+			Err:      &NotFoundError{LastError: errors.New("test")},
+			Expected: true,
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped not found error",
+			Err:  fmt.Errorf("test: %w", &NotFoundError{LastError: errors.New("test")}),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsNotFoundError(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The AWS Provider uses its [own versions](https://github.com/terraform-providers/terraform-provider-aws/blob/684357c96d9b6729db07daa3475ae161228babbc/aws/utils.go#L46-L54) of these helpers extensively and as the provider restructures to add more functionality in `internal` packages it makes sense to add them to the Plugin SDK.

The name `IsTimeoutErrorWithoutLastError` is just a suggestion (@bflad Any ideas?). The AWS Provider's name `isResourceTimeoutError` is misleading in general as what is being tested is whether it's a `TimeoutError` that doesn't wrap an error from the prior refresh function's invocation.

