### PR TITLE
helper/schema: Prevent panic with missing InstanceDiff in ReadDataSource

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -1123,7 +1123,11 @@ func (s *GRPCProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.
 		return resp, nil
 	}
 
-	diff.RawConfig = configVal
+	// Not setting RawConfig here is okay, as ResourceData.GetRawConfig()
+	// will return a NullVal of the schema if there is no InstanceDiff.
+	if diff != nil {
+		diff.RawConfig = configVal
+	}
 
 	// now we can get the new complete data source
 	newInstanceState, diags := res.ReadDataApply(ctx, diff, s.provider.Meta())


### PR DESCRIPTION
Closes #813

Previously:

```
    --- FAIL: TestReadDataSource/optional-no-id (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x12f3f64]

goroutine 20 [running]:
testing.tRunner.func1.2({0x1418300, 0x17d34d0})
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /usr/local/Cellar/go/1.17.1/libexec/src/testing/testing.go:1212 +0x218
panic({0x1418300, 0x17d34d0})
        /usr/local/Cellar/go/1.17.1/libexec/src/runtime/panic.go:1038 +0x215
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc00013ce58, {0x1583cb0, 0xc000128008}, 0xc0001626a0)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/grpc_provider.go:1126 +0x304
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.TestReadDataSource.func9(0xc0002124e0)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/grpc_provider_test.go:1381 +0x6b
```