### PR TITLE
Drop logging override.

### DIFF
--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugintest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -177,10 +176,6 @@ func runProviderCommand(t testing.T, f func() error, wd *plugintest.WorkingDir, 
 				String:  config.Addr.String,
 			},
 		}
-
-		// plugin.DebugServe hijacks our log output location, so let's
-		// reset it
-		logging.SetOutput(t)
 
 		// when the provider exits, remove one from the waitgroup
 		// so we can track when everything is done


### PR DESCRIPTION
Missed a logging override in #663. This should fix the last of the race
condition where logging can get written to stderr unexpectedly during
tests. We no longer need to do this because go-plugin was fixed and we
upgraded in #639. We don't want to overwrite that fix in tests.