### PR TITLE
Restore support for empty prefix in `ResourceDiff.GetChangedKeysPrefix`

### DIFF
--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -254,13 +254,13 @@ func (d *ResourceDiff) clear(key string) error {
 	return nil
 }
 
-// GetChangedKeysPrefix helps to implement Resource.CustomizeDiff
-// where we need to act on all nested fields
-// without calling out each one separately
+// GetChangedKeysPrefix helps to implement Resource.CustomizeDiff where we need to act
+// on all nested fields without calling out each one separately.
+// An empty prefix is supported, returning all changed keys.
 func (d *ResourceDiff) GetChangedKeysPrefix(prefix string) []string {
 	keys := make([]string, 0)
 	for k := range d.diff.Attributes {
-		if k == prefix || childAddrOf(k, prefix) {
+		if k == prefix || childAddrOf(k, prefix) || prefix == "" {
 			keys = append(keys, k)
 		}
 	}

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1312,7 +1312,7 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 				"foo": "abc",
 				"bar": []interface{}{
 					map[string]interface{}{
-						"baz": "abc",
+						"baz": "def",
 						"qux": "uvw",
 					},
 				},

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1275,6 +1275,62 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 			},
 		},
 		{
+			Name: "nested diff with empty prefix",
+			Schema: map[string]*Schema{
+				"foo": {
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"bar": {
+					Type:     TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"baz": {
+								Type:     TypeString,
+								Optional: true,
+							},
+							"qux": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo":       "abc",
+					"bar.#":     "1",
+					"bar.0.baz": "def",
+					"bar.0.qux": "xyz",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "abc",
+				"bar": []interface{}{
+					map[string]interface{}{
+						"baz": "abc",
+						"qux": "uvw",
+					},
+				},
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"bar.0.qux": {
+						Old: "xyz",
+						New: "uvw",
+					},
+				},
+			},
+			Key: "",
+			ExpectedKeys: []string{
+				"bar.0.qux",
+			},
+		},
+		{
 			Name: "nested field filtering",
 			Schema: map[string]*Schema{
 				"testfield": {

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1245,14 +1245,21 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 					Optional: true,
 					Computed: true,
 				},
+				"qux": {
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
 			},
 			State: &terraform.InstanceState{
 				Attributes: map[string]string{
 					"foo": "bar",
+					"qux": "abc",
 				},
 			},
 			Config: testConfig(t, map[string]interface{}{
 				"foo": "baz",
+				"qux": "abc",
 			}),
 			Diff: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1238,6 +1238,36 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 			},
 		},
 		{
+			Name: "basic primitive diff with empty prefix",
+			Schema: map[string]*Schema{
+				"foo": {
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "baz",
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": {
+						Old: "bar",
+						New: "baz",
+					},
+				},
+			},
+			Key: "",
+			ExpectedKeys: []string{
+				"foo",
+			},
+		},
+		{
 			Name: "nested field filtering",
 			Schema: map[string]*Schema{
 				"testfield": {


### PR DESCRIPTION
Closes #827.

```console
% go test ./helper/schema
ok  	github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema	0.629s
```