### PR TITLE
Do not match overlapping plain keys when looking for child keys.

### DIFF
--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -246,7 +246,7 @@ func (d *ResourceDiff) clear(key string) error {
 	}
 
 	for k := range d.diff.Attributes {
-		if strings.HasPrefix(k, key) {
+		if k == key || childAddrOf(k, key) {
 			delete(d.diff.Attributes, k)
 		}
 	}
@@ -259,7 +259,7 @@ func (d *ResourceDiff) clear(key string) error {
 func (d *ResourceDiff) GetChangedKeysPrefix(prefix string) []string {
 	keys := make([]string, 0)
 	for k := range d.diff.Attributes {
-		if strings.HasPrefix(k, prefix) {
+		if k == prefix || childAddrOf(k, prefix) {
 			keys = append(keys, k)
 		}
 	}


### PR DESCRIPTION
I ran this against the acceptance tests for AWS instances and network interfaces.

Closes #715