### PR TITLE
Use better command for module version detection.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ labels: bug
 <!---
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-sdk/v2
+go list -m github.com/hashicorp/terraform-plugin-sdk/...
 
 If you are not running the latest version of the SDK, please try upgrading
 because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ labels: bug
 <!---
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk/v2")'
+go list -m github.com/hashicorp/terraform-plugin-sdk/v2
 
 If you are not running the latest version of the SDK, please try upgrading
 because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-sdk/v2")'
+go list -m github.com/hashicorp/terraform-plugin-sdk/v2
 
 If you are not running the latest version of the SDK, please try upgrading
 because your feature may have already been implemented.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-sdk/v2
+go list -m github.com/hashicorp/terraform-plugin-sdk/...
 
 If you are not running the latest version of the SDK, please try upgrading
 because your feature may have already been implemented.


### PR DESCRIPTION
Update the issue templates to show a command that retrieves the current
version of the module without relying on jq or any other tooling beyond
the `go` command.

Fixes #641.