### PR TITLE
Surface the required block that's missing in the error.

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1447,7 +1447,8 @@ func (m schemaMap) validate(
 		if schema.Required {
 			return append(diags, diag.Diagnostic{
 				Severity:      diag.Error,
-				Summary:       "Required attribute is not set",
+				Summary:       "Missing required argument",
+				Detail:        fmt.Sprintf("The argument %q is required, but no definition was found.", k),
 				AttributePath: path,
 			})
 		}
@@ -1458,7 +1459,8 @@ func (m schemaMap) validate(
 		// This is a computed-only field
 		return append(diags, diag.Diagnostic{
 			Severity:      diag.Error,
-			Summary:       "Computed attribute cannot be set",
+			Summary:       "Computed attributes cannot be set",
+			Detail:        fmt.Sprintf("Computed attributes cannot be set, but a value was set for %q.", k),
 			AttributePath: path,
 		})
 	}


### PR DESCRIPTION
Our current diagnostic only surfaces that a required argument was not
set, but doesn't actually tell you which one. This updates the error
message to match the error returned by core, which includes the name of
the field that's missing.

Why do we return an error if core returns an error? Because core returns
the error only for required _attributes_, because as far as core is
concerned, there is no such thing as required blocks. Only attributes
can have flags, and "required" is a flag, so there can't be "required"
blocks.

But historically blocks have been able to be required, so the SDK fakes
it by doing provider-side validation on the block. But the error message
was less than helpful. This fixes the error message to be more
actionable.

Fixes #535.