### PR TITLE
Prototype exposing cty.Values from ResourceData.

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -552,6 +552,7 @@ func (s *GRPCProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Re
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 		return resp, nil
 	}
+	instanceState.RawState = stateVal
 
 	private := make(map[string]interface{})
 	if len(req.Private) > 0 {
@@ -656,11 +657,20 @@ func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprot
 		return resp, nil
 	}
 
+	configVal, err := msgpack.Unmarshal(req.Config.MsgPack, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
+		return resp, nil
+	}
+
 	priorState, err := res.ShimInstanceStateFromValue(priorStateVal)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 		return resp, nil
 	}
+	priorState.RawState = priorStateVal
+	priorState.RawPlan = proposedNewStateVal
+	priorState.RawConfig = configVal
 	priorPrivate := make(map[string]interface{})
 	if len(req.PriorPrivate) > 0 {
 		if err := json.Unmarshal(req.PriorPrivate, &priorPrivate); err != nil {
@@ -869,6 +879,12 @@ func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfpro
 		return resp, nil
 	}
 
+	configVal, err := msgpack.Unmarshal(req.Config.MsgPack, schemaBlock.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
+		return resp, nil
+	}
+
 	priorState, err := res.ShimInstanceStateFromValue(priorStateVal)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -893,9 +909,12 @@ func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfpro
 			Attributes: make(map[string]*terraform.ResourceAttrDiff),
 			Meta:       make(map[string]interface{}),
 			Destroy:    true,
+			RawPlan:    plannedStateVal,
+			RawState:   priorStateVal,
+			RawConfig:  configVal,
 		}
 	} else {
-		diff, err = DiffFromValues(ctx, priorStateVal, plannedStateVal, stripResourceModifiers(res))
+		diff, err = DiffFromValues(ctx, priorStateVal, plannedStateVal, configVal, stripResourceModifiers(res))
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 			return resp, nil
@@ -906,6 +925,9 @@ func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfpro
 		diff = &terraform.InstanceDiff{
 			Attributes: make(map[string]*terraform.ResourceAttrDiff),
 			Meta:       make(map[string]interface{}),
+			RawPlan:    plannedStateVal,
+			RawState:   priorStateVal,
+			RawConfig:  configVal,
 		}
 	}
 
@@ -1100,6 +1122,8 @@ func (s *GRPCProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 		return resp, nil
 	}
+
+	diff.RawConfig = configVal
 
 	// now we can get the new complete data source
 	newInstanceState, diags := res.ReadDataApply(ctx, diff, s.provider.Meta())

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -580,3 +580,51 @@ func (d *ResourceData) GetProviderMeta(dst interface{}) error {
 	}
 	return gocty.FromCtyValue(d.providerMeta, &dst)
 }
+
+// GetRawConfig returns the cty.Value that Terraform sent the SDK for the
+// config. If no value was sent, or if a null value was sent, the value will be
+// a null value of the resource's type.
+//
+// GetRawConfig is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceData) GetRawConfig() cty.Value {
+	if d.diff != nil && !d.diff.RawConfig.IsNull() {
+		return d.diff.RawConfig
+	}
+	if d.state != nil && !d.state.RawConfig.IsNull() {
+		return d.state.RawConfig
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
+}
+
+// GetRawState returns the cty.Value that Terraform sent the SDK for the state.
+// If no value was sent, or if a null value was sent, the value will be a null
+// value of the resource's type.
+//
+// GetRawState is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceData) GetRawState() cty.Value {
+	if d.diff != nil && !d.diff.RawState.IsNull() {
+		return d.diff.RawState
+	}
+	if d.state != nil && !d.state.RawState.IsNull() {
+		return d.state.RawState
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
+}
+
+// GetRawPlan returns the cty.Value that Terraform sent the SDK for the plan.
+// If no value was sent, or if a null value was sent, the value will be a null
+// value of the resource's type.
+//
+// GetRawPlan is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceData) GetRawPlan() cty.Value {
+	if d.diff != nil && !d.diff.RawPlan.IsNull() {
+		return d.diff.RawPlan
+	}
+	if d.state != nil && !d.state.RawPlan.IsNull() {
+		return d.state.RawPlan
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
+}

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -448,6 +449,54 @@ func (d *ResourceDiff) Id() string {
 		result = d.state.ID
 	}
 	return result
