### PR TITLE
Handle corner case in ResourceConfig.get

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -299,7 +299,7 @@ func (c *ResourceConfig) get(
 				}
 				current = cv.Index(int(i)).Interface()
 			}
-		case reflect.String:
+		default:
 			// This happens when map keys contain "." and have a common
 			// prefix so were split as path components above.
 			actualKey := strings.Join(parts[i-1:], ".")
@@ -309,8 +309,6 @@ func (c *ResourceConfig) get(
 			}
 
 			return nil, false
-		default:
-			panic(fmt.Sprintf("Unknown kind: %s", cv.Kind()))
 		}
 	}
 

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -181,8 +181,8 @@ func TestResourceConfigGet(t *testing.T) {
 		{
 			Config: cty.ObjectVal(map[string]cty.Value{
 				"mapname": cty.MapVal(map[string]cty.Value{
-					        "key:name":     cty.NumberIntVal(1),
-					        "key:name.suffix": cty.NumberIntVal(2),
+					"key:name":        cty.NumberIntVal(1),
+					"key:name.suffix": cty.NumberIntVal(2),
 				}),
 			}),
 			Schema: &configschema.Block{

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -178,6 +178,21 @@ func TestResourceConfigGet(t *testing.T) {
 			Key:   "mapname.0.listkey.0.key",
 			Value: 3,
 		},
+		{
+			Config: cty.ObjectVal(map[string]cty.Value{
+				"mapname": cty.MapVal(map[string]cty.Value{
+					        "key:name":     cty.NumberIntVal(1),
+					        "key:name.suffix": cty.NumberIntVal(2),
+				}),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"mapname": {Type: cty.Map(cty.Number), Optional: true},
+				},
+			},
+			Key:   "mapname.key:name.suffix",
+			Value: 2,
+		},
 	}
 
 	for i, tc := range cases {

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -181,17 +181,17 @@ func TestResourceConfigGet(t *testing.T) {
 		{
 			Config: cty.ObjectVal(map[string]cty.Value{
 				"mapname": cty.MapVal(map[string]cty.Value{
-					"key:name":        cty.NumberIntVal(1),
-					"key:name.suffix": cty.NumberIntVal(2),
+					"key:name":        cty.BoolVal(true),
+					"key:name.suffix": cty.BoolVal(false),
 				}),
 			}),
 			Schema: &configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
-					"mapname": {Type: cty.Map(cty.Number), Optional: true},
+					"mapname": {Type: cty.Map(cty.Bool), Optional: true},
 				},
 			},
 			Key:   "mapname.key:name.suffix",
-			Value: 2,
+			Value: false,
 		},
 	}
 


### PR DESCRIPTION
In some cases parsing of map with specifically formatted keys can create
a panic. This was handled for string values, but not integer ones: this
fixes it and add a test for it.

Fixes #658