### PR TITLE
Add logging using terraform-plugin-log.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/go-hclog v0.16.1
+	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.1
 	github.com/hashicorp/go-uuid v1.0.2
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.15.0
 	github.com/hashicorp/terraform-json v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.5.0
-	github.com/hashicorp/terraform-plugin-log v0.2.0
+	github.com/hashicorp/terraform-plugin-log v0.2.1
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,9 @@ github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.16.1 h1:IVQwpTGNRRIHafnTs2dQLIk4ENtneRIEEJWOVDqz99o=
 github.com/hashicorp/go-hclog v0.16.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
+github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
@@ -198,8 +199,9 @@ github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniy
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hashicorp/terraform-plugin-go v0.5.0 h1:+gCDdF0hcYCm0YBTxrP4+K1NGIS5ZKZBKDORBewLJmg=
 github.com/hashicorp/terraform-plugin-go v0.5.0/go.mod h1:PAVN26PNGpkkmsvva1qfriae5Arky3xl3NfzKa8XFVM=
-github.com/hashicorp/terraform-plugin-log v0.2.0 h1:rjflRuBqCnSk3UHOR25MP1G5BDLKktTA6lNjjcAnBfI=
 github.com/hashicorp/terraform-plugin-log v0.2.0/go.mod h1:E1kJmapEHzqu1x6M++gjvhzM2yMQNXPVWZRCB8sgYjg=
+github.com/hashicorp/terraform-plugin-log v0.2.1 h1:hl0G6ctSx7DRTE62VNsPWrq7d+JWy1kjk9ApOFrCq3I=
+github.com/hashicorp/terraform-plugin-log v0.2.1/go.mod h1:RW/n0x4dyITmenuirZ1ViPQGP5JQdPTZ4Wwc0rLKi94=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -24,12 +24,12 @@ import (
 
 const (
 	newExtraKey        = "_new_extra_shim"
-	tflogSubsystemName = "sdkv2"
+	tflogSubsystemName = "helper_schema"
 )
 
 func withLogger(ctx context.Context) context.Context {
 	return tfsdklog.NewSubsystem(ctx, tflogSubsystemName,
-		tfsdklog.WithLevelFromEnv("TF_LOG_SDK_V2"))
+		tfsdklog.WithLevelFromEnv("TF_LOG_SDK_HELPER_SCHEMA"))
 }
 
 func NewGRPCProviderServer(p *Provider) *GRPCProviderServer {

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -83,7 +83,7 @@ func TestUpgradeState_jsonState(t *testing.T) {
 		},
 	}
 
-	resp, err := server.UpgradeResourceState(nil, req)
+	resp, err := server.UpgradeResourceState(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestUpgradeState_jsonStateBigInt(t *testing.T) {
 		},
 	}
 
-	resp, err := server.UpgradeResourceState(nil, req)
+	resp, err := server.UpgradeResourceState(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestUpgradeState_removedAttr(t *testing.T) {
 					JSON: []byte(tc.raw),
 				},
 			}
-			resp, err := server.UpgradeResourceState(nil, req)
+			resp, err := server.UpgradeResourceState(context.Background(), req)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -463,7 +463,7 @@ func TestUpgradeState_flatmapState(t *testing.T) {
 
 	for i, req := range testReqs {
 		t.Run(fmt.Sprintf("%d-%d", i, req.Version), func(t *testing.T) {
-			resp, err := server.UpgradeResourceState(nil, req)
+			resp, err := server.UpgradeResourceState(context.Background(), req)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -542,7 +542,7 @@ func TestUpgradeState_flatmapStateMissingMigrateState(t *testing.T) {
 
 	for i, req := range testReqs {
 		t.Run(fmt.Sprintf("%d-%d", i, req.Version), func(t *testing.T) {
-			resp, err := server.UpgradeResourceState(nil, req)
+			resp, err := server.UpgradeResourceState(context.Background(), req)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1542,7 +1542,7 @@ func TestPrepareProviderConfig(t *testing.T) {
 				},
 			}
 
-			resp, err := server.PrepareProviderConfig(nil, testReq)
+			resp, err := server.PrepareProviderConfig(context.Background(), testReq)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Start using terraform-plugin-log to log SDKv2 level logs, using an
SDKv2-specific subsystem. The environment variable `TF_LOG_SDK_V2`
controls the subsystem's log output.

Fixes #804.