### PR TITLE
Make binary testing compatible with Terraform 0.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl/v2 v2.3.0
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-exec v0.12.0
+	github.com/hashicorp/terraform-exec v0.13.0
 	github.com/hashicorp/terraform-json v0.8.0
 	github.com/hashicorp/terraform-plugin-go v0.2.1
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggU
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.12.0 h1:Tb1VC2gqArl9EJziJjoazep2MyxMk00tnNKV/rgMba0=
-github.com/hashicorp/terraform-exec v0.12.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29UZIa8kpBbkGwQ+g9E8=
+github.com/hashicorp/terraform-exec v0.13.0 h1:1Pth+pdWJAufJuWWjaVOVNEkoRTOjGn3hQpAqj4aPdg=
+github.com/hashicorp/terraform-exec v0.13.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29UZIa8kpBbkGwQ+g9E8=
 github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
 github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-plugin-go v0.2.1 h1:EW/R8bB2Zbkjmugzsy1d27yS8/0454b3MtYHkzOknqA=

--- a/internal/plugintest/helper.go
+++ b/internal/plugintest/helper.go
@@ -107,12 +107,6 @@ func (h *Helper) NewWorkingDir() (*WorkingDir, error) {
 		return nil, err
 	}
 
-	// symlink the provider source files into the base directory
-	err = symlinkDirectoriesOnly(h.sourceDir, dir)
-	if err != nil {
-		return nil, err
-	}
-
 	return &WorkingDir{
 		h:             h,
 		baseDir:       dir,

--- a/internal/plugintest/helper.go
+++ b/internal/plugintest/helper.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
 const subprocessCurrentSigil = "4acd63807899403ca4859f5bb948d2c6"
@@ -107,8 +109,21 @@ func (h *Helper) NewWorkingDir() (*WorkingDir, error) {
 		return nil, err
 	}
 
+	// symlink the provider source files into the config directory
+	// e.g. testdata
+	err = symlinkDirectoriesOnly(h.sourceDir, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	tf, err := tfexec.NewTerraform(dir, h.terraformExec)
+	if err != nil {
+		return nil, err
+	}
+
 	return &WorkingDir{
 		h:             h,
+		tf:            tf,
 		baseDir:       dir,
 		terraformExec: h.terraformExec,
 	}, nil

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -13,6 +13,11 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
+const (
+	ConfigFileName = "terraform_plugin_test.tf"
+	PlanFileName   = "tfplan"
+)
+
 // WorkingDir represents a distinct working directory that can be used for
 // running tests. Each test should construct its own WorkingDir by calling
 // NewWorkingDir or RequireNewWorkingDir on its package's singleton
@@ -25,9 +30,6 @@ type WorkingDir struct {
 
 	// baseArgs is arguments that should be appended to all commands
 	baseArgs []string
-
-	// configDir contains the singular config file generated for each test
-	configDir string
 
 	// tf is the instance of tfexec.Terraform used for running Terraform commands
 	tf *tfexec.Terraform
@@ -75,61 +77,31 @@ func (wd *WorkingDir) GetHelper() *Helper {
 	return wd.h
 }
 
-func (wd *WorkingDir) relativeConfigDir() (string, error) {
-	relPath, err := filepath.Rel(wd.baseDir, wd.configDir)
-	if err != nil {
-		return "", fmt.Errorf("Error determining relative path of configuration directory: %w", err)
-	}
-	return relPath, nil
-}
-
 // SetConfig sets a new configuration for the working directory.
 //
 // This must be called at least once before any call to Init, Plan, Apply, or
 // Destroy to establish the configuration. Any previously-set configuration is
 // discarded and any saved plan is cleared.
 func (wd *WorkingDir) SetConfig(cfg string) error {
-	// Each call to SetConfig creates a new directory under our baseDir.
-	// We create them within so that our final cleanup step will delete them
-	// automatically without any additional tracking.
-	configDir, err := ioutil.TempDir(wd.baseDir, "config")
-	if err != nil {
-		return err
-	}
-	configFilename := filepath.Join(configDir, "terraform_plugin_test.tf")
-	err = ioutil.WriteFile(configFilename, []byte(cfg), 0700)
-	if err != nil {
-		return err
-	}
-
-	// symlink the provider source files into the config directory
-	// e.g. testdata
-	err = symlinkDirectoriesOnly(wd.h.sourceDir, configDir)
-	if err != nil {
-		return err
-	}
-
-	tf, err := tfexec.NewTerraform(configDir, wd.terraformExec)
+	configFilename := filepath.Join(wd.baseDir, ConfigFileName)
+	err := ioutil.WriteFile(configFilename, []byte(cfg), 0700)
 	if err != nil {
 		return err
 	}
 
 	var mismatch *tfexec.ErrVersionMismatch
-	err = tf.SetDisablePluginTLS(true)
+	err = wd.tf.SetDisablePluginTLS(true)
 	if err != nil && !errors.As(err, &mismatch) {
 		return err
 	}
-	err = tf.SetSkipProviderVerify(true)
+	err = wd.tf.SetSkipProviderVerify(true)
 	if err != nil && !errors.As(err, &mismatch) {
 		return err
 	}
 
 	if p := os.Getenv("TF_ACC_LOG_PATH"); p != "" {
-		tf.SetLogPath(p)
+		wd.tf.SetLogPath(p)
 	}
-
-	wd.configDir = configDir
-	wd.tf = tf
 
 	// Changing configuration invalidates any saved plan.
 	err = wd.ClearPlan()
@@ -144,7 +116,7 @@ func (wd *WorkingDir) SetConfig(cfg string) error {
 // Any remote objects tracked by the state are not destroyed first, so this
 // will leave them dangling in the remote system.
 func (wd *WorkingDir) ClearState() error {
-	err := os.Remove(filepath.Join(wd.configDir, "terraform.tfstate"))
+	err := os.Remove(filepath.Join(wd.baseDir, "terraform.tfstate"))
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -163,28 +135,32 @@ func (wd *WorkingDir) ClearPlan() error {
 // Init runs "terraform init" for the given working directory, forcing Terraform
 // to use the current version of the plugin under test.
 func (wd *WorkingDir) Init() error {
-	if wd.configDir == "" {
+	if _, err := os.Stat(wd.configFilename()); err != nil {
 		return fmt.Errorf("must call SetConfig before Init")
 	}
 
 	return wd.tf.Init(context.Background(), tfexec.Reattach(wd.reattachInfo))
 }
 
+func (wd *WorkingDir) configFilename() string {
+	return filepath.Join(wd.baseDir, ConfigFileName)
+}
+
 func (wd *WorkingDir) planFilename() string {
-	return filepath.Join(wd.configDir, "tfplan")
+	return filepath.Join(wd.baseDir, PlanFileName)
 }
 
 // CreatePlan runs "terraform plan" to create a saved plan file, which if successful
 // will then be used for the next call to Apply.
 func (wd *WorkingDir) CreatePlan() error {
-	_, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out("tfplan"))
+	_, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out(PlanFileName))
 	return err
 }
 
 // CreateDestroyPlan runs "terraform plan -destroy" to create a saved plan
 // file, which if successful will then be used for the next call to Apply.
 func (wd *WorkingDir) CreateDestroyPlan() error {
-	_, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out("tfplan"), tfexec.Destroy(true))
+	_, err := wd.tf.Plan(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false), tfexec.Out(PlanFileName), tfexec.Destroy(true))
 	return err
 }
 
@@ -195,7 +171,7 @@ func (wd *WorkingDir) CreateDestroyPlan() error {
 func (wd *WorkingDir) Apply() error {
 	args := []tfexec.ApplyOption{tfexec.Reattach(wd.reattachInfo), tfexec.Refresh(false)}
 	if wd.HasSavedPlan() {
-		args = append(args, tfexec.DirOrPlan("tfplan"))
+		args = append(args, tfexec.DirOrPlan(PlanFileName))
 	}
 
 	return wd.tf.Apply(context.Background(), args...)
@@ -260,12 +236,12 @@ func (wd *WorkingDir) State() (*tfjson.State, error) {
 
 // Import runs terraform import
 func (wd *WorkingDir) Import(resource, id string) error {
-	return wd.tf.Import(context.Background(), resource, id, tfexec.Config(wd.configDir), tfexec.Reattach(wd.reattachInfo))
+	return wd.tf.Import(context.Background(), resource, id, tfexec.Config(wd.baseDir), tfexec.Reattach(wd.reattachInfo))
 }
 
 // Refresh runs terraform refresh
 func (wd *WorkingDir) Refresh() error {
-	return wd.tf.Refresh(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.State(filepath.Join(wd.configDir, "terraform.tfstate")))
+	return wd.tf.Refresh(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.State(filepath.Join(wd.baseDir, "terraform.tfstate")))
 }
 
 // Schemas returns an object describing the provider schemas.


### PR DESCRIPTION
Terraform 0.15 deprecates a number of CLI arguments, including the `[DIR]` positional argument used in `terraform init` and `terraform apply`. The binary test framework made use of these arguments as a way of working around plugin source limitations in v1. This workaround is no longer needed.

The main difference here is that previously we would instantiate one `tfexec.Terraform` per test config file, but `wd.workDir` set as the working directory. Since we no longer have to symlink the plugin binary itself in `wd.workDir`, we can now just use `wd.configDir` as the Terraform working dir instead.

Provider source files (testdata in directories alongside test source files) must still be symlinked into the Terraform working directory. Since this is now `wd.configDir`, not `wd.workDir`, and each `wd.workDir` has several `wd.configDirs`, this symlinking must unfortunately be carried out more often. Performance should not be impacted as we should still be symlinking only a small number of directories.

Example test temp directory structure before this change:

```
/tmp/plugintest594266265
└── work819712804
    ├── config403653211
    │   └── terraform_plugin_test.tf
    ├── config502955059
    │   └── terraform_plugin_test.tf
    ├── terraform.tfstate
    ├── testdata -> /home/katy/dev/go/src/github.com/hashicorp/terraform-provider-random/internal/provider/testdata
    └── tfplan

```

Example test temp directory structure after this change:
```
/tmp/plugintest099393048
└── work460918423
    ├── config243863818
    │   ├── terraform_plugin_test.tf
    │   └── testdata -> /home/katy/dev/go/src/github.com/hashicorp/terraform-provider-random/internal/provider/testdata
    └── config848766255
        ├── terraform_plugin_test.tf
        ├── terraform.tfstate
        ├── testdata -> /home/katy/dev/go/src/github.com/hashicorp/terraform-provider-random/internal/provider/testdata
        └── tfplan
```

## Update following 515c54261

In order to reinstate the automatic persistence of `terraform.tfstate` between test steps, 515c54261 simplifies the test temp directory structure by removing config dirs altogether. The structure is now:

```
/tmp/plugintest594266265
└── work819712804
    ├── terraform_plugin_test.tf
    ├── terraform.tfstate
    ├── testdata -> /home/katy/dev/go/src/github.com/hashicorp/terraform-provider-random/internal/provider/testdata
    └── tfplan
```
where `terraform_plugin_test.tf` gets overwritten each time a new test config is set.

## Testing

Tested this change locally with the following providers:
 - `terraform-provider-random`
 - `terraform-provider-archive`
 - `terraform-provider-dns`

and the following Terraform versions:
 - 0.14.5
 - `master` as of 2nd February 2021 (c8f83e184b67a5f79255b2fffb86524c6c8ef811)

fixes #697 
