### PR TITLE
Relax validation of ID attribute

### DIFF
--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -825,6 +825,7 @@ func TestResourceInternalValidate(t *testing.T) {
 				Schema: map[string]*Schema{
 					"id": {
 						Type:       TypeString,
+						Computed:   true,
 						Optional:   true,
 						Deprecated: "Use x_id instead",
 					},


### PR DESCRIPTION
Fixes #607

Currently in the `InternalValidate` validation, we prohibit any explicit overriding of the `id` attribute for resources in favor of writing an explicit version. But this does not allow modifying the `Optional` bit, or setting a custom `Description` which is useful for docs generation and the language server. This allows implementers to override the `id` if they so choose as long as it still adheres to the rules specified for the built-in usage.