### PR TITLE
Stop using json.Number when decoding Private.

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -555,7 +555,7 @@ func (s *GRPCProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Re
 
 	private := make(map[string]interface{})
 	if len(req.Private) > 0 {
-		if err := unmarshalJSON(req.Private, &private); err != nil {
+		if err := json.Unmarshal(req.Private, &private); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}
@@ -663,7 +663,7 @@ func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprot
 	}
 	priorPrivate := make(map[string]interface{})
 	if len(req.PriorPrivate) > 0 {
-		if err := unmarshalJSON(req.PriorPrivate, &priorPrivate); err != nil {
+		if err := json.Unmarshal(req.PriorPrivate, &priorPrivate); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}
@@ -877,7 +877,7 @@ func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfpro
 
 	private := make(map[string]interface{})
 	if len(req.PlannedPrivate) > 0 {
-		if err := unmarshalJSON(req.PlannedPrivate, &private); err != nil {
+		if err := json.Unmarshal(req.PlannedPrivate, &private); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}


### PR DESCRIPTION
Our Timeouts code can't handle it yet.