### PR TITLE
Fix error context

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"errors"
 	"fmt"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -12,9 +13,6 @@ import (
 
 func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
 	t.Helper()
-
-	var idRefreshCheck *terraform.ResourceState
-	idRefresh := c.IDRefreshName != ""
 
 	if !step.Destroy {
 		var state *terraform.State
@@ -35,74 +33,77 @@ func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step Test
 		return fmt.Errorf("Error setting config: %w", err)
 	}
 
+	if step.PlanOnly {
+		return testStepNewPlanConfig(t, c, wd, step)
+	}
+	return testStepNewApplyConfig(t, c, wd, step)
+}
+
+func testStepNewApplyConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+
 	// require a refresh before applying
 	// failing to do this will result in data sources not being updated
-	err = runProviderCommand(t, func() error {
+	err := runProviderCommand(t, func() error {
 		return wd.Refresh()
 	}, wd, c.ProviderFactories)
 	if err != nil {
 		return fmt.Errorf("Error running pre-apply refresh: %w", err)
 	}
 
-	// If this step is a PlanOnly step, skip over this first Plan and
-	// subsequent Apply, and use the follow-up Plan that checks for
-	// permadiffs
-	if !step.PlanOnly {
-		// Plan!
-		err := runProviderCommand(t, func() error {
-			if step.Destroy {
-				return wd.CreateDestroyPlan()
+	// Plan!
+	err = runProviderCommand(t, func() error {
+		if step.Destroy {
+			return wd.CreateDestroyPlan()
+		}
+		return wd.CreatePlan()
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error running pre-apply plan: %w", err)
+	}
+
+	// We need to keep a copy of the state prior to destroying such
+	// that the destroy steps can verify their behavior in the
+	// check function
+	var stateBeforeApplication *terraform.State
+	err = runProviderCommand(t, func() error {
+		stateBeforeApplication = getState(t, wd)
+		return nil
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error retrieving pre-apply state: %w", err)
+	}
+
+	// Apply the diff, creating real resources
+	err = runProviderCommand(t, func() error {
+		return wd.Apply()
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		if step.Destroy {
+			return fmt.Errorf("Error running destroy: %w", err)
+		}
+		return fmt.Errorf("Error running apply: %w", err)
+	}
+
+	// Get the new state
+	var state *terraform.State
+	err = runProviderCommand(t, func() error {
+		state = getState(t, wd)
+		return nil
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error retrieving state after apply: %w", err)
+	}
+
+	// Run any configured checks
+	if step.Check != nil {
+		state.IsBinaryDrivenTest = true
+		if step.Destroy {
+			if err := step.Check(stateBeforeApplication); err != nil {
+				return fmt.Errorf("Check failed: %w", err)
 			}
-			return wd.CreatePlan()
-		}, wd, c.ProviderFactories)
-		if err != nil {
-			return fmt.Errorf("Error running pre-apply plan: %w", err)
-		}
-
-		// We need to keep a copy of the state prior to destroying such
-		// that the destroy steps can verify their behavior in the
-		// check function
-		var stateBeforeApplication *terraform.State
-		err = runProviderCommand(t, func() error {
-			stateBeforeApplication = getState(t, wd)
-			return nil
-		}, wd, c.ProviderFactories)
-		if err != nil {
-			return fmt.Errorf("Error retrieving pre-apply state: %w", err)
-		}
-
-		// Apply the diff, creating real resources
-		err = runProviderCommand(t, func() error {
-			return wd.Apply()
-		}, wd, c.ProviderFactories)
-		if err != nil {
-			if step.Destroy {
-				return fmt.Errorf("Error running destroy: %w", err)
-			}
-			return fmt.Errorf("Error running apply: %w", err)
-		}
-
-		// Get the new state
-		var state *terraform.State
-		err = runProviderCommand(t, func() error {
-			state = getState(t, wd)
-			return nil
-		}, wd, c.ProviderFactories)
-		if err != nil {
-			return fmt.Errorf("Error retrieving state after apply: %w", err)
-		}
-
-		// Run any configured checks
-		if step.Check != nil {
-			state.IsBinaryDrivenTest = true
-			if step.Destroy {
-				if err := step.Check(stateBeforeApplication); err != nil {
-					return fmt.Errorf("Check failed: %w", err)
-				}
-			} else {
-				if err := step.Check(state); err != nil {
-					return fmt.Errorf("Check failed: %w", err)
-				}
+		} else {
+			if err := step.Check(state); err != nil {
+				return fmt.Errorf("Check failed: %w", err)
 			}
 		}
 	}
@@ -186,43 +187,148 @@ func testStepNewConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step Test
 		}
 		return fmt.Errorf("After applying this test step and performing a `terraform refresh`, the plan was not empty.\nstdout\n\n%s", stdout)
 	} else if step.ExpectNonEmptyPlan && planIsEmpty(plan) {
-		return fmt.Errorf("Expected a non-empty plan, but got an empty plan!")
+		return errors.New("Expected a non-empty plan, but got an empty plan")
 	}
+
+	return testIDRefreshOnFirstResource(t, c, wd, step)
+}
+
+func testStepNewPlanConfig(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
+
+	// require a refresh before applying
+	// failing to do this will result in data sources not being updated
+	err := runProviderCommand(t, func() error {
+		return wd.Refresh()
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error running pre-plan refresh: %w", err)
+	}
+
+	// do a plan
+	err = runProviderCommand(t, func() error {
+		if step.Destroy {
+			return wd.CreateDestroyPlan()
+		}
+		return wd.CreatePlan()
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error running plan: %w", err)
+	}
+
+	var firstPlan *tfjson.Plan
+	err = runProviderCommand(t, func() error {
+		var err error
+		firstPlan, err = wd.SavedPlan()
+		return err
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error retrieving post-plan plan: %w", err)
+	}
+
+	if !planIsEmpty(firstPlan) && !step.ExpectNonEmptyPlan {
+		var stdout string
+		err = runProviderCommand(t, func() error {
+			var err error
+			stdout, err = wd.SavedPlanStdout()
+			return err
+		}, wd, c.ProviderFactories)
+		if err != nil {
+			return fmt.Errorf("Error retrieving formatted plan output: %w", err)
+		}
+		return fmt.Errorf("After planning this test step, the plan was not empty.\nstdout:\n\n%s", stdout)
+	}
+
+	// do a refresh
+	if !step.Destroy || (step.Destroy && !step.PreventPostDestroyRefresh) {
+		err := runProviderCommand(t, func() error {
+			return wd.Refresh()
+		}, wd, c.ProviderFactories)
+		if err != nil {
+			return fmt.Errorf("Error running post-apply refresh: %w", err)
+		}
+	}
+
+	// do another plan
+	err = runProviderCommand(t, func() error {
+		if step.Destroy {
+			return wd.CreateDestroyPlan()
+		}
+		return wd.CreatePlan()
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error running second post-apply plan: %w", err)
+	}
+
+	var secondPlan *tfjson.Plan
+	err = runProviderCommand(t, func() error {
+		var err error
+		secondPlan, err = wd.SavedPlan()
+		return err
+	}, wd, c.ProviderFactories)
+	if err != nil {
+		return fmt.Errorf("Error retrieving second post-apply plan: %w", err)
+	}
+
+	// TODO: Insert checking whether plans are the same
+
+	if !planIsEmpty(secondPlan) && !step.ExpectNonEmptyPlan {
+		var stdout string
+		err = runProviderCommand(t, func() error {
+			var err error
+			stdout, err = wd.SavedPlanStdout()
+			return err
+		}, wd, c.ProviderFactories)
+		if err != nil {
+			return fmt.Errorf("Error retrieving formatted second plan output: %w", err)
+		}
+		return fmt.Errorf("After planning this test step and performing a `terraform refresh`, the plan was not empty.\nstdout\n\n%s", stdout)
+	} else if step.ExpectNonEmptyPlan && planIsEmpty(secondPlan) {
+		return errors.New("Expected a non-empty plan, but got an empty plan")
+	}
+
+	return testIDRefreshOnFirstResource(t, c, wd, step)
+}
+
+func testIDRefreshOnFirstResource(t testing.T, c TestCase, wd *tftest.WorkingDir, step TestStep) error {
 
 	// ID-ONLY REFRESH
 	// If we've never checked an id-only refresh and our state isn't
 	// empty, find the first resource and test it.
 	var state *terraform.State
-	err = runProviderCommand(t, func() error {
+	err := runProviderCommand(t, func() error {
 		state = getState(t, wd)
 		return nil
 	}, wd, c.ProviderFactories)
 	if err != nil {
 		return err
 	}
-	if idRefresh && idRefreshCheck == nil && !state.Empty() {
-		// Find the first non-nil resource in the state
-		for _, m := range state.Modules {
-			if len(m.Resources) > 0 {
-				if v, ok := m.Resources[c.IDRefreshName]; ok {
-					idRefreshCheck = v
-				}
 
-				break
+	var idRefreshCheck *terraform.ResourceState
+	idRefresh := c.IDRefreshName != ""
+	if !idRefresh || idRefreshCheck != nil || state.Empty() {
+		return nil
+	}
+	// Find the first non-nil resource in the state
+	for _, m := range state.Modules {
+		if len(m.Resources) > 0 {
+			if v, ok := m.Resources[c.IDRefreshName]; ok {
+				idRefreshCheck = v
 			}
+
+			break
 		}
+	}
 
-		// If we have an instance to check for refreshes, do it
-		// immediately. We do it in the middle of another test
-		// because it shouldn't affect the overall state (refresh
-		// is read-only semantically) and we want to fail early if
-		// this fails. If refresh isn't read-only, then this will have
-		// caught a different bug.
-		if idRefreshCheck != nil {
-			if err := testIDRefresh(c, t, wd, step, idRefreshCheck); err != nil {
-				return fmt.Errorf(
-					"[ERROR] Test: ID-only test failed: %s", err)
-			}
+	// If we have an instance to check for refreshes, do it
+	// immediately. We do it in the middle of another test
+	// because it shouldn't affect the overall state (refresh
+	// is read-only semantically) and we want to fail early if
+	// this fails. If refresh isn't read-only, then this will have
+	// caught a different bug.
+	if idRefreshCheck != nil {
+		if err := testIDRefresh(c, t, wd, step, idRefreshCheck); err != nil {
+			return fmt.Errorf(
+				"[ERROR] Test: ID-only test failed: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Before errors where always in the apply "context". Now split code paths
into Apply <-> Plan. Thus the error messages can correctly reflect, which
mode they are running in.
Also has the effect that the code paths got a bit easier since
permutations are reduced and less conditionals are needed.