### PR TITLE
A second approach to fixing timeouts in state.

### DIFF
--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -566,7 +566,7 @@ func TestProviderDiff_timeoutInvalidValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected provider.Diff to fail with invalid timeout value")
 	}
-	expectedErrMsg := "time: invalid duration invalid"
+	expectedErrMsg := "time: invalid duration \"invalid\""
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Fatalf("Unexpected error message: %q\nExpected message to contain %q",
 			err.Error(),

--- a/internal/helper/plugin/grpc_provider.go
+++ b/internal/helper/plugin/grpc_provider.go
@@ -1040,6 +1040,11 @@ func (s *GRPCProviderServer) ImportResourceState(ctx context.Context, req *proto
 		// Normalize the value and fill in any missing blocks.
 		newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, schemaBlock)
 
+		timeouts, ok := newStateVal.AsValueMap()[schema.TimeoutsConfigKey]
+		if ok {
+			newStateVal = copyTimeoutValues(newStateVal, cty.NullVal(timeouts.Type()))
+		}
+
 		newStateMP, err := msgpack.Marshal(newStateVal, schemaBlock.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)


### PR DESCRIPTION
Timeouts are persisted in state in a funny way, and the SDK manages how
this happens. PlanResourceChange, ImportResourceChange, and ReadResource
all apply this logic to persisting the timeouts and state, but
ImportResource doesn't. This is likely because the logic assumes there's
a state that the timeouts _may_ be present in, but ImportResource
obviously doesn't have a state.

This PR just applies the same logic assuming the resource state is null
(which, technically, is kinda true?) and experimentally it has the same
effect that running `apply` has.

Why are we storing timeouts in state at all? My guess is it has
something to do with Terraform's type management with cty between state
and config; I bet we're not allowed to have something in config that's
not in state, or some such.