### PR TITLE
Remove `TypeSet` truncation warning if none are truncated

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -2098,9 +2098,11 @@ func (m schemaMap) validateType(
 		// indexing into sets is not representable in the current protocol
 		// best we can do is associate the path up to this attribute.
 		diags = m.validateList(k, raw, schema, c, path)
-		log.Printf("[WARN] Truncating attribute path of %d diagnostics for TypeSet", len(diags))
-		for i := range diags {
-			diags[i].AttributePath = path
+		if len(diags) > 0 {
+			log.Printf("[WARN] Truncating attribute path of %d diagnostics for TypeSet", len(diags))
+			for i := range diags {
+				diags[i].AttributePath = path
+			}
 		}
 	case TypeMap:
 		diags = m.validateMap(k, raw, schema, c, path)


### PR DESCRIPTION
When running Terraform with logging level set to `WARN` or more verbose, the message `Truncating attribute path of 0 diagnostics for TypeSet` can be repeated multiple times. This message is displayed even though no diagnostics are affected.

For example, when running acceptance tests for `aws_elasticache_global_replication_group` the message is logged over 150 times.

This PR checks that there are elements to truncate before printing the warning.
