### PR TITLE
Avoid panics when testing nested sets of varying depth

### DIFF
--- a/helper/resource/testing_sets.go
+++ b/helper/resource/testing_sets.go
@@ -214,7 +214,7 @@ func testCheckTypeSetElemNestedAttrsInState(is *terraform.InstanceState, attrPar
 		// a Set/List item with nested attrs would have a flatmap address of
 		// at least length 3
 		// foo.0.name = "bar"
-		if len(stateKeyParts) < 3 {
+		if len(stateKeyParts) < 3 || len(attrParts) > len(stateKeyParts) {
 			continue
 		}
 		var pathMatch bool

--- a/helper/resource/testing_sets_test.go
+++ b/helper/resource/testing_sets_test.go
@@ -2078,6 +2078,105 @@ func TestTestCheckTypeSetElemNestedAttrs(t *testing.T) {
 			},
 		},
 		{
+			Description:       "single root TypeSet attribute single nested value match with varying depths",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "groups.*.groups.*.groups.*",
+			Values: map[string]string{
+				"gid": "group ID 3",
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                                   "2",
+										"id":                                  "resource ID",
+										"groups.%":                            "2",
+										"groups.#":                            "2",
+										"groups.0.%":                          "2",
+										"groups.0.gid":                        "group ID 0",
+										"groups.0.groups.#":                   "0",
+										"groups.1.%":                          "2",
+										"groups.1.gid":                        "group ID 1",
+										"groups.1.groups.#":                   "1",
+										"groups.1.groups.0.%":                 "2",
+										"groups.1.groups.0.gid":               "group ID 2",
+										"groups.1.groups.0.groups.#":          "1",
+										"groups.1.groups.0.groups.0.%":        "2",
+										"groups.1.groups.0.groups.0.gid":      "group ID 3",
+										"groups.1.groups.0.groups.0.groups.#": "0",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+		},
+		{
+			Description:       "single root TypeSet attribute single nested value mismatch with varying depths",
+			ResourceAddress:   "example_thing.test",
+			ResourceAttribute: "groups.*.groups.*.groups.*",
+			Values: map[string]string{
+				"gid": "group ID 7",
+			},
+			TerraformState: &terraform.State{
+				Version: 3,
+				Modules: []*terraform.ModuleState{
+					{
+						Path:    []string{"root"},
+						Outputs: map[string]*terraform.OutputState{},
+						Resources: map[string]*terraform.ResourceState{
+							"example_thing.test": {
+								Type:     "example_thing",
+								Provider: "example",
+								Primary: &terraform.InstanceState{
+									ID: "11111",
+									Meta: map[string]interface{}{
+										"schema_version": 0,
+									},
+									Attributes: map[string]string{
+										"%":                                   "2",
+										"id":                                  "resource ID",
+										"groups.%":                            "2",
+										"groups.#":                            "2",
+										"groups.0.%":                          "2",
+										"groups.0.gid":                        "group ID 0",
+										"groups.0.groups.#":                   "0",
+										"groups.1.%":                          "2",
+										"groups.1.gid":                        "group ID 1",
+										"groups.1.groups.#":                   "1",
+										"groups.1.groups.0.%":                 "2",
+										"groups.1.groups.0.gid":               "group ID 2",
+										"groups.1.groups.0.groups.#":          "1",
+										"groups.1.groups.0.groups.0.%":        "2",
+										"groups.1.groups.0.groups.0.gid":      "group ID 3",
+										"groups.1.groups.0.groups.0.groups.#": "0",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
+				},
+			},
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "\"example_thing.test\" no TypeSet element \"groups.*.groups.*.groups.*\"")
+			},
+		},
+		{
 			Description:       "single root TypeSet attribute single nested value mismatch",
 			ResourceAddress:   "example_thing.test",
 			ResourceAttribute: "test.*",


### PR DESCRIPTION
I encountered a panic when I have a hierarchical attribute where the depth of the hierarchy isn't necessarily the same for all  objects. The panic is caused by an out of bounds slice index in cases where you specify an attribute path greater than or equal to the deepest structure in state when using `TestCheckTypeSetElemNestedAttrs()`.

example - Let's say there are groups that can have sub-groups. Your state contains 4 groups and three of them are in a chain and the other has no sub-groups:

```
group1 <- group 2 <- group3

group4
```

When a unit test tries to match `TestCheckTypeSetElemNestedAttrs("groups.*.groups.*.groups.*", map[string]string{"name": expectedName})`, it will panic because `groups.*.groups.*.groups.*` causes the check to index too far into group4.
