### PR TITLE
Fix nil pointer dereference in ResourceData.HasChangeExcept

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -172,7 +172,7 @@ func (d *ResourceData) HasChange(key string) bool {
 //
 // This function only works with root attribute keys.
 func (d *ResourceData) HasChangeExcept(key string) bool {
-	if d.diff == nil {
+	if d == nil || d.diff == nil {
 		return false
 	}
 	for attr := range d.diff.Attributes {


### PR DESCRIPTION
`ResourceData.HasChangeExcept` and `ResourceData. HasChangesExcept` accesses `.diff.Attributes` which could be nil and cause nil pointer dereference error.
This PR fixes the issue by checking the value and if it's nil, then return false(meaning no changes)