### PR TITLE
Update GPG usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,9 @@ workflows:
                 - main
           type: approval
       - "docker-go115 release":
+          context:
+            - releases-gpg-private-signing-key
+            - releases-gpg-public-signing-key
           filters:
             branches:
               only:

--- a/internal/vault/helper/pgpkeys/flag_test.go
+++ b/internal/vault/helper/pgpkeys/flag_test.go
@@ -149,7 +149,7 @@ func TestPubKeyFilesFlagSetKeybase(t *testing.T) {
 	exp := []string{
 		"0f801f518ec853daff611e836528efcac6caa3db",
 		"cf3d4694c9f57b28cb4092c2eb832c67eb5e8957",
-		"91a6e7f85d05c65630bef18951852d87348ffc4c",
+		"c874011f0ab405110d02105534365d9472d7468f",
 	}
 
 	if !reflect.DeepEqual(fingerprints, exp) {

--- a/internal/vault/helper/pgpkeys/keybase_test.go
+++ b/internal/vault/helper/pgpkeys/keybase_test.go
@@ -33,7 +33,7 @@ func TestFetchKeybasePubkeys(t *testing.T) {
 
 	exp := []string{
 		"0f801f518ec853daff611e836528efcac6caa3db",
-		"91a6e7f85d05c65630bef18951852d87348ffc4c",
+		"c874011f0ab405110d02105534365d9472d7468f",
 	}
 
 	if !reflect.DeepEqual(fingerprints, exp) {

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -22,9 +22,8 @@ function init {
   START_DIR=`pwd`
 
   if [ "$CI" = true ] ; then
-    GPG_KEY_ID=FBA4BCB482BC44B5
-    gpg --import <(echo -e "${GPG_PUBLIC_KEY}")
-    gpg --import <(echo -e "${GPG_PRIVATE_KEY}")
+    gpg --batch --import <(echo -e "${RELEASES_GPG_PUB_KEY}")
+    gpg --batch --import <(echo -e "${RELEASES_GPG_PRIV_KEY}")
     git config --global user.email hashibot-feedback+tf-sdk-circleci@hashicorp.com
     git config --global user.name "Terraform SDK CircleCI"
   fi
@@ -81,8 +80,11 @@ function commitChanges {
   git add meta/meta.go
 
   if [ "$CI" = true ] ; then
-      git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
-      git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"
+      # load GPG passphrase into gpg-agent for reuse when git calls gpg
+      gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${RELEASES_GPG_PASSPHRASE}" <(echo)
+
+      git commit --gpg-sign="${RELEASES_GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
+      git tag -a -m "v${TARGET_VERSION}" -s -u "${RELEASES_GPG_KEY_ID}" "v${TARGET_VERSION}"
   else
       git commit -m "v${TARGET_VERSION} [skip ci]"
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"


### PR DESCRIPTION
As part of rotating the GPG key used for signing products, we are also moving the GPG bits into a dedicated CircleCI context.  This PR renames the GPG env vars to match those from the new context and applies the context to the job that uses the key.