### PR TITLE
Check the error on post-test destroy.

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -63,7 +63,10 @@ func runNewTest(t testing.T, c TestCase, helper *tftest.Helper) {
 		}
 
 		if !stateIsEmpty(statePreDestroy) {
-			runPostTestDestroy(t, c, wd, c.ProviderFactories)
+			err := runPostTestDestroy(t, c, wd, c.ProviderFactories)
+			if err != nil {
+				t.Fatalf("Error running post-test destroy, there may be dangling resources: %s", err.Error())
+			}
 		}
 
 		wd.Close()


### PR DESCRIPTION
We were silently discarding the error instead of surfacing it when there
was an error returned from our post-test destroy code responsible for
tearing down infrastructure. Let's tell the user so they know
infrastructure may be dangling, and can see what went wrong and ideally
fix it.

Fixes #571.