### PR TITLE
Restore pre-binary testing ExpectNonEmptyPlan behavior.

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -141,8 +141,6 @@ func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step Test
 			return fmt.Errorf("Error retrieving formatted plan output: %w", err)
 		}
 		return fmt.Errorf("After applying this test step, the plan was not empty.\nstdout:\n\n%s", stdout)
-	} else if step.ExpectNonEmptyPlan && planIsEmpty(plan) {
-		return fmt.Errorf("Expected a non-empty plan, but got an empty plan!")
 	}
 
 	// do a refresh


### PR DESCRIPTION
TestSteps do a number of things: first they apply a config, then they
run some checks on that config, then they do a plan _without_
refreshing, then refresh, then do _another_ plan.

When you tell a TestStep you expect a non-empty plan, _right now_ it
expects _both_ those plans to come back empty. Pre-binary testing,
however, it only required the second one to come back non-empty.

This matters because some providers overload TestChecks to modify
resources out of band. When this is done, there's a plan without a
refresh (that won't see the modifications) and a plan after a refresh
(that will see the changes). If both are forced to agree on whether the
plan should be empty or not, you can't use that pattern anymore, because
they can't _both_ be right.

This restores the original behavior of allowing the first plan to be
non-empty _or_ empty when ExpectNonEmptyPlan is set to true (it must be
empty when ExpectNonEmptyPlan is false), but requiring the second plan,
after the refresh, to be non-empty when ExpectNonEmptyPlan is true.