### PR TITLE
Cache ObjectSpec on Block

### DIFF
--- a/internal/configs/configschema/decoder_spec.go
+++ b/internal/configs/configschema/decoder_spec.go
@@ -18,6 +18,10 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 		return ret
 	}
 
+	if b.Spec != nil {
+		return *b.Spec
+	}
+
 	for name, attrS := range b.Attributes {
 		ret[name] = attrS.decoderSpec(name)
 	}
@@ -110,6 +114,8 @@ func (b *Block) DecoderSpec() hcldec.Spec {
 			continue
 		}
 	}
+
+	b.Spec = &ret
 
 	return ret
 }

--- a/internal/configs/configschema/schema.go
+++ b/internal/configs/configschema/schema.go
@@ -1,6 +1,7 @@
 package configschema
 
 import (
+	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -41,6 +42,9 @@ type Block struct {
 	// Deprecated indicates whether the block has been marked as deprecated in the
 	// provider and usage should be discouraged.
 	Deprecated bool
+
+	// Cache result of DecoderSpec
+	Spec *hcldec.ObjectSpec
 }
 
 // Attribute represents a configuration attribute, within a block.


### PR DESCRIPTION
This seems to be a big performance hit on complex schema. We observed that on the Datadog provider, where our dashboard resource has a really big schema. This shows up in usage and easily in CI.

Before: 183 tests in 733.311s
After: 183 tests in 94.616s

This patch is against v1 as that's what we use currently, but I believe the same approach can be used in v2, and with the same impact.

This basically a backport to v1 of https://github.com/hashicorp/terraform/pull/26577. The interesting part is that it's in the SDK, not in terraform. I'm looking out to see if the fix is still applicable to v2.