### PR TITLE
Don't send back empty AttributePaths.

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-cty/cty"
 	ctyconvert "github.com/hashicorp/go-cty/cty/convert"
 	"github.com/hashicorp/go-cty/cty/msgpack"
@@ -1105,6 +1106,7 @@ func (s *GRPCProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.
 	newInstanceState, diags := res.ReadDataApply(ctx, diff, s.provider.Meta())
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, diags)
 	if diags.HasError() {
+		log.Printf("[DEBUG] paddy561 got response: %s", spew.Sdump(resp))
 		return resp, nil
 	}
 

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-cty/cty"
 	ctyconvert "github.com/hashicorp/go-cty/cty/convert"
 	"github.com/hashicorp/go-cty/cty/msgpack"
@@ -1106,7 +1105,6 @@ func (s *GRPCProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.
 	newInstanceState, diags := res.ReadDataApply(ctx, diff, s.provider.Meta())
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, diags)
 	if diags.HasError() {
-		log.Printf("[DEBUG] paddy561 got response: %s", spew.Sdump(resp))
 		return resp, nil
 	}
 
@@ -1154,6 +1152,9 @@ func pathToAttributePath(path cty.Path) *tftypes.AttributePath {
 		}
 	}
 
+	if len(steps) < 1 {
+		return nil
+	}
 	return &tftypes.AttributePath{Steps: steps}
 }
 

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -1753,3 +1753,10 @@ func TestStopContext_stopReset(t *testing.T) {
 		t.Fatal("Stop message did not cancel request context")
 	}
 }
+
+func Test_pathToAttributePath_noSteps(t *testing.T) {
+	res := pathToAttributePath(cty.Path{})
+	if res != nil {
+		t.Errorf("Expected nil attribute path, got %+v", res)
+	}
+}

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -107,6 +107,9 @@ func AttributePathToPath(ap *tftypes.AttributePath) cty.Path {
 
 // PathToAttributePath takes a cty.Path and converts it to a proto-encoded path.
 func PathToAttributePath(p cty.Path) *tftypes.AttributePath {
+	if p == nil || len(p) < 1 {
+		return nil
+	}
 	ap := &tftypes.AttributePath{}
 	for _, step := range p {
 		switch selector := step.(type) {

--- a/internal/plugin/convert/diagnostics_test.go
+++ b/internal/plugin/convert/diagnostics_test.go
@@ -281,3 +281,23 @@ func TestDiagnostics(t *testing.T) {
 		})
 	}
 }
+
+func TestPathToAttributePath(t *testing.T) {
+	tests := map[string]struct {
+		path cty.Path
+		want *tftypes.AttributePath
+	}{
+		"no steps": {
+			path: cty.Path{},
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := PathToAttributePath(tc.path)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("Unexpected diff: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When returning Diagnostics, only populate the AttributePath if there are
actually steps. Terraform core has a bug (see hashicorp/terraform#27710)
that will result in any Diagnostic that has an AttributePath with no
steps not being associated with a specific part of the config.

Fixes #561.