### PR TITLE
Add timing instrumentation to resource and region sweepers

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	testing "github.com/mitchellh/go-testing-interface"
@@ -113,6 +114,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 		var regionSweeperErrorFound bool
 		regionSweeperRunList := make(map[string]error)
 
+		start := time.Now()
 		log.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
 		for _, sweeper := range sweepers {
 			if err := runSweeperWithRegion(region, sweeper, sweepers, regionSweeperRunList, allowFailures); err != nil {
@@ -124,8 +126,10 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 				return sweeperRunList, fmt.Errorf("sweeper (%s) for region (%s) failed: %s", sweeper.Name, region, err)
 			}
 		}
+		elapsed := time.Now().Sub(start)
+		log.Printf("Completed Sweepers for region (%s) in %s", region, elapsed)
 
-		log.Printf("Sweeper Tests ran successfully:\n")
+		log.Printf("Sweeper Tests for region (%s) ran successfully:\n", region)
 		for sweeper, sweeperErr := range regionSweeperRunList {
 			if sweeperErr == nil {
 				fmt.Printf("\t- %s\n", sweeper)
@@ -136,7 +140,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 
 		if regionSweeperErrorFound {
 			sweeperErrorFound = true
-			log.Printf("Sweeper Tests ran unsuccessfully:\n")
+			log.Printf("Sweeper Tests for region (%s) ran unsuccessfully:\n", region)
 			for sweeper, sweeperErr := range regionSweeperRunList {
 				if sweeperErr != nil {
 					fmt.Printf("\t- %s: %s\n", sweeper, sweeperErr)
@@ -233,7 +237,11 @@ func runSweeperWithRegion(region string, s *Sweeper, sweepers map[string]*Sweepe
 
 	log.Printf("[DEBUG] Running Sweeper (%s) in region (%s)", s.Name, region)
 
+	start := time.Now()
 	runE := s.F(region)
+	elapsed := time.Now().Sub(start)
+
+	log.Printf("[DEBUG] Completed Sweeper (%s) in region (%s) in %s", s.Name, region, elapsed)
 
 	sweeperRunList[s.Name] = runE
 


### PR DESCRIPTION
As the number of resources grows, especially those that take a long time to destroy, it can be challenging to find how long specific sweepers take to run.

This PR adds timing instrumentation for:
* A region as a whole
* Specific sweepers

Example output:

```console
2021/07/14 11:12:06 [DEBUG] Running Sweepers for region (us-west-2):
2021/07/14 11:12:06 [DEBUG] Running Sweeper (aws_fsx_windows_file_system) in region (us-west-2)
2021/07/14 11:12:08 [DEBUG] Completed Sweeper (aws_fsx_windows_file_system) in region (us-west-2) in 1.540335945s
2021/07/14 11:12:08 [DEBUG] Running Sweeper (aws_workspaces_workspace) in region (us-west-2)
2021/07/14 11:12:08 [DEBUG] Completed Sweeper (aws_workspaces_workspace) in region (us-west-2) in 246.532764ms
...
2021/07/14 11:12:09 Completed Sweepers for region (us-west-2) in 2.984776468s
2021/07/14 11:12:09 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_directory_service_directory
	- aws_ec2_client_vpn_network_association
	- aws_ec2_client_vpn_endpoint
	- aws_fsx_windows_file_system
	- aws_workspaces_workspace
	- aws_workspaces_directory
	- aws_db_instance
```