### PR TITLE
Support testing of configurations in JSON syntax.

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -445,6 +445,9 @@ type TestStep struct {
 	// Config a string of the configuration to give to Terraform. If this
 	// is set, then the TestCase will execute this step with the same logic
 	// as a `terraform apply`.
+	//
+	// JSON Configuration Syntax can be used and is assumed whenever Config
+	// contains valid JSON.
 	Config string
 
 	// Check is called after the Config is applied. Use this step to

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -3,6 +3,7 @@ package plugintest
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -15,8 +16,9 @@ import (
 )
 
 const (
-	ConfigFileName = "terraform_plugin_test.tf"
-	PlanFileName   = "tfplan"
+	ConfigFileName     = "terraform_plugin_test.tf"
+	ConfigFileNameJSON = ConfigFileName + ".json"
+	PlanFileName       = "tfplan"
 )
 
 // WorkingDir represents a distinct working directory that can be used for
@@ -28,6 +30,10 @@ type WorkingDir struct {
 
 	// baseDir is the root of the working directory tree
 	baseDir string
+
+	// configFilename is the full filename where the latest configuration
+	// was stored; empty until SetConfig is called.
+	configFilename string
 
 	// baseArgs is arguments that should be appended to all commands
 	baseArgs []string
@@ -84,11 +90,20 @@ func (wd *WorkingDir) GetHelper() *Helper {
 // Destroy to establish the configuration. Any previously-set configuration is
 // discarded and any saved plan is cleared.
 func (wd *WorkingDir) SetConfig(ctx context.Context, cfg string) error {
-	configFilename := filepath.Join(wd.baseDir, ConfigFileName)
-	err := ioutil.WriteFile(configFilename, []byte(cfg), 0700)
+	outFilename := filepath.Join(wd.baseDir, ConfigFileName)
+	rmFilename := filepath.Join(wd.baseDir, ConfigFileNameJSON)
+	bCfg := []byte(cfg)
+	if json.Valid(bCfg) {
+		outFilename, rmFilename = rmFilename, outFilename
+	}
+	if err := os.Remove(rmFilename); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to remove %q: %w", rmFilename, err)
+	}
+	err := ioutil.WriteFile(outFilename, bCfg, 0700)
 	if err != nil {
 		return err
 	}
+	wd.configFilename = outFilename
 
 	var mismatch *tfexec.ErrVersionMismatch
 	err = wd.tf.SetDisablePluginTLS(true)
@@ -157,11 +172,16 @@ func (wd *WorkingDir) ClearPlan(ctx context.Context) error {
 	return nil
 }
 
+var errWorkingDirSetConfigNotCalled = fmt.Errorf("must call SetConfig before Init")
+
 // Init runs "terraform init" for the given working directory, forcing Terraform
 // to use the current version of the plugin under test.
 func (wd *WorkingDir) Init(ctx context.Context) error {
-	if _, err := os.Stat(wd.configFilename()); err != nil {
-		return fmt.Errorf("must call SetConfig before Init")
+	if wd.configFilename == "" {
+		return errWorkingDirSetConfigNotCalled
+	}
+	if _, err := os.Stat(wd.configFilename); err != nil {
+		return errWorkingDirSetConfigNotCalled
 	}
 
 	logging.HelperResourceTrace(ctx, "Calling Terraform CLI init command")
@@ -171,10 +191,6 @@ func (wd *WorkingDir) Init(ctx context.Context) error {
 	logging.HelperResourceTrace(ctx, "Called Terraform CLI init command")
 
 	return err
-}
-
-func (wd *WorkingDir) configFilename() string {
-	return filepath.Join(wd.baseDir, ConfigFileName)
 }
 
 func (wd *WorkingDir) planFilename() string {

--- a/internal/plugintest/working_dir_json_test.go
+++ b/internal/plugintest/working_dir_json_test.go
@@ -14,7 +14,7 @@ import (
 // forth, the framework deletes the previous configuration file.
 func TestJSONConfig(t *testing.T) {
 	providerFactories := map[string]func() (*schema.Provider, error){
-		"tst": func() (*schema.Provider, error) { return tstProvider(), nil },
+		"tst": func() (*schema.Provider, error) { return tstProvider(), nil }, //nolint:unparam // required signature
 	}
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:        true,
@@ -35,7 +35,7 @@ func TestJSONConfig(t *testing.T) {
 func tstProvider() *schema.Provider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"tst_t": &schema.Resource{
+			"tst_t": {
 				CreateContext: resourceTstTCreate,
 				ReadContext:   resourceTstTRead,
 				UpdateContext: resourceTstTCreate, // Update is the same as Create

--- a/internal/plugintest/working_dir_json_test.go
+++ b/internal/plugintest/working_dir_json_test.go
@@ -41,7 +41,7 @@ func tstProvider() *schema.Provider {
 				UpdateContext: resourceTstTCreate, // Update is the same as Create
 				DeleteContext: resourceTstTDelete,
 				Schema: map[string]*schema.Schema{
-					"s": &schema.Schema{
+					"s": {
 						Type:     schema.TypeString,
 						Required: true,
 					},

--- a/internal/plugintest/working_dir_json_test.go
+++ b/internal/plugintest/working_dir_json_test.go
@@ -1,0 +1,69 @@
+package plugintest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestJSONConfig verifies that TestStep.Config can contain JSON.
+// This test also proves that when changing the HCL and JSON formats back and
+// forth, the framework deletes the previous configuration file.
+func TestJSONConfig(t *testing.T) {
+	providerFactories := map[string]func() (*schema.Provider, error){
+		"tst": func() (*schema.Provider, error) { return tstProvider(), nil },
+	}
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:        true,
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{{
+			Config: `{"resource":{"tst_t":{"r1":{"s":"x1"}}}}`,
+			Check:  resource.TestCheckResourceAttr("tst_t.r1", "s", "x1"),
+		}, {
+			Config: `resource "tst_t" "r1" { s = "x2" }`,
+			Check:  resource.TestCheckResourceAttr("tst_t.r1", "s", "x2"),
+		}, {
+			Config: `{"resource":{"tst_t":{"r1":{"s":"x3"}}}}`,
+			Check:  resource.TestCheckResourceAttr("tst_t.r1", "s", "x3"),
+		}},
+	})
+}
+
+func tstProvider() *schema.Provider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"tst_t": &schema.Resource{
+				CreateContext: resourceTstTCreate,
+				ReadContext:   resourceTstTRead,
+				UpdateContext: resourceTstTCreate, // Update is the same as Create
+				DeleteContext: resourceTstTDelete,
+				Schema: map[string]*schema.Schema{
+					"s": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceTstTCreate(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	d.SetId(d.Get("s").(string))
+	return nil
+}
+
+func resourceTstTRead(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	if err := d.Set("s", d.Id()); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceTstTDelete(ctx context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
This implements the proposal described in https://github.com/hashicorp/terraform-plugin-sdk/issues/721

The exported [plugintest.WorkingDir.SetConfig](
https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.4/internal/plugintest#WorkingDir.SetConfig
) API was deliberately left unmodified to avoid a breaking change.

The only possible breaking change is the [mid-struct addition](
https://github.com/hashicorp/terraform-plugin-sdk/compare/master...rudo-thomas:support-json-syntax-in-tests?expand=1#diff-ef6290017990b7efb9ea81ebcad8974eb0a441f9f2adca610f403dbd32ea5619R405
) of the `ConfigIsJSON` field to `TestStep` which could break users that initialise the structure without using the the _Field_: syntax. Such uses are very unlikely, as the structure had 19 fields already, 20 with this change.

I wasn't able to find a good place to add tests for the new functionality. I'll be happy to take any advice on this. Thanks.