### PR TITLE
Fix import when reattach testing in v1.

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -64,14 +64,14 @@ func testStepNewImportState(t *testing.T, c TestCase, wd *tftest.WorkingDir, ste
 	importWd.RequireSetConfig(t, step.Config)
 	err = runProviderCommand(t, func() error {
 		return importWd.Init()
-	}, wd, c.ProviderFactories)
+	}, importWd, c.ProviderFactories)
 	if err != nil {
 		return fmt.Errorf("Error running init: %v", err)
 	}
 
 	err = runProviderCommand(t, func() error {
 		return importWd.Import(step.ResourceName, importId)
-	}, wd, c.ProviderFactories)
+	}, importWd, c.ProviderFactories)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We were using the wrong WorkingDir when doing reattach import testing in
v1. This is fixed in v2, but hasn't been backported yet, apparently.