### PR TITLE
Adds Unwrap function to SDK errors

### DIFF
--- a/helper/resource/error.go
+++ b/helper/resource/error.go
@@ -26,6 +26,10 @@ func (e *NotFoundError) Error() string {
 	return "couldn't find resource"
 }
 
+func (e *NotFoundError) Unwrap() error {
+	return e.LastError
+}
+
 // UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
 type UnexpectedStateError struct {
 	LastError     error
@@ -40,6 +44,10 @@ func (e *UnexpectedStateError) Error() string {
 		strings.Join(e.ExpectedState, ", "),
 		e.LastError,
 	)
+}
+
+func (e *UnexpectedStateError) Unwrap() error {
+	return e.LastError
 }
 
 // TimeoutError is returned when WaitForState times out
@@ -76,4 +84,8 @@ func (e *TimeoutError) Error() string {
 
 	return fmt.Sprintf("timeout while waiting for %s%s",
 		expectedState, suffix)
+}
+
+func (e *TimeoutError) Unwrap() error {
+	return e.LastError
 }

--- a/helper/resource/wait.go
+++ b/helper/resource/wait.go
@@ -78,6 +78,10 @@ type RetryError struct {
 	Retryable bool
 }
 
+func (e *RetryError) Unwrap() error {
+	return e.Err
+}
+
 // RetryableError is a helper to create a RetryError that's retryable from a
 // given error. To prevent logic errors, will return an error when passed a
 // nil error.


### PR DESCRIPTION
To help support the [Go 1.13 `error` enhancements](https://blog.golang.org/go1.13-errors), i.e. `errors.Is()`, `errors.As()` and the `%w` verb, this PR adds the `Unwrap()` function to the exported errors from the SDK.