### PR TITLE
internal/plugintest: Output saved plans in human readable format

### DIFF
--- a/helper/resource/testing_new_config.go
+++ b/helper/resource/testing_new_config.go
@@ -144,7 +144,7 @@ func testStepNewConfig(t testing.T, c TestCase, wd *plugintest.WorkingDir, step 
 		var stdout string
 		err = runProviderCommand(t, func() error {
 			var err error
-			stdout, err = wd.SavedPlanStdout()
+			stdout, err = wd.SavedPlanRawStdout()
 			return err
 		}, wd, c.ProviderFactories)
 		if err != nil {
@@ -188,7 +188,7 @@ func testStepNewConfig(t testing.T, c TestCase, wd *plugintest.WorkingDir, step 
 		var stdout string
 		err = runProviderCommand(t, func() error {
 			var err error
-			stdout, err = wd.SavedPlanStdout()
+			stdout, err = wd.SavedPlanRawStdout()
 			return err
 		}, wd, c.ProviderFactories)
 		if err != nil {

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -231,11 +231,11 @@ func (wd *WorkingDir) SavedPlan() (*tfjson.Plan, error) {
 	return wd.tf.ShowPlanFile(context.Background(), wd.planFilename(), tfexec.Reattach(wd.reattachInfo))
 }
 
-// SavedPlanStdout returns a stdout capture of the current saved plan file, if any.
+// SavedPlanRawStdout returns a human readable stdout capture of the current saved plan file, if any.
 //
-// If no plan is saved or if the plan file cannot be read, SavedPlanStdout returns
+// If no plan is saved or if the plan file cannot be read, SavedPlanRawStdout returns
 // an error.
-func (wd *WorkingDir) SavedPlanStdout() (string, error) {
+func (wd *WorkingDir) SavedPlanRawStdout() (string, error) {
 	if !wd.HasSavedPlan() {
 		return "", fmt.Errorf("there is no current saved plan")
 	}
@@ -244,7 +244,7 @@ func (wd *WorkingDir) SavedPlanStdout() (string, error) {
 
 	wd.tf.SetStdout(&ret)
 	defer wd.tf.SetStdout(ioutil.Discard)
-	_, err := wd.tf.ShowPlanFile(context.Background(), wd.planFilename(), tfexec.Reattach(wd.reattachInfo))
+	_, err := wd.tf.ShowPlanFileRaw(context.Background(), wd.planFilename(), tfexec.Reattach(wd.reattachInfo))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/578
Closes #604

Restores v2.0.3 behavior and renames the function slightly for additional clarity on its intent.

Previously with consistently failing provider check:

```
=== CONT  TestAccAWSDmsReplicationTask_basic
TestAccAWSDmsReplicationTask_basic: resource_aws_dms_replication_task_test.go:18: Step 1/3 error: After applying this test step, the plan was not empty.
stdout:
{"format_version":"0.1","terraform_version":"0.12.29","planned_values":{"root_module":{"resources":[{"address":"aws_dms_endpoint.dms_endpoint_source","mode":"managed","type":"aws_dms_endpoint","name":"dms_endpoint_source","provider_name":"aws","schema_version":0,"values":{"certificate_arn":"","database_name":"tf-test-dms-db","elasticsearch_settings":[],"endpoint_arn":"arn:aws:dms:us-west-2:*******:endpoint:JIH35DGCIVAHLVA4L3H7S2QJKNIMW5K2X7LDSAY","endpoint_id":"tf-test-dms-endpoint-source-0qkeppvm","endpoint_type":"source","engine_name":"aurora","extra_connection_attributes":"","id":"tf-test-dms-endpoint-source-0qkeppvm","kafka_settings":[],"kinesis_settings":[],"kms_key_arn":"arn:aws:kms:us-west-2:*******:key/f5709827-76e0-4544-b2ec-9d09d1138bb1","mongodb_settings":[],"password":"tftest","port":3306,"s3_settings":[],"server_name":"tf-test-cluster.cluster-xxxxxxx.us-west-2.rds.amazonaws.com","service_access_role":null,"ssl_mode":"none","tags":null,"username":"tftest"}},{"address":"aws_dms_endpoint.dms_endpoint_target","mode":"managed","type":"aws_dms_endpoint","name":"dms_endpoint_target","provider_name":"aws","schema_version":0,"values":{"certificate_arn":"","database_name":"tf-test-dms-db","elasticsearch_settings":[],"endpoint_arn":"arn:...........
```

Now with local Go Module replace directive:

```
=== CONT  TestAccAWSDmsReplicationTask_basic
    resource_aws_dms_replication_task_test.go:18: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:

        An execution plan has been generated and is shown below.
        Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_dms_replication_task.dms_replication_task will be updated in-place
          ~ resource "aws_dms_replication_task" "dms_replication_task" {
                id                        = "tf-test-dms-replication-task-qsk63z02"
                migration_type            = "full-load"
                replication_instance_arn  = "arn:aws:dms:us-west-2:--OMITTED--:rep:AZCTZFYYTBQUNMNFP3LDR3A5RAC44QTLT36UC4I"
                replication_task_arn      = "arn:aws:dms:us-west-2:--OMITTED--:task:YS3DREABEI2X4KW46QHESNSZIBOAZXU4WLIPH5I"
                replication_task_id       = "tf-test-dms-replication-task-qsk63z02"
              ~ replication_task_settings = jsonencode(
                  ~ {
```