### PR TITLE
helper/acctest: Generate 2048 bit long private keys in helper/acctest.RandTLSCert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ FEATURES
 * Ported TypeSet test check funcs essential for migrating to V2 of the SDK [GH-614]
 * Improved debug output for how to manually invoke the Terraform CLI [GH-615]
 
+ENHANCEMENTS
+* Generate 2048 bit long private keys with `helper/acctest.RandTLSCert` [GH-621]
+
 # 2.0.4 (October 06, 2020)
 
 BUG FIXES

--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -142,7 +142,7 @@ func RandIpAddress(s string) (string, error) {
 }
 
 func genPrivateKey() (*rsa.PrivateKey, string, error) {
-	privateKey, err := rsa.GenerateKey(crand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(crand.Reader, 2048)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
Generate 2048 bit long private keys in helper/acctest.RandTLSCert instead of 1024 bit long private keys.

This closes #621 