### PR TITLE
fix: add path to error when list has too many or few items

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1946,7 +1946,7 @@ func (m schemaMap) validateList(
 		return append(diags, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       "Too many list items",
-			Detail:        fmt.Sprintf("Attribute supports %d item maximum, but config has %d declared.", schema.MaxItems, rawV.Len()),
+			Detail:        fmt.Sprintf("Attribute %s supports %d item maximum, but config has %d declared.", k, schema.MaxItems, rawV.Len()),
 			AttributePath: path,
 		})
 	}
@@ -1955,7 +1955,7 @@ func (m schemaMap) validateList(
 		return append(diags, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       "Not enough list items",
-			Detail:        fmt.Sprintf("Attribute requires %d item minimum, but config has only %d declared.", schema.MinItems, rawV.Len()),
+			Detail:        fmt.Sprintf("Attribute %s requires %d item minimum, but config has only %d declared.", k, schema.MinItems, rawV.Len()),
 			AttributePath: path,
 		})
 	}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -6841,7 +6841,7 @@ func TestSchemaSet_ValidateMaxItems(t *testing.T) {
 			Diff: nil,
 			Err:  true,
 			Errors: []error{
-				fmt.Errorf("Error: Too many list items: Attribute supports 1 item maximum, but config has 2 declared."),
+				fmt.Errorf("Error: Too many list items: Attribute aliases supports 1 item maximum, but config has 2 declared."),
 			},
 		},
 		"#1": {
@@ -6876,6 +6876,40 @@ func TestSchemaSet_ValidateMaxItems(t *testing.T) {
 			Diff:   nil,
 			Err:    false,
 			Errors: nil,
+		},
+		"#3": {
+			Schema: map[string]*Schema{
+				"service_account": {
+					Type:     TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"aliases": {
+								Type:     TypeSet,
+								Optional: true,
+								MinItems: 2,
+								Elem:     &Schema{Type: TypeString},
+							},
+						},
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"service_account": []interface{}{
+					map[string]interface{}{
+						"aliases": []interface{}{"foo"},
+					},
+				},
+			},
+			Diff: nil,
+			Err:  true,
+			Errors: []error{
+				fmt.Errorf("Error: Not enough list items: Attribute service_account.0.aliases requires 2 item minimum, but config has only 1 declared."),
+			},
 		},
 	}
 
@@ -6963,7 +6997,41 @@ func TestSchemaSet_ValidateMinItems(t *testing.T) {
 			Diff: nil,
 			Err:  true,
 			Errors: []error{
-				fmt.Errorf("Error: Not enough list items: Attribute requires 2 item minimum, but config has only 1 declared."),
+				fmt.Errorf("Error: Not enough list items: Attribute aliases requires 2 item minimum, but config has only 1 declared."),
+			},
+		},
+		"#3": {
+			Schema: map[string]*Schema{
+				"service_account": {
+					Type:     TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"aliases": {
+								Type:     TypeSet,
+								Optional: true,
+								MinItems: 2,
+								Elem:     &Schema{Type: TypeString},
+							},
+						},
+					},
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"service_account": []interface{}{
+					map[string]interface{}{
+						"aliases": []interface{}{"foo"},
+					},
+				},
+			},
+			Diff: nil,
+			Err:  true,
+			Errors: []error{
+				fmt.Errorf("Error: Not enough list items: Attribute service_account.0.aliases requires 2 item minimum, but config has only 1 declared."),
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds the resource path to error messages when a list type either has too many or too few elements.