### PR TITLE
helper/resource: Remove data source exclusion from ExpectNonEmptyPlan handling

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -163,12 +163,6 @@ func stateIsEmpty(state *terraform.State) bool {
 
 func planIsEmpty(plan *tfjson.Plan) bool {
 	for _, rc := range plan.ResourceChanges {
-		if rc.Mode == tfjson.DataResourceMode {
-			// Skip data sources as the current implementation ignores
-			// existing state and they are all re-read every time
-			continue
-		}
-
 		for _, a := range rc.Change.Actions {
 			if a != tfjson.ActionNoop {
 				return false


### PR DESCRIPTION
Closes #593

Can confirm with this fixes the given acceptance test case while not presenting unexpected errors with other similar data source testing not using ExpectNonEmptyPlan.