### PR TITLE
Add SUPPORT.md outlining our support policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Migrating to the v2 release of the SDK is covered in the [v2 Upgrade Guide](http
 
 ## Versioning
 
-The Terraform Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modules) versioned using [semantic versioning](https://semver.org/).
+The Terraform Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modules) versioned using [semantic versioning](https://semver.org/). See [SUPPORT.md](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/SUPPORT.md) for information on our support policies.
 
 ## Contributing
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,7 +3,7 @@
 Version 2 of the Terraform Plugin SDK is considered **GA (generally
 available)** and has the following support policy:
 
-Critical bug fixes will be accepted and merged. New features and non-critical
+- Critical bug fixes will be accepted and merged. New features and non-critical
 bug fixes may be accepted at maintainers’ discretion, but our priority is
 maintaining stability.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support Policy
+
+Version 2 of the Terraform Plugin SDK is considered **GA (generally
+available)** and has the following support policy:
+
+Critical bug fixes will be accepted and merged. New features and non-critical
+bug fixes may be accepted at maintainers’ discretion, but our priority is
+maintaining stability.
+
+We will not break the public interface exposed by the SDK in a minor or patch
+release unless a critical security issue or bug demands it, and only then as a
+last resort.
+
+We will continue testing version 2 of the SDK against new releases of Terraform
+to ensure compatibility.
+
+We will not be backporting bug fixes to prior minor releases. Only the latest
+minor release receives new patch versions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,13 +6,10 @@ available)** and has the following support policy:
 - Critical bug fixes will be accepted and merged. New features and non-critical
 bug fixes may be accepted at maintainers’ discretion, but our priority is
 maintaining stability.
-
 - We will not break the public interface exposed by the SDK in a minor or patch
 release unless a critical security issue or bug demands it, and only then as a
 last resort.
-
 - We will continue testing version 2 of the SDK against new releases of Terraform
 to ensure compatibility.
-
 - We will not be backporting bug fixes to prior minor releases. Only the latest
 minor release receives new patch versions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,7 +11,7 @@ maintaining stability.
 release unless a critical security issue or bug demands it, and only then as a
 last resort.
 
-We will continue testing version 2 of the SDK against new releases of Terraform
+- We will continue testing version 2 of the SDK against new releases of Terraform
 to ensure compatibility.
 
 We will not be backporting bug fixes to prior minor releases. Only the latest

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,5 +14,5 @@ last resort.
 - We will continue testing version 2 of the SDK against new releases of Terraform
 to ensure compatibility.
 
-We will not be backporting bug fixes to prior minor releases. Only the latest
+- We will not be backporting bug fixes to prior minor releases. Only the latest
 minor release receives new patch versions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@ available)** and has the following support policy:
 bug fixes may be accepted at maintainers’ discretion, but our priority is
 maintaining stability.
 
-We will not break the public interface exposed by the SDK in a minor or patch
+- We will not break the public interface exposed by the SDK in a minor or patch
 release unless a critical security issue or bug demands it, and only then as a
 last resort.
 


### PR DESCRIPTION
Call out that v2 is generally available and will receive fixes, but that
we don't backport fixes to other minor versions. Generally lay out the
support policy we have been operating with thus far.