### PR TITLE
handle nil error values in diag.FromErr

### DIFF
--- a/diag/helpers.go
+++ b/diag/helpers.go
@@ -6,10 +6,11 @@ import "fmt"
 // as the most common use case in Go will be handling a single error
 // returned from a function.
 //
-//   if err != nil {
-//     return diag.FromErr(err)
-//   }
+//   return diag.FromErr(err)
 func FromErr(err error) Diagnostics {
+	if err == nil {
+		return nil
+	}
 	return Diagnostics{
 		Diagnostic{
 			Severity: Error,

--- a/diag/helpers.go
+++ b/diag/helpers.go
@@ -6,7 +6,9 @@ import "fmt"
 // as the most common use case in Go will be handling a single error
 // returned from a function.
 //
-//   return diag.FromErr(err)
+//   if err != nil {
+//     return diag.FromErr(err)
+//   }
 func FromErr(err error) Diagnostics {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Allow `nil` error values to be passed to `diag.FromErr`. This makes using `diag.FromErr` much more ergonomic when porting providers using the v1 SDK to the v2 SDK.

This semantic would have been useful in preventing https://github.com/digitalocean/terraform-provider-digitalocean/issues/505 which occurred because a `return err` was refactored to `return diag.FromErr(err)` in the v2 SDK upgrade without performing a `nil` check (as solved by https://github.com/digitalocean/terraform-provider-digitalocean/pull/506).