### PR TITLE
Stop overriding log output in plugin.Serve in tests

### DIFF
--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -85,6 +85,7 @@ func runProviderCommand(t testing.T, f func() error, wd *plugintest.WorkingDir, 
 				Level:  hclog.Trace,
 				Output: ioutil.Discard,
 			}),
+			NoLogOutputOverride: true,
 		}
 
 		// let's actually start the provider server
@@ -160,6 +161,7 @@ func runProviderCommand(t testing.T, f func() error, wd *plugintest.WorkingDir, 
 				Level:  hclog.Trace,
 				Output: ioutil.Discard,
 			}),
+			NoLogOutputOverride: true,
 		}
 
 		// let's actually start the provider server


### PR DESCRIPTION
When testing, we don't want to override where log output gets sent--the
test framework takes care of that itself. go-plugin has disabled its use
of log.SetOutput for us, but #639 introduced a log.SetOutput in
plugin.Serve. This adds a plugin.ServeOpt property to disable that
log.SetOutput call so we can finally have tests where log lines don't
randomly show up in test output.