### PR TITLE
[v1] Stop using json.Number when decoding Private.

### DIFF
--- a/internal/helper/plugin/grpc_provider.go
+++ b/internal/helper/plugin/grpc_provider.go
@@ -525,7 +525,7 @@ func (s *GRPCProviderServer) ReadResource(_ context.Context, req *proto.ReadReso
 
 	private := make(map[string]interface{})
 	if len(req.Private) > 0 {
-		if err := unmarshalJSON(req.Private, &private); err != nil {
+		if err := json.Unmarshal(req.Private, &private); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}
@@ -623,7 +623,7 @@ func (s *GRPCProviderServer) PlanResourceChange(_ context.Context, req *proto.Pl
 	}
 	priorPrivate := make(map[string]interface{})
 	if len(req.PriorPrivate) > 0 {
-		if err := unmarshalJSON(req.PriorPrivate, &priorPrivate); err != nil {
+		if err := json.Unmarshal(req.PriorPrivate, &priorPrivate); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}
@@ -827,7 +827,7 @@ func (s *GRPCProviderServer) ApplyResourceChange(_ context.Context, req *proto.A
 
 	private := make(map[string]interface{})
 	if len(req.PlannedPrivate) > 0 {
-		if err := unmarshalJSON(req.PlannedPrivate, &private); err != nil {
+		if err := json.Unmarshal(req.PlannedPrivate, &private); err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
 		}


### PR DESCRIPTION
Our Timeouts code can't handle it yet.

This is a backport of #667.