### PR TITLE
Enable errcheck linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
   enable:
     - deadcode
     - durationcheck
-    # - errcheck # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - errcheck
     - exportloopref
     - gofmt
     # - gosimple # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

--- a/helper/customdiff/computed.go
+++ b/helper/customdiff/computed.go
@@ -2,6 +2,7 @@ package customdiff
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -11,7 +12,9 @@ import (
 func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 		if f(ctx, d, meta) {
-			d.SetNewComputed(key)
+			if err := d.SetNewComputed(key); err != nil {
+				return fmt.Errorf("unable to set %q to unknown: %w", key, err)
+			}
 		}
 		return nil
 	}

--- a/helper/customdiff/force_new.go
+++ b/helper/customdiff/force_new.go
@@ -2,6 +2,7 @@ package customdiff
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -15,7 +16,9 @@ import (
 func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 		if f(ctx, d, meta) {
-			d.ForceNew(key)
+			if err := d.ForceNew(key); err != nil {
+				return fmt.Errorf("unable to set %q to require replacement: %w", key, err)
+			}
 		}
 		return nil
 	}
@@ -35,7 +38,9 @@ func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDi
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 		old, new := d.GetChange(key)
 		if f(ctx, old, new, meta) {
-			d.ForceNew(key)
+			if err := d.ForceNew(key); err != nil {
+				return fmt.Errorf("unable to set %q to require replacement: %w", key, err)
+			}
 		}
 		return nil
 	}

--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -52,7 +52,7 @@ func prettyPrintJsonLines(b []byte) string {
 	for i, p := range parts {
 		if b := []byte(p); json.Valid(b) {
 			var out bytes.Buffer
-			json.Indent(&out, b, "", " ")
+			_ = json.Indent(&out, b, "", " ") // already checked for validity
 			parts[i] = out.String()
 		}
 	}

--- a/helper/resource/state_shim.go
+++ b/helper/resource/state_shim.go
@@ -226,7 +226,7 @@ func (sf *shimmedFlatmap) AddMap(prefix string, m map[string]interface{}) error 
 
 		err := sf.AddEntry(k, value)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to add map key %q entry: %w", k, err)
 		}
 	}
 
@@ -235,7 +235,9 @@ func (sf *shimmedFlatmap) AddMap(prefix string, m map[string]interface{}) error 
 		mapLength = fmt.Sprintf("%s.%s", prefix, "%")
 	}
 
-	sf.AddEntry(mapLength, strconv.Itoa(len(m)))
+	if err := sf.AddEntry(mapLength, strconv.Itoa(len(m))); err != nil {
+		return fmt.Errorf("unable to add map length %q entry: %w", mapLength, err)
+	}
 
 	return nil
 }
@@ -245,12 +247,14 @@ func (sf *shimmedFlatmap) AddSlice(name string, elements []interface{}) error {
 		key := fmt.Sprintf("%s.%d", name, i)
 		err := sf.AddEntry(key, elem)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to add slice key %q entry: %w", key, err)
 		}
 	}
 
 	sliceLength := fmt.Sprintf("%s.#", name)
-	sf.AddEntry(sliceLength, strconv.Itoa(len(elements)))
+	if err := sf.AddEntry(sliceLength, strconv.Itoa(len(elements))); err != nil {
+		return fmt.Errorf("unable to add slice length %q entry: %w", sliceLength, err)
+	}
 
 	return nil
 }

