### PR TITLE
fix: 🐛  statefunc can set empty strings

### DIFF
--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2345,6 +2345,49 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
+			Name: ": StateFunc to hide values (#1759)",
+			Schema: map[string]*Schema{
+				"map_with_sensitive_keys": {
+					Type:     TypeMap,
+					Optional: true,
+					ForceNew: true,
+					Elem: &Schema{
+						Type: TypeString,
+						StateFunc: func(v interface{}) string {
+							return ""
+						},
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"map_with_sensitive_keys": map[string]interface{}{
+					"password": "123",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"map_with_sensitive_keys.#": {
+						Old:         "0",
+						New:         "1",
+						RequiresNew: true,
+					},
+					"map_with_sensitive_keys.password.123": {
+						Old:         "",
+						New:         "",
+						NewExtra:    "123",
+						RequiresNew: true,
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
 			Name: "Removing set elements",
 			Schema: map[string]*Schema{
 				"instances": {


### PR DESCRIPTION
Please do not merge this. This PR maybe should just be an issue, but I wanted to show the code, the test, and the output to demonstrate what I think is a bug.

`StateFunc` cannot be used to set an empty value, which is useful when you want to keep a value out of state because it is sensitive.

```
2021/06/11 17:58:28 [DEBUG] A computed value with the empty string as the new value and a non-empty old value was found. Interpreting the empty string as "unset" to align with legacy behavior.
2021/06/11 17:58:28 [DEBUG] A computed value with the empty string as the new value and a non-empty old value was found. Interpreting the empty string as "unset" to align with legacy behavior.
--- FAIL: TestSchemaMap_Diff (0.02s)
    --- FAIL: TestSchemaMap_Diff/61-:_StateFunc_to_hide_values_(#1759) (0.00s)
        schema_test.go:3157: expected:
            *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"map_with_sensitive_keys.#":*terraform.ResourceAttrDiff{Old:"0", New:"1", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "map_with_sensitive_keys.password.123":*terraform.ResourceAttrDiff{Old:"", New:"", NewComputed:false, NewRemoved:false, NewExtra:"123", RequiresNew:true, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}

            got:
            *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"map_with_sensitive_keys.%":*terraform.ResourceAttrDiff{Old:"0", New:"1", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "map_with_sensitive_keys.password":*terraform.ResourceAttrDiff{Old:"", New:"123", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}
```

The important bit to highlight is:

expected:
```
*terraform.ResourceAttrDiff{Old:"", New:"", 
```

got:
```
*terraform.ResourceAttrDiff{Old:"", New:"123"
```
            