### PR TITLE
helper/schema: Return error for provider reconfiguration

### DIFF
--- a/helper/schema/provider_configuration_error.go
+++ b/helper/schema/provider_configuration_error.go
@@ -1,0 +1,22 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ProviderReconfiguredError = errors.New("reconfigured")
+
+// ProviderConfigurationError is the error type for provider configuration
+type ProviderConfigurationError struct {
+	Provider *Provider
+	Err      error
+}
+
+func (e *ProviderConfigurationError) Error() string {
+	return fmt.Sprintf("error configuring provider: %s", e.Err.Error())
+}
+
+func (e *ProviderConfigurationError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Closes #636

Implementation idea 2 where the SDK returns errors for this situation. For implementation idea 1 (warning log), see https://github.com/hashicorp/terraform-plugin-sdk/pull/636.

In practice, this looks like the following where the messaging could be further enhanced by the acceptance testing framework:

```
=== CONT  TestAccAWSEIPAssociation_instance
=== CONT  TestAccAWSEIPAssociation_ec2Classic
=== CONT  TestAccAWSEIPAssociation_instance
    resource_aws_eip_association_test.go:18: Step 1/2 error: Error running pre-apply refresh: 2020/11/04 14:15:04 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: error configuring provider: reconfigured

--- FAIL: TestAccAWSEIPAssociation_instance (1.76s)
=== CONT  TestAccAWSEIPAssociation_ec2Classic
    resource_aws_eip_association_test.go:97: Step 1/2 error: Error running pre-apply refresh: 2020/11/04 14:15:05 [DEBUG] Using modified User-Agent: Terraform/0.12.29 HashiCorp-terraform-exec/0.10.0

        Error: error configuring provider: reconfigured

--- FAIL: TestAccAWSEIPAssociation_ec2Classic (2.10s)
```