### PR TITLE
Backport #576: fix importstateverify + timeouts.

### DIFF
--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -210,6 +210,26 @@ func testStepNewImportState(t *testing.T, c TestCase, wd *tftest.WorkingDir, ste
 				}
 			}
 
+			// timeouts are only _sometimes_ added to state. To
+			// account for this, just don't compare timeouts at
+			// all.
+			for k := range actual {
+				if strings.HasPrefix(k, "timeouts.") {
+					delete(actual, k)
+				}
+				if k == "timeouts" {
+					delete(actual, k)
+				}
+			}
+			for k := range expected {
+				if strings.HasPrefix(k, "timeouts.") {
+					delete(expected, k)
+				}
+				if k == "timeouts" {
+					delete(expected, k)
+				}
+			}
+
 			if !reflect.DeepEqual(actual, expected) {
 				// Determine only the different attributes
 				for k, v := range expected {


### PR DESCRIPTION
Resolve the issue with spurious test failures with ImportStateVerify from resources using timeouts on the v1-maint branch, as well.