+}
+
+// GetRawConfig returns the cty.Value that Terraform sent the SDK for the
+// config. If no value was sent, or if a null value was sent, the value will be
+// a null value of the resource's type.
+//
+// GetRawConfig is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceDiff) GetRawConfig() cty.Value {
+	if d.diff != nil {
+		return d.diff.RawConfig
+	}
+	if d.state != nil {
+		return d.state.RawConfig
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
+}
+
+// GetRawState returns the cty.Value that Terraform sent the SDK for the state.
+// If no value was sent, or if a null value was sent, the value will be a null
+// value of the resource's type.
+//
+// GetRawState is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceDiff) GetRawState() cty.Value {
+	if d.diff != nil {
+		return d.diff.RawState
+	}
+	if d.state != nil {
+		return d.state.RawState
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
+}
+
+// GetRawPlan returns the cty.Value that Terraform sent the SDK for the plan.
+// If no value was sent, or if a null value was sent, the value will be a null
+// value of the resource's type.
+//
+// GetRawPlan is considered experimental and advanced functionality, and
+// familiarity with the Terraform protocol is suggested when using it.
+func (d *ResourceDiff) GetRawPlan() cty.Value {
+	if d.diff != nil {
+		return d.diff.RawPlan
+	}
+	if d.state != nil {
+		return d.state.RawPlan
+	}
+	return cty.NullVal(schemaMap(d.schema).CoreConfigSchema().ImpliedType())
 }
 
 // getChange gets values from two different levels, designed for use in

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -509,6 +509,9 @@ func (m schemaMap) Diff(
 	// Make sure to mark if the resource is tainted
 	if s != nil {
 		result.DestroyTainted = s.Tainted
+		result.RawConfig = s.RawConfig
+		result.RawState = s.RawState
+		result.RawPlan = s.RawPlan
 	}
 
 	d := &ResourceData{

--- a/helper/schema/shims.go
+++ b/helper/schema/shims.go
@@ -16,19 +16,23 @@ import (
 // derives a terraform.InstanceDiff to give to the legacy providers. This is
 // used to take the states provided by the new ApplyResourceChange method and
 // convert them to a state+diff required for the legacy Apply method.
-func DiffFromValues(ctx context.Context, prior, planned cty.Value, res *Resource) (*terraform.InstanceDiff, error) {
-	return diffFromValues(ctx, prior, planned, res, nil)
+func DiffFromValues(ctx context.Context, prior, planned, config cty.Value, res *Resource) (*terraform.InstanceDiff, error) {
+	return diffFromValues(ctx, prior, planned, config, res, nil)
 }
 
 // diffFromValues takes an additional CustomizeDiffFunc, so we can generate our
 // test fixtures from the legacy tests. In the new provider protocol the diff
 // only needs to be created for the apply operation, and any customizations
 // have already been done.
-func diffFromValues(ctx context.Context, prior, planned cty.Value, res *Resource, cust CustomizeDiffFunc) (*terraform.InstanceDiff, error) {
+func diffFromValues(ctx context.Context, prior, planned, config cty.Value, res *Resource, cust CustomizeDiffFunc) (*terraform.InstanceDiff, error) {
 	instanceState, err := res.ShimInstanceStateFromValue(prior)
 	if err != nil {
 		return nil, err
 	}
+
+	instanceState.RawConfig = config
+	instanceState.RawPlan = planned
+	instanceState.RawState = prior
 
 	configSchema := res.CoreConfigSchema()
 

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -290,6 +290,10 @@ func TestShimResourceDiff_Timeout_diff(t *testing.T) {
 			"create": "2h",
 		},
 	})
+
+	configVal := cty.ObjectVal(map[string]cty.Value{
+		"foo": cty.NumberIntVal(42),
+	})
 	var s *terraform.InstanceState
 
 	actual, err := r.Diff(context.Background(), s, conf, nil)
@@ -347,7 +351,7 @@ func TestShimResourceDiff_Timeout_diff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := DiffFromValues(context.Background(), initialVal, appliedVal, r)
+	d, err := DiffFromValues(context.Background(), initialVal, appliedVal, configVal, r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3408,7 +3412,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 
 			res := &Resource{Schema: tc.Schema}
 
-			d, err := diffFromValues(context.Background(), stateVal, configVal, res, tc.CustomizeDiff)
+			d, err := diffFromValues(context.Background(), stateVal, configVal, configVal, res, tc.CustomizeDiff)
 			if err != nil {
 				if !tc.Err {
 					t.Fatal(err)

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -39,6 +39,10 @@ type InstanceDiff struct {
 	DestroyDeposed bool
 	DestroyTainted bool
 
+	RawConfig cty.Value
+	RawState  cty.Value
+	RawPlan   cty.Value
+
 	// Meta is a simple K/V map that is stored in a diff and persisted to
 	// plans but otherwise is completely ignored by Terraform core. It is
 	// meant to be used for additional data a resource may want to pass through.

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1343,6 +1343,10 @@ type InstanceState struct {
 
 	ProviderMeta cty.Value
 
+	RawConfig cty.Value
+	RawState  cty.Value
+	RawPlan   cty.Value
+
 	// Tainted is used to mark a resource for recreation.
 	Tainted bool `json:"tainted"`
 


### PR DESCRIPTION
Fixes #793.

We actually create a `terraform.InstanceState` when handling the gRPC methods, and then a ResourceData is created from _that_. So, like with ProviderMeta functionality (#405) we're following the same path and threading our cty values through the instance state.

This still needs unit tests.