### PR TITLE
Fix for the bug #720

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -27,21 +27,18 @@ func init() {
 
 // RandInt generates a random integer
 func RandInt() int {
-	return rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	return rand.Int()
 }
 
 // RandomWithPrefix is used to generate a unique name with a prefix, for
 // randomizing names in acceptance tests
 func RandomWithPrefix(name string) string {
-	return fmt.Sprintf("%s-%d", name, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+	return fmt.Sprintf("%s-%d", name, RandInt())
 }
 
 // RandIntRange returns a random integer between min (inclusive) and max (exclusive)
 func RandIntRange(min int, max int) int {
-	source := rand.New(rand.NewSource(time.Now().UnixNano()))
-	rangeMax := max - min
-
-	return int(source.Int31n(int32(rangeMax))) + min
+	return rand.Intn(max-min) + min
 }
 
 // RandString generates a random alphanumeric string of the length specified
@@ -54,7 +51,7 @@ func RandString(strlen int) string {
 func RandStringFromCharSet(strlen int, charSet string) string {
 	result := make([]byte, strlen)
 	for i := 0; i < strlen; i++ {
-		result[i] = charSet[rand.Intn(len(charSet))]
+		result[i] = charSet[RandIntRange(0, len(charSet))]
 	}
 	return string(result)
 }


### PR DESCRIPTION
- `math/rand.Seed` is set at the init function therefore all followed calls to the rand package should be distinct.
- `math/rand` package returns the same values on Windows when the seed is set in every function that calls rand package - the issue already reported in the bug: https://stackoverflow.com/questions/57285292/why-does-time-now-unixnano-returns-the-same-result-after-an-io-operation
- The fix was to remove repetitive seed set when `math/rand` package is called.