### PR TITLE
Add information on support policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Migrating to the standalone SDK v1 is covered on the [Plugin SDK section](https:
 
 ## Versioning
 
-The Terraform Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modules) versioned using [semantic versioning](https://semver.org/).
+The Terraform Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modules) versioned using [semantic versioning](https://semver.org/). See [SUPPORT.md](https://github.com/hashicorp/terraform-plugin-sdk/blob/v1-maint/SUPPORT.md) for information on our support policies.
 
 ## Contributing
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,7 +12,7 @@ release unless a critical security issue demands it, and only then as a last
 resort.
 
 - We do not proactively test version 1 of the SDK against new releases of
-Terraform to ensure compatibility, but will address critical compatibility
+- Terraform to ensure compatibility, but will address critical compatibility
 issues that are reported until July 31, 2021.
 
 We do not backport bug fixes to prior minor releases. Only the latest minor

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,14 +6,15 @@ the following support policy is in place:
 - Critical bug fixes will be accepted and merged until July 31, 2021, at which
 point this version is considered End Of Life and no longer supported. New
 features and non-critical bug fixes will not be accepted.
-
 - We will not break the public interface exposed by the SDK in a minor or patch
 release unless a critical security issue demands it, and only then as a last
 resort.
-
 - We do not proactively test version 1 of the SDK against new releases of
 - Terraform to ensure compatibility, but will address critical compatibility
 issues that are reported until July 31, 2021.
-
 - We do not backport bug fixes to prior minor releases. Only the latest minor
 release receives new patch versions.
+
+Please see the [upgrade
+guide](https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html) for
+information on how to upgrade to version 2.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@ the following support policy is in place:
 point this version is considered End Of Life and no longer supported. New
 features and non-critical bug fixes will not be accepted.
 
-We will not break the public interface exposed by the SDK in a minor or patch
+- We will not break the public interface exposed by the SDK in a minor or patch
 release unless a critical security issue demands it, and only then as a last
 resort.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# Support Policy
+
+Version 1 of the Terraform Plugin SDK is considered **deprecated**, which means
+the following support policy is in place:
+
+Critical bug fixes will be accepted and merged until July 31, 2021, at which
+point this version is considered End Of Life and no longer supported. New
+features and non-critical bug fixes will not be accepted.
+
+We will not break the public interface exposed by the SDK in a minor or patch
+release unless a critical security issue demands it, and only then as a last
+resort.
+
+We do not proactively test version 1 of the SDK against new releases of
+Terraform to ensure compatibility, but will address critical compatibility
+issues that are reported until July 31, 2021.
+
+We do not backport bug fixes to prior minor releases. Only the latest minor
+release receives new patch versions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,7 +3,7 @@
 Version 1 of the Terraform Plugin SDK is considered **deprecated**, which means
 the following support policy is in place:
 
-Critical bug fixes will be accepted and merged until July 31, 2021, at which
+- Critical bug fixes will be accepted and merged until July 31, 2021, at which
 point this version is considered End Of Life and no longer supported. New
 features and non-critical bug fixes will not be accepted.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -15,5 +15,5 @@ resort.
 - Terraform to ensure compatibility, but will address critical compatibility
 issues that are reported until July 31, 2021.
 
-We do not backport bug fixes to prior minor releases. Only the latest minor
+- We do not backport bug fixes to prior minor releases. Only the latest minor
 release receives new patch versions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,7 +11,7 @@ features and non-critical bug fixes will not be accepted.
 release unless a critical security issue demands it, and only then as a last
 resort.
 
-We do not proactively test version 1 of the SDK against new releases of
+- We do not proactively test version 1 of the SDK against new releases of
 Terraform to ensure compatibility, but will address critical compatibility
 issues that are reported until July 31, 2021.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ features and non-critical bug fixes will not be accepted.
 release unless a critical security issue demands it, and only then as a last
 resort.
 - We do not proactively test version 1 of the SDK against new releases of
-- Terraform to ensure compatibility, but will address critical compatibility
+Terraform to ensure compatibility, but will address critical compatibility
 issues that are reported until July 31, 2021.
 - We do not backport bug fixes to prior minor releases. Only the latest minor
 release receives new patch versions.


### PR DESCRIPTION
Document that v1-maint is considered deprecated and will EOL on July
31, 2021, and lay out what that means.