### PR TITLE
Rename master branch to main.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,13 +154,13 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           type: approval
       - "docker-go115 release":
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - trigger-release
             - "docker-go115 test"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,10 +41,10 @@ This section describes the scope of notable repositories, which may help you
 ensure you're in the right place when reporting bugs and feature requests,
 or submitting a patch.
 
- - `hashicorp/terraform` - Terraform **Core** which implements all the low-level functionality which isn't domain specific (that's covered by providers). Read more about [distinction between core & providers in the Readme](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/README.md#scope-providers-vs-core).
+ - `hashicorp/terraform` - Terraform **Core** which implements all the low-level functionality which isn't domain specific (that's covered by providers). Read more about [distinction between core & providers in the Readme](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/README.md#scope-providers-vs-core).
  - `terraform-providers/*` - This organization contains all official Terraform **Providers** built on top of the Plugin SDK
  - `hashicorp/terraform-plugin-sdk` - Terraform **Plugin SDK** used to build Providers
- - `hashicorp/terraform-website` - Source code of **documentation** published on [terraform.io](https://www.terraform.io), including [Extend section](https://www.terraform.io/docs/extend/index.html) which has source in [the `extend` folder](https://github.com/hashicorp/terraform-website/tree/master/content/source/docs/extend).
+ - `hashicorp/terraform-website` - Source code of **documentation** published on [terraform.io](https://www.terraform.io), including [Extend section](https://www.terraform.io/docs/extend/index.html) which has source in [the `extend` folder](https://github.com/hashicorp/terraform-website/tree/main/content/source/docs/extend).
  - `hashicorp/hcl2` - **HCL** (HashiCorp Config Language) is the language used by users of Terraform (Core) to describe infrastructure. The parser and other features concerning the language (such as builtin functions) are found here.
  - `zclconf/go-cty` - **cty**, the type system used by both Terraform (Core) and SDK (therefore providers too) to represent data in state before and after gRPC encoding/decoding
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The Terraform Plugin SDK is a [Go module](https://github.com/golang/go/wiki/Modu
 
 ## Contributing
 
-See [`.github/CONTRIBUTING.md`](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/.github/CONTRIBUTING.md)
+See [`.github/CONTRIBUTING.md`](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/.github/CONTRIBUTING.md)
 
 ## License
 
-[Mozilla Public License v2.0](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/LICENSE)
+[Mozilla Public License v2.0](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/LICENSE)


### PR DESCRIPTION
Change all references to "master" to "main" in advance of changing the
default branch on GitHub.

Following merge, we'll use the GitHub functionality to rename the master
branch.