### PR TITLE
Remove all or none of object keys in set

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1335,12 +1335,21 @@ func (m schemaMap) diffSet(
 			switch t := schema.Elem.(type) {
 			case *Resource:
 				// This is a complex resource
+				var subKs []string
+				newRemoved := true
 				for k2, schema := range t.Schema {
 					subK := fmt.Sprintf("%s.%s.%s", k, code, k2)
 					err := m.diff(subK, schema, diff, d, true)
 					if err != nil {
 						return err
 					}
+					subKs = append(subKs, subK)
+					if !diff.Attributes[subK].NewRemoved {
+						newRemoved = false
+					}
+				}
+				for _, subK := range subKs {
+					diff.Attributes[subK].NewRemoved = newRemoved
 				}
 			case *Schema:
 				// Copy the schema so that we can set Computed/ForceNew from


### PR DESCRIPTION
Please refer to my analysis from https://github.com/hashicorp/terraform-provider-helm/issues/817 to find out how the current behavior makes terraform-provider-helm create inconsistent final plan when value in set refers to unknown value that actually doesn't change after apply.

It looks that all object keys in set defined in schema are meant to be always present while object still in set. So my proposal is to delete a key from an object only when all keys of that object get deleted, which means an object itself gets deleted from set.

The latest 2.4.1 version of terraform-provider-helm uses terraform-plugin-sdk 2.8.0. I rebuilt and checked with 2.10.1 and the problem is still there.

I'm not a go/tf developer, so my code may be ugly and my reasoning may be absolutely wrong. So please be patient. At least it fixes https://github.com/hashicorp/terraform-provider-helm/issues/817.