### PR TITLE
helper/schema: Ensure Provider.ConfigureContextFunc warning-only diagnostics are returned

### DIFF
--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -282,15 +282,21 @@ func (p *Provider) Configure(ctx context.Context, c *terraform.ResourceConfig) d
 		}
 		p.meta = meta
 	}
+
+	var diags diag.Diagnostics
+
 	if p.ConfigureContextFunc != nil {
-		meta, diags := p.ConfigureContextFunc(ctx, data)
+		meta, configureDiags := p.ConfigureContextFunc(ctx, data)
+		diags = append(diags, configureDiags...)
+
 		if diags.HasError() {
 			return diags
 		}
+
 		p.meta = meta
 	}
 
-	return nil
+	return diags
 }
 
 // Resources returns all the available resource types that this provider


### PR DESCRIPTION
Closes #790

Previously:

```
--- FAIL: TestProviderConfigure (0.00s)
    --- FAIL: TestProviderConfigure/ConfigureContextFunc-warning (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/provider_test.go:265: Unexpected diagnostics (-wanted +got):   diag.Diagnostics(
            - 	{{Severity: 1, Summary: "Test Warning Diagnostic", Detail: "This is a warning."}},
            + 	nil,
              )
```