--- a/helper/schema/field_writer_map.go
+++ b/helper/schema/field_writer_map.go
@@ -148,7 +148,7 @@ func (w *MapFieldWriter) setList(
 	if err != nil {
 		for i := range vs {
 			is := strconv.FormatInt(int64(i), 10)
-			setElement(is, nil)
+			_ = setElement(is, nil) // best effort; error returned below
 		}
 
 		return err
@@ -228,11 +228,13 @@ func (w *MapFieldWriter) setObject(
 	}
 	if err != nil {
 		for k1 := range v {
-			w.set(append(addrCopy, k1), nil)
+			_ = w.set(append(addrCopy, k1), nil) // best effort; error returned below
 		}
+
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (w *MapFieldWriter) setPrimitive(

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -2319,7 +2319,13 @@ func TestStopContext_stop(t *testing.T) {
 				}
 				close(doneCh)
 			}()
-			server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			if err != nil {
+				t.Fatalf("unexpected StopProvider error: %s", err)
+			}
+
 			select {
 			case <-doneCh:
 			case err := <-errCh:
@@ -2437,7 +2443,13 @@ func TestStopContext_stopReset(t *testing.T) {
 				}
 				close(d)
 			}(doneCh)
-			server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			if err != nil {
+				t.Fatalf("unexpected StopProvider error: %s", err)
+			}
+
 			select {
 			case <-doneCh:
 			case err := <-errCh:
@@ -2461,7 +2473,13 @@ func TestStopContext_stopReset(t *testing.T) {
 				}
 				close(d)
 			}(doneCh)
-			server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
+
+			if err != nil {
+				t.Fatalf("unexpected StopProvider error: %s", err)
+			}
+
 			select {
 			case <-doneCh:
 			case err := <-errCh:

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -2320,9 +2320,7 @@ func TestStopContext_stop(t *testing.T) {
 				close(doneCh)
 			}()
 
-			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
-
-			if err != nil {
+			if _, err := server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{}); err != nil {
 				t.Fatalf("unexpected StopProvider error: %s", err)
 			}
 
@@ -2444,9 +2442,7 @@ func TestStopContext_stopReset(t *testing.T) {
 				close(d)
 			}(doneCh)
 
-			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
-
-			if err != nil {
+			if _, err := server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{}); err != nil {
 				t.Fatalf("unexpected StopProvider error: %s", err)
 			}
 
@@ -2474,9 +2470,7 @@ func TestStopContext_stopReset(t *testing.T) {
 				close(d)
 			}(doneCh)
 
-			_, err = server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
-
-			if err != nil {
+			if _, err := server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{}); err != nil {
 				t.Fatalf("unexpected StopProvider error: %s", err)
 			}
 

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1853,7 +1853,10 @@ func TestResourceDiffGetOkExistsSetNew(t *testing.T) {
 	}
 
 	d := newResourceDiff(tc.Schema, testConfig(t, map[string]interface{}{}), tc.State, tc.Diff)
-	d.SetNew(tc.Key, tc.Value)
+
+	if err := d.SetNew(tc.Key, tc.Value); err != nil {
+		t.Fatalf("unexpected SetNew error: %s", err)
+	}
 
 	v, ok := d.GetOkExists(tc.Key)
 	if s, ok := v.(*Set); ok {
@@ -1901,7 +1904,10 @@ func TestResourceDiffGetOkExistsSetNewComputed(t *testing.T) {
 	}
 
 	d := newResourceDiff(tc.Schema, testConfig(t, map[string]interface{}{}), tc.State, tc.Diff)
-	d.SetNewComputed(tc.Key)
+
+	if err := d.SetNewComputed(tc.Key); err != nil {
+		t.Fatalf("unexpected SetNewComputed error: %s", err)
+	}
 
 	_, ok := d.GetOkExists(tc.Key)
 
@@ -2142,7 +2148,10 @@ func TestResourceDiffNewValueKnownSetNew(t *testing.T) {
 	}
 
 	d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
-	d.SetNew(tc.Key, tc.Value)
+
+	if err := d.SetNew(tc.Key, tc.Value); err != nil {
+		t.Fatalf("unexpected SetNew error: %s", err)
+	}
 
 	actual := d.NewValueKnown(tc.Key)
 	if tc.Expected != actual {
@@ -2179,7 +2188,10 @@ func TestResourceDiffNewValueKnownSetNewComputed(t *testing.T) {
 	}
 
 	d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
-	d.SetNewComputed(tc.Key)
+
+	if err := d.SetNewComputed(tc.Key); err != nil {
+		t.Fatalf("unexpected SetNewComputed error: %s", err)
+	}
 
 	actual := d.NewValueKnown(tc.Key)
 	if tc.Expected != actual {

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -412,7 +412,9 @@ func TestResourceApply_destroyPartial(t *testing.T) {
 	}
 
 	r.Delete = func(d *ResourceData, m interface{}) error {
-		d.Set("foo", 42)
+		if err := d.Set("foo", 42); err != nil {
+			return fmt.Errorf("unexpected Set error: %s", err)
+		}
 		return fmt.Errorf("some error")
 	}
 
@@ -459,7 +461,9 @@ func TestResourceApply_update(t *testing.T) {
 	}
 
 	r.Update = func(d *ResourceData, m interface{}) error {
-		d.Set("foo", 42)
+		if err := d.Set("foo", 42); err != nil {
+			return fmt.Errorf("unexpected Set error: %s", err)
+		}
 		return nil
 	}
 
@@ -551,15 +555,21 @@ func TestResourceApply_isNewResource(t *testing.T) {
 	}
 
 	updateFunc := func(d *ResourceData, m interface{}) error {
-		d.Set("foo", "updated")
+		if err := d.Set("foo", "updated"); err != nil {
+			return fmt.Errorf("unexpected Set error: %s", err)
+		}
 		if d.IsNewResource() {
-			d.Set("foo", "new-resource")
+			if err := d.Set("foo", "new-resource"); err != nil {
+				return fmt.Errorf("unexpected Set error: %s", err)
+			}
 		}
 		return nil
 	}
 	r.Create = func(d *ResourceData, m interface{}) error {
 		d.SetId("foo")
-		d.Set("foo", "created")
+		if err := d.Set("foo", "created"); err != nil {
+			return fmt.Errorf("unexpected Set error: %s", err)
+		}
 		return updateFunc(d, m)
 	}
 	r.Update = updateFunc

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2945,7 +2945,9 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			CustomizeDiff: func(_ context.Context, d *ResourceDiff, meta interface{}) error {
 				if d.HasChange("etag") {
-					d.SetNewComputed("version_id")
+					if err := d.SetNewComputed("version_id"); err != nil {
+						return fmt.Errorf("unexpected SetNewComputed error: %w", err)
+					}
 				}
 				return nil
 			},
@@ -2986,7 +2988,10 @@ func TestSchemaMap_Diff(t *testing.T) {
 			Config: map[string]interface{}{},
 
 			CustomizeDiff: func(_ context.Context, d *ResourceDiff, meta interface{}) error {
-				d.SetNewComputed("foo")
+				if err := d.SetNewComputed("foo"); err != nil {
+					return fmt.Errorf("unexpected SetNewComputed error: %w", err)
+				}
+
 				return nil
 			},
 

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -3236,7 +3236,9 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 
 			CustomizeDiff: func(_ context.Context, d *ResourceDiff, meta interface{}) error {
 				if d.HasChange("etag") {
-					d.SetNewComputed("version_id")
+					if err := d.SetNewComputed("version_id"); err != nil {
+						return fmt.Errorf("unexpected SetNewComputed error: %w", err)
+					}
 				}
 				return nil
 			},

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -100,7 +100,9 @@ func (wd *WorkingDir) SetConfig(cfg string) error {
 	}
 
 	if p := os.Getenv("TF_ACC_LOG_PATH"); p != "" {
-		wd.tf.SetLogPath(p)
+		if err := wd.tf.SetLogPath(p); err != nil {
+			return fmt.Errorf("unable to set log path: %w", err)
+		}
 	}
 
 	// Changing configuration invalidates any saved plan.


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

Previously:

```text
helper/logging/transport.go:55:15: Error return value of `json.Indent` is not checked (errcheck)
                        json.Indent(&out, b, "", " ")
                                   ^
internal/plugintest/working_dir.go:103:19: Error return value of `wd.tf.SetLogPath` is not checked (errcheck)
                wd.tf.SetLogPath(p)
                                ^
helper/customdiff/computed.go:14:20: Error return value of `d.SetNewComputed` is not checked (errcheck)
                        d.SetNewComputed(key)
                                        ^
helper/customdiff/force_new.go:18:14: Error return value of `d.ForceNew` is not checked (errcheck)
                        d.ForceNew(key)
                                  ^
helper/customdiff/force_new.go:38:14: Error return value of `d.ForceNew` is not checked (errcheck)
                        d.ForceNew(key)
                                  ^
helper/resource/state_shim.go:238:13: Error return value of `sf.AddEntry` is not checked (errcheck)
        sf.AddEntry(mapLength, strconv.Itoa(len(m)))
                   ^
helper/resource/state_shim.go:253:13: Error return value of `sf.AddEntry` is not checked (errcheck)
        sf.AddEntry(sliceLength, strconv.Itoa(len(elements)))
                   ^
helper/schema/field_writer_map.go:151:14: Error return value is not checked (errcheck)
                        setElement(is, nil)
                                  ^
helper/schema/field_writer_map.go:231:9: Error return value of `w.set` is not checked (errcheck)
                        w.set(append(addrCopy, k1), nil)
                             ^
helper/schema/grpc_provider_test.go:2322:23: Error return value of `server.StopProvider` is not checked (errcheck)
                        server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
                                           ^
helper/schema/grpc_provider_test.go:2440:23: Error return value of `server.StopProvider` is not checked (errcheck)
                        server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
                                           ^
helper/schema/grpc_provider_test.go:2464:23: Error return value of `server.StopProvider` is not checked (errcheck)
                        server.StopProvider(context.Background(), &tfprotov5.StopProviderRequest{})
                                           ^
helper/schema/resource_diff_test.go:1856:10: Error return value of `d.SetNew` is not checked (errcheck)
        d.SetNew(tc.Key, tc.Value)
                ^
helper/schema/resource_diff_test.go:1904:18: Error return value of `d.SetNewComputed` is not checked (errcheck)
        d.SetNewComputed(tc.Key)
                        ^
helper/schema/resource_diff_test.go:2145:10: Error return value of `d.SetNew` is not checked (errcheck)
        d.SetNew(tc.Key, tc.Value)
                ^
helper/schema/resource_diff_test.go:2182:18: Error return value of `d.SetNewComputed` is not checked (errcheck)
        d.SetNewComputed(tc.Key)
                        ^
helper/schema/resource_test.go:415:8: Error return value of `d.Set` is not checked (errcheck)
                d.Set("foo", 42)
                     ^
helper/schema/resource_test.go:462:8: Error return value of `d.Set` is not checked (errcheck)
                d.Set("foo", 42)
                     ^
helper/schema/resource_test.go:554:8: Error return value of `d.Set` is not checked (errcheck)
                d.Set("foo", "updated")
                     ^
helper/schema/resource_test.go:556:9: Error return value of `d.Set` is not checked (errcheck)
                        d.Set("foo", "new-resource")
                             ^
helper/schema/resource_test.go:562:8: Error return value of `d.Set` is not checked (errcheck)
                d.Set("foo", "created")
                     ^
helper/schema/schema_test.go:2948:22: Error return value of `d.SetNewComputed` is not checked (errcheck)
                                        d.SetNewComputed("version_id")
                                                        ^
helper/schema/schema_test.go:2989:21: Error return value of `d.SetNewComputed` is not checked (errcheck)
                                d.SetNewComputed("foo")
                                                ^
helper/schema/shims_test.go:3239:22: Error return value of `d.SetNewComputed` is not checked (errcheck)
                                        d.SetNewComputed("version_id")
```