### PR TITLE
Adds HasChanges() to ResourceDiff

### DIFF
--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -421,6 +421,16 @@ func (d *ResourceDiff) NewValueKnown(key string) bool {
 	return !r.Computed
 }
 
+// HasChanges returns whether or not any of the given keys has been changed.
+func (d *ResourceDiff) HasChanges(keys ...string) bool {
+	for _, key := range keys {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
+}
+
 // HasChange checks to see if there is a change between state and the diff, or
 // in the overridden diff.
 func (d *ResourceDiff) HasChange(key string) bool {

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -2044,3 +2044,107 @@ func TestResourceDiffNewValueKnownSetNewComputed(t *testing.T) {
 		t.Fatalf("expected ok: %t, got: %t", tc.Expected, actual)
 	}
 }
+
+func TestResourceDiffHasChanges(t *testing.T) {
+	cases := []struct {
+		Schema map[string]*Schema
+		State  *terraform.InstanceState
+		Diff   *terraform.InstanceDiff
+		Keys   []string
+		Change bool
+	}{
+		// empty call d.HasChanges()
+		{
+			Schema: map[string]*Schema{},
+
+			State: nil,
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{},
+			},
+
+			Keys: []string{},
+
+			Change: false,
+		},
+		// neither has change
+		{
+			Schema: map[string]*Schema{
+				"a": {
+					Type: TypeString,
+				},
+				"b": {
+					Type: TypeString,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"a": "foo",
+					"b": "foo",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"a": {
+						Old: "",
+						New: "foo",
+					},
+					"b": {
+						Old: "",
+						New: "foo",
+					},
+				},
+			},
+
+			Keys: []string{"a", "b"},
+
+			Change: false,
+		},
+		// one key has change
+		{
+			Schema: map[string]*Schema{
+				"a": {
+					Type: TypeString,
+				},
+				"b": {
+					Type: TypeString,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"a": "foo",
+					"b": "foo",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"a": {
+						Old: "",
+						New: "bar",
+					},
+					"b": {
+						Old: "",
+						New: "foo",
+					},
+				},
+			},
+
+			Keys: []string{"a", "b"},
+
+			Change: true,
+		},
+	}
+
+	for i, tc := range cases {
+		d := newResourceDiff(tc.Schema, testConfig(t, map[string]interface{}{}), tc.State, tc.Diff)
+
+		actual := d.HasChanges(tc.Keys...)
+		if actual != tc.Change {
+			t.Fatalf("Bad: %d %#v", i, actual)
+		}
+	}
+}

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -930,16 +930,22 @@ func isValidFieldName(name string) bool {
 	return re.MatchString(name)
 }
 
-// resourceDiffer is an interface that is used by the private diff functions.
+// ResourceDiffer is an interface that exposes value and value change information.
 // This helps facilitate diff logic for both ResourceData and ResoureDiff with
 // minimal divergence in code.
-type resourceDiffer interface {
-	diffChange(string) (interface{}, interface{}, bool, bool, bool)
+type ResourceDiffer interface {
 	Get(string) interface{}
 	GetChange(string) (interface{}, interface{})
 	GetOk(string) (interface{}, bool)
 	HasChange(string) bool
+	HasChanges(...string) bool
 	Id() string
+}
+
+// resourceDiffer extends ResourceDiffer with unexported functions.
+type resourceDiffer interface {
+	ResourceDiffer
+	diffChange(string) (interface{}, interface{}, bool, bool, bool)
 }
 
 func (m schemaMap) diff(

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -930,22 +930,17 @@ func isValidFieldName(name string) bool {
 	return re.MatchString(name)
 }
 
-// ResourceDiffer is an interface that exposes value and value change information.
+// resourceDiffer is an interface that is used by the private diff functions.
 // This helps facilitate diff logic for both ResourceData and ResoureDiff with
 // minimal divergence in code.
-type ResourceDiffer interface {
+type resourceDiffer interface {
+	diffChange(string) (interface{}, interface{}, bool, bool, bool)
 	Get(string) interface{}
 	GetChange(string) (interface{}, interface{})
 	GetOk(string) (interface{}, bool)
 	HasChange(string) bool
 	HasChanges(...string) bool
 	Id() string
-}
-
-// resourceDiffer extends ResourceDiffer with unexported functions.
-type resourceDiffer interface {
-	ResourceDiffer
-	diffChange(string) (interface{}, interface{}, bool, bool, bool)
 }
 
 func (m schemaMap) diff(


### PR DESCRIPTION
The following changes will enable shared diff checking functions both during Diff phase and during CRUD operations. Currently, if there is shared logic, the functions look similar to (from https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/data_source_aws_lambda_function.go):

```go
type resourceDiffer interface {
	HasChange(string) bool
}

func needsFunctionCodeUpdate(d resourceDiffer) bool {
	return d.HasChange("filename") || d.HasChange("source_code_hash") || d.HasChange("s3_bucket") || d.HasChange("s3_key") || d.HasChange("s3_object_version")
}

func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
	if needsFunctionCodeUpdate(d) {
		...
	}
}

func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
	...
	codeUpdate := needsFunctionCodeUpdate(d)
	if codeUpdate {
		...
	}
	...
}
```

[`tfproviderlint`](https://github.com/bflad/tfproviderlint) provides the check [R005](https://github.com/bflad/tfproviderlint/blob/master/passes/R005/README.md) which checks for `ResourceData.HasChange()` calls that can be combined into one `ResourceData.HasChanges()` call. This currently does not work with `ResourceDiff`.

With these changes, the calls to `HasChange()` in the example above can be replaced with a single call to 

```go
HasChanges("filename", "source_code_hash", "s3_bucket", "s3_key", "s3_object_version")
```

Closes #852