### PR TITLE
deps: Remove github.com/golang/mock and github.com/go-test/deep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
 	github.com/aws/aws-sdk-go v1.25.3 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/go-test/deep v1.0.3
-	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -121,7 +121,6 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/helper/resource/testing_new_test.go
+++ b/helper/resource/testing_new_test.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	tfjson "github.com/hashicorp/terraform-json"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -1112,8 +1111,8 @@ func TestShimState(t *testing.T) {
 			// Lineage is randomly generated, so we wipe it to make comparing easier
 			shimmedState.Lineage = ""
 
-			if diff := deep.Equal(tc.ExpectedState, shimmedState); diff != nil {
-				t.Fatalf("state mismatch:\n%s", strings.Join(diff, "\n"))
+			if diff := cmp.Diff(tc.ExpectedState, shimmedState); diff != "" {
+				t.Fatalf("state mismatch:\n%s", diff)
 			}
 		})
 	}

--- a/internal/configs/hcl2shim/flatmap_test.go
+++ b/internal/configs/hcl2shim/flatmap_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-cty/cty"
 )
 
 func TestFlatmapValueFromHCL2(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Value cty.Value
 		Want  map[string]string
@@ -238,17 +240,23 @@ func TestFlatmapValueFromHCL2(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.Value.GoString(), func(t *testing.T) {
+			t.Parallel()
+
 			got := FlatmapValueFromHCL2(test.Value)
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if diff := cmp.Diff(got, test.Want); diff != "" {
+				t.Errorf("unexpected differences: %s", diff)
 			}
 		})
 	}
 }
 
 func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		Name string
 		Map  map[string]string
@@ -301,7 +309,11 @@ func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
 			val, err := HCL2ValueFromFlatmap(test.Map, test.Type)
 			if err != nil {
 				t.Fatal(err)
@@ -309,8 +321,8 @@ func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
 
 			got := FlatmapValueFromHCL2(val)
 
-			for _, problem := range deep.Equal(got, test.Map) {
-				t.Error(problem)
+			if diff := cmp.Diff(got, test.Map); diff != "" {
+				t.Errorf("unexpected differences: %s", diff)
 			}
 		})
 	}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -4,7 +4,6 @@
 package tools
 
 import (
-	_ "github.com/golang/mock/mockgen"
 	_ "golang.org/x/tools/cmd/cover"
 	_ "golang.org/x/tools/cmd/stringer"
 )


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/851
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/849

The `mockgen` command is not used in this repository and likely was a vestiage of splitting this repository from github.com/hashicorp/terraform.

This repository (and many of the other Terraform Plugin repositories) overwhelmingly use `go-cmp` instead of `deep`. The three usages are migrated for consistency and to remove this dependency.