### PR TITLE
v1: fixing timeouts

### DIFF
--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -31,7 +32,7 @@ func timeoutKeys() []string {
 	}
 }
 
-// could be time.Duration, int64 or float64
+// could be time.Duration, int64, float64 or json.Number
 func DefaultTimeout(tx interface{}) *time.Duration {
 	var td time.Duration
 	switch raw := tx.(type) {
@@ -41,8 +42,14 @@ func DefaultTimeout(tx interface{}) *time.Duration {
 		td = time.Duration(raw)
 	case float64:
 		td = time.Duration(int64(raw))
+	case json.Number:
+		i, err := raw.Int64()
+		if err != nil {
+			panic(fmt.Errorf("json.Number value %#v was not convertable to an integer: %+v", tx, err))
+		}
+		td = time.Duration(i)
 	default:
-		log.Printf("[WARN] Unknown type in DefaultTimeout: %#v", tx)
+		log.Printf("[WARN] Unknown type %T in DefaultTimeout: %#v", tx, tx)
 	}
 	return &td
 }


### PR DESCRIPTION
Discovered when upgrading https://github.com/terraform-providers/terraform-provider-azurerm/pull/11431

The latest changes to one of the dependencies, presumably `terraform-exec`, return the Duration as a `json.Number` rather than the expected time.Duration, int64 or float64, hence this fails silently with the log message:

```
2021/04/22 11:01:20 [WARN] Unknown type in DefaultTimeout: "5400000000000"
2021/04/22 11:01:20 [WARN] Unknown type in DefaultTimeout: "300000000000"
2021/04/22 11:01:20 [WARN] Unknown type in DefaultTimeout: "5400000000000"
2021/04/22 11:01:20 [WARN] Unknown type in DefaultTimeout: "5400000000000
```

When expanding that log message to include the type (without the new switch item) - this becomes:

```
[WARN] Unknown type json.Number in DefaultTimeout: “5400000000000”
```

Arguably this warning should be a Panic and not a Warning, but that's probably outside the scope of this fix. It also appears that this affects v2 as well as v1 - so this may need to be applied to v2 as well? https://github.com/hashicorp/terraform-plugin-sdk/blob/112e2164c381d80e8ada3170dac9a8a5db01079a/helper/schema/resource_timeout.go#L35-L49