### PR TITLE
Fix spurious diff from timeouts.

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -171,6 +171,26 @@ func testStepNewImportState(t testing.T, c TestCase, helper *tftest.Helper, wd *
 				}
 			}
 
+			// timeouts are only _sometimes_ added to state. To
+			// account for this, just don't compare timeouts at
+			// all.
+			for k := range actual {
+				if strings.HasPrefix(k, "timeouts.") {
+					delete(actual, k)
+				}
+				if k == "timeouts" {
+					delete(actual, k)
+				}
+			}
+			for k := range expected {
+				if strings.HasPrefix(k, "timeouts.") {
+					delete(expected, k)
+				}
+				if k == "timeouts" {
+					delete(expected, k)
+				}
+			}
+
 			if !reflect.DeepEqual(actual, expected) {
 				// Determine only the different attributes
 				for k, v := range expected {


### PR DESCRIPTION
When testing and verifying that the imported state matches the applied
state, we're seeing some resources report that the number of elements in
the `timeouts` map don't match between the two states. Apparently, any
timeouts set in the config are added to state during _import_, but
aren't during a regular apply.

To avoid returning this incorrectly as a diff, we're just not going to
verify that.