### PR TITLE
Allow for "v" prefix in version strings

### DIFF
--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/terraform-exec/tfinstall"
 )
@@ -23,7 +24,7 @@ type Config struct {
 // DiscoverConfig uses environment variables and other means to automatically
 // discover a reasonable test helper configuration.
 func DiscoverConfig(sourceDir string) (*Config, error) {
-	tfVersion := os.Getenv("TF_ACC_TERRAFORM_VERSION")
+	tfVersion := strings.TrimPrefix(os.Getenv("TF_ACC_TERRAFORM_VERSION"), "v")
 	tfPath := os.Getenv("TF_ACC_TERRAFORM_PATH")
 
 	tempDir := os.Getenv("TF_ACC_TEMP_DIR")


### PR DESCRIPTION
I've accidentally made this error a few times, since Go uses these in its .mod file, etc. May be a bit more forgiving for users.