### PR TITLE
helper/validation: Wrapper function for legacy SchemaValidateFunc

### DIFF
--- a/helper/validation/meta.go
+++ b/helper/validation/meta.go
@@ -2,10 +2,11 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"reflect"
 )
 
 // NoZeroValues is a SchemaValidateFunc which tests if the provided value is

--- a/helper/validation/meta.go
+++ b/helper/validation/meta.go
@@ -64,7 +64,10 @@ func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc {
 func ToDiagFunc(validator schema.SchemaValidateFunc) schema.SchemaValidateDiagFunc {
 	return func(i interface{}, p cty.Path) diag.Diagnostics {
 		var diags diag.Diagnostics
-		ws, es := validator(i, "")
+
+		attr := p[len(p)-1].(cty.GetAttrStep)
+		ws, es := validator(i, attr.Name)
+
 		for _, w := range ws {
 			diags = append(diags, diag.Diagnostic{
 				Severity:      diag.Warning,

--- a/helper/validation/meta_test.go
+++ b/helper/validation/meta_test.go
@@ -99,3 +99,38 @@ func TestValidationAny(t *testing.T) {
 		},
 	})
 }
+
+func TestToDiagFunc(t *testing.T) {
+	runDiagTestCases(t, []diagTestCase{
+		{
+			val: 43,
+			f: ToDiagFunc(Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			)),
+		},
+		{
+			val: "foo",
+			f: ToDiagFunc(All(
+				StringLenBetween(1, 10),
+				StringIsNotWhiteSpace,
+			)),
+		},
+		{
+			val: 7,
+			f: ToDiagFunc(Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			)),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
+		},
+		{
+			val: 7,
+			f: ToDiagFunc(Any(
+				IntAtLeast(42),
+				IntAtMost(5),
+			)),
+			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
+		},
+	})
+}

--- a/helper/validation/testing.go
+++ b/helper/validation/testing.go
@@ -5,6 +5,8 @@ import (
 
 	testing "github.com/mitchellh/go-testing-interface"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,19 +16,14 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
+type diagTestCase struct {
+	val         interface{}
+	f           schema.SchemaValidateDiagFunc
+	expectedErr *regexp.Regexp
+}
+
 func runTestCases(t testing.T, cases []testCase) {
 	t.Helper()
-
-	matchErr := func(errs []error, r *regexp.Regexp) bool {
-		// err must match one provided
-		for _, err := range errs {
-			if r.MatchString(err.Error()) {
-				return true
-			}
-		}
-
-		return false
-	}
 
 	for i, tc := range cases {
 		_, errs := tc.f(tc.val, "test_property")
@@ -39,8 +36,50 @@ func runTestCases(t testing.T, cases []testCase) {
 			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
 		}
 
-		if !matchErr(errs, tc.expectedErr) {
+		if !matchAnyError(errs, tc.expectedErr) {
 			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
 		}
 	}
+}
+
+func matchAnyError(errs []error, r *regexp.Regexp) bool {
+	// err must match one provided
+	for _, err := range errs {
+		if r.MatchString(err.Error()) {
+			return true
+		}
+	}
+	return false
+}
+
+func runDiagTestCases(t testing.T, cases []diagTestCase) {
+	t.Helper()
+
+	for i, tc := range cases {
+		p := cty.Path{
+			cty.GetAttrStep{Name: "test_property"},
+		}
+		diags := tc.f(tc.val, p)
+
+		if !diags.HasError() && tc.expectedErr == nil {
+			continue
+		}
+
+		if diags.HasError() && tc.expectedErr == nil {
+			t.Fatalf("expected test case %d to produce no errors, got %v", i, diags)
+		}
+
+		if !matchAnyDiagSummary(diags, tc.expectedErr) {
+			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, diags)
+		}
+	}
+}
+
+func matchAnyDiagSummary(ds diag.Diagnostics, r *regexp.Regexp) bool {
+	for _, d := range ds {
+		if r.MatchString(d.Summary) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Adds a wrapper function for validation functions of type `SchemaValidateFunc` (https://github.com/hashicorp/terraform-plugin-sdk/issues/534). 📦

It follows a similar implementation as currently used in `schema.validateFunc` ([schema.go#L441-L456](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/helper/schema/schema.go#L441-L456))to handle legacy validation functions. This implementation parses the last step of given `cty.Path` to be used as the second parameter of the legacy validator.

This would help a lot of projects since no "diag" versions of the validation helpers are implemented yet.