### PR TITLE
resource: Retry helper exits before callback finishes

### DIFF
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -225,12 +225,9 @@ func (conf *StateChangeConf) WaitForStateContext(ctx context.Context) (interface
 			return nil, ctx.Err()
 		case <-timeout:
 			log.Printf("[WARN] WaitForState timeout after %s", conf.Timeout)
-			log.Printf("[WARN] WaitForState starting %s refresh grace period", refreshGracePeriod)
 
-			// cancel the goroutine and start our grace period timer
+			// cancel the goroutine
 			close(cancelCh)
-			timeout := time.After(refreshGracePeriod)
-
 			// we need a for loop and a label to break on, because we may have
 			// an extra response value to read, but still want to wait for the
 			// channel to close.
@@ -252,10 +249,7 @@ func (conf *StateChangeConf) WaitForStateContext(ctx context.Context) (interface
 					// TimeoutError and wait for the channel to close
 					lastResult = r
 				case <-ctx.Done():
-					log.Println("[ERROR] Context cancelation detected, abandoning grace period")
-					break forSelect
-				case <-timeout:
-					log.Println("[ERROR] WaitForState exceeded refresh grace period")
+					log.Println("[ERROR] Context cancellation detected, abandoning grace period")
 					break forSelect
 				}
 			}

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -167,7 +167,7 @@ func TestWaitForState_timeout(t *testing.T) {
 		t.Fatal("Expected timeout error. No error returned.")
 	}
 
-	expectedErr := "timeout while waiting for state to become 'running' (timeout: 1ms)"
+	expectedErr := "timeout while waiting for state to become 'running' (timeout: 1ms): failed"
 	if err.Error() != expectedErr {
 		t.Fatalf("Errors don't match.\nExpected: %q\nGiven: %q\n", expectedErr, err.Error())
 	}

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -67,8 +67,8 @@ func TestRetry_hang(t *testing.T) {
 	}
 
 	err := Retry(50*time.Millisecond, f)
-	if err == nil {
-		t.Fatal("should error")
+	if err != nil {
+		t.Fatal("should not error")
 	}
 }
 


### PR DESCRIPTION
This is a copy of [https://github.com/hashicorp/terraform-plugin-sdk/pull/529](#529) with updated unit tests.
I'm seeing this issue regularly with our terraform provider.