### PR TITLE
add support for cross version provider import

### DIFF
--- a/helper/resource/cross_version_import_helper.go
+++ b/helper/resource/cross_version_import_helper.go
@@ -1,0 +1,70 @@
+package resource
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+	This helper is used to replace developing provider which contains a sdk upgrade and released provider.
+    By deploying resources with released provider and importing resources with developing provider, to verify whether there's backend breaking change introduced.
+*/
+
+func isCrossVersionImportEnabled() bool {
+	if enabled, err := strconv.ParseBool(os.Getenv("TF_ACC_CROSS_VERSION_IMPORT")); err == nil {
+		return enabled
+	}
+	return false
+}
+
+func getStandardProviderName() string {
+	if provider := os.Getenv("TF_ACC_PROVIDER"); provider != "" {
+		return provider
+	}
+	return "azurerm"
+}
+
+func getStandardProviderNamespace() string {
+	if namespace := os.Getenv("TF_ACC_PROVIDER_NAMESPACE"); namespace != "" {
+		return namespace
+	}
+	return "hashicorp"
+}
+
+func getStandardProviderVersion() string {
+	return os.Getenv("TF_ACC_PROVIDER_VERSION")
+}
+
+/*
+replace develop provider with released provider
+*/
+func useExternalProvider(c TestCase) func() (*schema.Provider, error) {
+	if isCrossVersionImportEnabled() {
+		provider := getStandardProviderName()
+		externalProvider := ExternalProvider{
+			Source: fmt.Sprintf("registry.terraform.io/%s/%s", getStandardProviderNamespace(), provider),
+		}
+		if version := getStandardProviderVersion(); version != "" {
+			externalProvider.VersionConstraint = "=" + version
+		}
+		c.ExternalProviders[provider] = externalProvider
+		backupProviderFactory := c.ProviderFactories[provider]
+		delete(c.ProviderFactories, provider)
+		return backupProviderFactory
+	}
+	return nil
+}
+
+/*
+replace released provider with develop provider
+*/
+func useDevelopProvider(c TestCase, backupProviderFactory func() (*schema.Provider, error)) {
+	if isCrossVersionImportEnabled() {
+		provider := getStandardProviderName()
+		c.ProviderFactories[provider] = backupProviderFactory
+		delete(c.ExternalProviders, provider)
+	}
+}

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -66,7 +66,7 @@ func runNewTest(t testing.T, c TestCase, helper *plugintest.Helper) {
 
 		wd.Close()
 	}()
-
+	backupProviderFactory := useExternalProvider(c)
 	providerCfg, err := testProviderConfig(c)
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +105,9 @@ func runNewTest(t testing.T, c TestCase, helper *plugintest.Helper) {
 		}
 
 		if step.ImportState {
+			useDevelopProvider(c, backupProviderFactory)
 			err := testStepNewImportState(t, c, helper, wd, step, appliedCfg)
+			useExternalProvider(c)
 			if step.ExpectError != nil {
 				if err == nil {
 					t.Fatalf("Step %d/%d error running import: expected an error but got none", i+1, len(c.Steps))


### PR DESCRIPTION
This solution is used to detect SDK behavioral change when upgrade SDK for terraform providers. It takes advantage of existing acceptance tests. By deploying resources with released provider and using import step with developing provider to check whether there's a behavioral change.

Here's an example of detecting breaking change like https://azure.microsoft.com/en-us/updates/zone-behavior-change/. If there's a breaking behavioral change after SDK upgrade, running acc tests will show ` ImportStateVerify attributes not equivalent`.
```

=== RUN   TestAccPublicIpStatic_standard
=== PAUSE TestAccPublicIpStatic_standard
=== CONT  TestAccPublicIpStatic_standard
    testcase.go:95: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) (len=4) {
         (string) (len=7) "zones.#": (string) (len=1) "3",
         (string) (len=7) "zones.0": (string) (len=1) "1",
         (string) (len=7) "zones.1": (string) (len=1) "2",
         (string) (len=7) "zones.2": (string) (len=1) "3"
        }
        
        
        (map[string]string) {
        }
```

And this feature is disabled by default. So it won't affect regular acceptance tests.

Similar issue: https://github.com/hashicorp/terraform-plugin-sdk/issues/628 

This is just an idea to prevent breaking change in SDK upgrade, I'm open to all suggestions. :smiley:
