### PR TITLE
Enable ineffassign linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - exportloopref
     - gofmt
     # - gosimple # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
-    # - ineffassign # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - ineffassign
     # - makezero # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - nilerr # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -10,27 +10,20 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	ctyconvert "github.com/hashicorp/go-cty/cty/convert"
 	"github.com/hashicorp/go-cty/cty/msgpack"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/plans/objchange"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugin/convert"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	newExtraKey        = "_new_extra_shim"
-	tflogSubsystemName = "helper_schema"
+	newExtraKey = "_new_extra_shim"
 )
-
-func withLogger(ctx context.Context) context.Context {
-	return tfsdklog.NewSubsystem(ctx, tflogSubsystemName,
-		tfsdklog.WithLevelFromEnv("TF_LOG_SDK_HELPER_SCHEMA"))
-}
 
 func NewGRPCProviderServer(p *Provider) *GRPCProviderServer {
 	return &GRPCProviderServer{
@@ -62,7 +55,7 @@ func mergeStop(ctx context.Context, cancel context.CancelFunc, stopCh chan struc
 // It creates a goroutine to wait for the server stop and propagates
 // cancellation to the derived grpc context.
 func (s *GRPCProviderServer) StopContext(ctx context.Context) context.Context {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	s.stopMu.Lock()
 	defer s.stopMu.Unlock()
 
@@ -72,7 +65,9 @@ func (s *GRPCProviderServer) StopContext(ctx context.Context) context.Context {
 }
 
 func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Getting provider schema")
 
 	resp := &tfprotov5.GetProviderSchemaResponse{
 		ResourceSchemas:   make(map[string]*tfprotov5.Schema),
@@ -88,6 +83,8 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 	}
 
 	for typ, res := range s.provider.ResourcesMap {
+		logging.HelperSchemaTrace(ctx, "Found resource type", logging.KeyResourceType, typ)
+
 		resp.ResourceSchemas[typ] = &tfprotov5.Schema{
 			Version: int64(res.SchemaVersion),
 			Block:   convert.ConfigSchemaToProto(res.CoreConfigSchema()),
@@ -95,6 +92,8 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 	}
 
 	for typ, dat := range s.provider.DataSourcesMap {
+		logging.HelperSchemaTrace(ctx, "Found data source type", logging.KeyDataSourceType, typ)
+
 		resp.DataSourceSchemas[typ] = &tfprotov5.Schema{
 			Version: int64(dat.SchemaVersion),
 			Block:   convert.ConfigSchemaToProto(dat.CoreConfigSchema()),
@@ -123,8 +122,10 @@ func (s *GRPCProviderServer) getDatasourceSchemaBlock(name string) *configschema
 }
 
 func (s *GRPCProviderServer) PrepareProviderConfig(ctx context.Context, req *tfprotov5.PrepareProviderConfigRequest) (*tfprotov5.PrepareProviderConfigResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.PrepareProviderConfigResponse{}
+
+	logging.HelperSchemaTrace(ctx, "Preparing provider configuration")
 
 	schemaBlock := s.getProviderSchemaBlock()
 
@@ -213,7 +214,9 @@ func (s *GRPCProviderServer) PrepareProviderConfig(ctx context.Context, req *tfp
 
 	config := terraform.NewResourceConfigShimmed(configVal, schemaBlock)
 
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, s.provider.Validate(config))
+	logging.HelperSchemaTrace(ctx, "Called downstream")
 
 	preparedConfigMP, err := msgpack.Marshal(configVal, schemaBlock.ImpliedType())
 	if err != nil {
@@ -227,7 +230,7 @@ func (s *GRPCProviderServer) PrepareProviderConfig(ctx context.Context, req *tfp
 }
 
 func (s *GRPCProviderServer) ValidateResourceTypeConfig(ctx context.Context, req *tfprotov5.ValidateResourceTypeConfigRequest) (*tfprotov5.ValidateResourceTypeConfigResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ValidateResourceTypeConfigResponse{}
 
 	schemaBlock := s.getResourceSchemaBlock(req.TypeName)
@@ -240,13 +243,15 @@ func (s *GRPCProviderServer) ValidateResourceTypeConfig(ctx context.Context, req
 
 	config := terraform.NewResourceConfigShimmed(configVal, schemaBlock)
 
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, s.provider.ValidateResource(req.TypeName, config))
+	logging.HelperSchemaTrace(ctx, "Called downstream")
 
 	return resp, nil
 }
 
 func (s *GRPCProviderServer) ValidateDataSourceConfig(ctx context.Context, req *tfprotov5.ValidateDataSourceConfigRequest) (*tfprotov5.ValidateDataSourceConfigResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ValidateDataSourceConfigResponse{}
 
 	schemaBlock := s.getDatasourceSchemaBlock(req.TypeName)
@@ -265,13 +270,15 @@ func (s *GRPCProviderServer) ValidateDataSourceConfig(ctx context.Context, req *
 
 	config := terraform.NewResourceConfigShimmed(configVal, schemaBlock)
 
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, s.provider.ValidateDataSource(req.TypeName, config))
+	logging.HelperSchemaTrace(ctx, "Called downstream")
 
 	return resp, nil
 }
 
 func (s *GRPCProviderServer) UpgradeResourceState(ctx context.Context, req *tfprotov5.UpgradeResourceStateRequest) (*tfprotov5.UpgradeResourceStateResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.UpgradeResourceStateResponse{}
 
 	res, ok := s.provider.ResourcesMap[req.TypeName]
@@ -290,6 +297,8 @@ func (s *GRPCProviderServer) UpgradeResourceState(ctx context.Context, req *tfpr
 	// We first need to upgrade a flatmap state if it exists.
 	// There should never be both a JSON and Flatmap state in the request.
 	case len(req.RawState.Flatmap) > 0:
+		logging.HelperSchemaTrace(ctx, "Upgrading flatmap state")
+
 		jsonMap, version, err = s.upgradeFlatmapState(ctx, version, req.RawState.Flatmap, res)
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -307,11 +316,13 @@ func (s *GRPCProviderServer) UpgradeResourceState(ctx context.Context, req *tfpr
 			return resp, nil
 		}
 	default:
-		tfsdklog.SubsystemDebug(ctx, tflogSubsystemName, "no state provided to upgrade")
+		logging.HelperSchemaDebug(ctx, "no state provided to upgrade")
 		return resp, nil
 	}
 
 	// complete the upgrade of the JSON states
+	logging.HelperSchemaTrace(ctx, "Upgrading JSON state")
+
 	jsonMap, err = s.upgradeJSONState(ctx, version, jsonMap, res)
 	if err != nil {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -472,14 +483,14 @@ func (s *GRPCProviderServer) removeAttributes(ctx context.Context, v interface{}
 		}
 
 		if ty == cty.DynamicPseudoType {
-			tflog.SubsystemDebug(ctx, tflogSubsystemName, "ignoring dynamic block", "block", v)
+			logging.HelperSchemaDebug(ctx, "ignoring dynamic block", "block", v)
 			return
 		}
 
 		if !ty.IsObjectType() {
 			// This shouldn't happen, and will fail to decode further on, so
 			// there's no need to handle it here.
-			tflog.SubsystemWarn(ctx, tflogSubsystemName, "unexpected type for map in JSON state", "type", ty)
+			logging.HelperSchemaWarn(ctx, "unexpected type for map in JSON state", "type", ty)
 			return
 		}
 
@@ -487,7 +498,7 @@ func (s *GRPCProviderServer) removeAttributes(ctx context.Context, v interface{}
 		for attr, attrV := range v {
 			attrTy, ok := attrTypes[attr]
 			if !ok {
-				tflog.SubsystemDebug(ctx, tflogSubsystemName, "attribute no longer present in schema", "attribute", attr)
+				logging.HelperSchemaDebug(ctx, "attribute no longer present in schema", "attribute", attr)
 				delete(v, attr)
 				continue
 			}
@@ -498,7 +509,10 @@ func (s *GRPCProviderServer) removeAttributes(ctx context.Context, v interface{}
 }
 
 func (s *GRPCProviderServer) StopProvider(ctx context.Context, _ *tfprotov5.StopProviderRequest) (*tfprotov5.StopProviderResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Stopping provider")
+
 	s.stopMu.Lock()
 	defer s.stopMu.Unlock()
 
@@ -507,11 +521,13 @@ func (s *GRPCProviderServer) StopProvider(ctx context.Context, _ *tfprotov5.Stop
 	// reset the stop signal
 	s.stopCh = make(chan struct{})
 
+	logging.HelperSchemaTrace(ctx, "Stopped provider")
+
 	return &tfprotov5.StopProviderResponse{}, nil
 }
 
 func (s *GRPCProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov5.ConfigureProviderRequest) (*tfprotov5.ConfigureProviderResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ConfigureProviderResponse{}
 
 	schemaBlock := s.getProviderSchemaBlock()
@@ -537,14 +553,18 @@ func (s *GRPCProviderServer) ConfigureProvider(ctx context.Context, req *tfproto
 	// function. Ideally a provider should migrate to the context aware API that receives
 	// request scoped contexts, however this is a large undertaking for very large providers.
 	ctxHack := context.WithValue(ctx, StopContextKey, s.StopContext(context.Background()))
+
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	diags := s.provider.Configure(ctxHack, config)
+	logging.HelperSchemaTrace(ctx, "Called downstream")
+
 	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, diags)
 
 	return resp, nil
 }
 
 func (s *GRPCProviderServer) ReadResource(ctx context.Context, req *tfprotov5.ReadResourceRequest) (*tfprotov5.ReadResourceResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ReadResourceResponse{
 		// helper/schema did previously handle private data during refresh, but
 		// core is now going to expect this to be maintained in order to
@@ -637,7 +657,7 @@ func (s *GRPCProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Re
 }
 
 func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.PlanResourceChangeResponse{}
 
 	// This is a signal to Terraform Core that we're doing the best we can to
@@ -752,6 +772,11 @@ func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprot
 
 	// now we need to apply the diff to the prior state, so get the planned state
 	plannedAttrs, err := diff.Apply(priorState.Attributes, schemaBlock)
+
+	if err != nil {
+		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
+		return resp, nil
+	}
 
 	plannedStateVal, err := hcl2shim.HCL2ValueFromFlatmap(plannedAttrs, schemaBlock.ImpliedType())
 	if err != nil {
@@ -874,7 +899,7 @@ func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprot
 }
 
 func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ApplyResourceChangeResponse{
 		// Start with the existing state as a fallback
 		NewState: req.PriorState,
@@ -1054,7 +1079,7 @@ func (s *GRPCProviderServer) ApplyResourceChange(ctx context.Context, req *tfpro
 }
 
 func (s *GRPCProviderServer) ImportResourceState(ctx context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ImportResourceStateResponse{}
 
 	info := &terraform.InstanceInfo{
@@ -1113,7 +1138,7 @@ func (s *GRPCProviderServer) ImportResourceState(ctx context.Context, req *tfpro
 }
 
 func (s *GRPCProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
-	ctx = withLogger(ctx)
+	ctx = logging.InitContext(ctx)
 	resp := &tfprotov5.ReadDataSourceResponse{}
 
 	schemaBlock := s.getDatasourceSchemaBlock(req.TypeName)

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/configschema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -378,11 +379,15 @@ func (p *Provider) ImportState(
 	results := []*ResourceData{data}
 	if r.Importer.State != nil || r.Importer.StateContext != nil {
 		var err error
+		logging.HelperSchemaTrace(ctx, "Calling downstream")
+
 		if r.Importer.StateContext != nil {
 			results, err = r.Importer.StateContext(ctx, data, p.meta)
 		} else {
 			results, err = r.Importer.State(data, p.meta)
 		}
+		logging.HelperSchemaTrace(ctx, "Called downstream")
+
 		if err != nil {
 			return nil, err
 		}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -436,7 +437,10 @@ func (r *Resource) Apply(
 	if d.Destroy || d.RequiresNew() {
 		if s.ID != "" {
 			// Destroy the resource since it is created
+			logging.HelperSchemaTrace(ctx, "Calling downstream")
 			diags = append(diags, r.delete(ctx, data, meta)...)
+			logging.HelperSchemaTrace(ctx, "Called downstream")
+
 			if diags.HasError() {
 				return r.recordCurrentSchemaVersion(data.State()), diags
 			}
@@ -464,7 +468,9 @@ func (r *Resource) Apply(
 	if data.Id() == "" {
 		// We're creating, it is a new resource.
 		data.MarkNewResource()
+		logging.HelperSchemaTrace(ctx, "Calling downstream")
 		diags = append(diags, r.create(ctx, data, meta)...)
+		logging.HelperSchemaTrace(ctx, "Called downstream")
 	} else {
 		if !r.updateFuncSet() {
 			return s, append(diags, diag.Diagnostic{
@@ -472,7 +478,9 @@ func (r *Resource) Apply(
 				Summary:  "doesn't support update",
 			})
 		}
+		logging.HelperSchemaTrace(ctx, "Calling downstream")
 		diags = append(diags, r.update(ctx, data, meta)...)
+		logging.HelperSchemaTrace(ctx, "Called downstream")
 	}
 
 	return r.recordCurrentSchemaVersion(data.State()), diags
@@ -566,7 +574,10 @@ func (r *Resource) ReadDataApply(
 		return nil, diag.FromErr(err)
 	}
 
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	diags := r.read(ctx, data, meta)
+	logging.HelperSchemaTrace(ctx, "Called downstream")
+
 	state := data.State()
 	if state != nil && state.ID == "" {
 		// Data sources can set an ID if they want, but they aren't
@@ -612,7 +623,10 @@ func (r *Resource) RefreshWithoutUpgrade(
 			data.providerMeta = s.ProviderMeta
 		}
 
+		logging.HelperSchemaTrace(ctx, "Calling downstream")
 		exists, err := r.Exists(data, meta)
+		logging.HelperSchemaTrace(ctx, "Called downstream")
+
 		if err != nil {
 			return s, diag.FromErr(err)
 		}
@@ -632,7 +646,10 @@ func (r *Resource) RefreshWithoutUpgrade(
 		data.providerMeta = s.ProviderMeta
 	}
 
+	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	diags := r.read(ctx, data, meta)
+	logging.HelperSchemaTrace(ctx, "Called downstream")
+
 	state := data.State()
 	if state != nil && state.ID == "" {
 		state = nil

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -528,7 +528,7 @@ func (d *ResourceData) getChange(
 func (d *ResourceData) get(addr []string, source getSource) getResult {
 	d.once.Do(d.init)
 
-	level := "set"
+	var level string
 	flags := source & ^getSourceLevelMask
 	exact := flags&getSourceExact != 0
 	source = source & getSourceLevelMask

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/hcl2shim"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -544,7 +545,12 @@ func (m schemaMap) Diff(
 	if !result.DestroyTainted && customizeDiff != nil {
 		mc := m.DeepCopy()
 		rd := newResourceDiff(mc, c, s, result)
-		if err := customizeDiff(ctx, rd, meta); err != nil {
+
+		logging.HelperSchemaTrace(ctx, "Calling downstream")
+		err := customizeDiff(ctx, rd, meta)
+		logging.HelperSchemaTrace(ctx, "Called downstream")
+
+		if err != nil {
 			return nil, err
 		}
 		for _, k := range rd.UpdatedKeys() {

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -1,0 +1,14 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+// InitContext creates SDK logger contexts.
+func InitContext(ctx context.Context) context.Context {
+	ctx = tfsdklog.NewSubsystem(ctx, SubsystemHelperSchema, tfsdklog.WithLevelFromEnv(EnvTfLogSdkHelperSchema))
+
+	return ctx
+}

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -1,0 +1,9 @@
+package logging
+
+// Environment variables.
+const (
+	// EnvTfLogSdkHelperSchema is an environment variable that sets the logging
+	// level of SDK helper/schema loggers. Infers root SDK logging level, if
+	// unset.
+	EnvTfLogSdkHelperSchema = "TF_LOG_SDK_HELPER_SCHEMA"
+)

--- a/internal/logging/helper_schema.go
+++ b/internal/logging/helper_schema.go
@@ -1,0 +1,27 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const (
+	// SubsystemHelperSchema is the tfsdklog subsystem name for helper/schema.
+	SubsystemHelperSchema = "helper_schema"
+)
+
+// HelperSchemaDebug emits a helper/schema subsystem log at DEBUG level.
+func HelperSchemaDebug(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemDebug(ctx, SubsystemHelperSchema, msg, args)
+}
+
+// HelperSchemaTrace emits a helper/schema subsystem log at TRACE level.
+func HelperSchemaTrace(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemTrace(ctx, SubsystemHelperSchema, msg, args)
+}
+
+// HelperSchemaWarn emits a helper/schema subsystem log at WARN level.
+func HelperSchemaWarn(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemWarn(ctx, SubsystemHelperSchema, msg, args)
+}

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -1,0 +1,16 @@
+package logging
+
+// Structured logging keys.
+//
+// Practitioners or tooling reading logs may be depending on these keys, so be
+// conscious of that when changing them.
+//
+// Refer to the terraform-plugin-go logging keys as well, which should be
+// equivalent to these when possible.
+const (
+	// The type of resource being operated on, such as "random_pet"
+	KeyResourceType = "tf_resource_type"
+
+	// The type of data source being operated on, such as "archive_file"
+	KeyDataSourceType = "tf_data_source_type"
+)

--- a/internal/plugintest/util.go
+++ b/internal/plugintest/util.go
@@ -1,20 +1,31 @@
 package plugintest
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
-func symlinkFile(src string, dest string) (err error) {
-	err = os.Symlink(src, dest)
-	if err == nil {
-		srcInfo, err := os.Stat(src)
-		if err != nil {
-			err = os.Chmod(dest, srcInfo.Mode())
-		}
+func symlinkFile(src string, dest string) error {
+	err := os.Symlink(src, dest)
+
+	if err != nil {
+		return fmt.Errorf("unable to symlink %q to %q: %w", src, dest, err)
 	}
 
-	return
+	srcInfo, err := os.Stat(src)
+
+	if err != nil {
+		return fmt.Errorf("unable to stat %q: %w", src, err)
+	}
+
+	err = os.Chmod(dest, srcInfo.Mode())
+
+	if err != nil {
+		return fmt.Errorf("unable to set %q permissions: %w", dest, err)
+	}
+
+	return nil
 }
 
 // symlinkDir is a simplistic function for recursively symlinking all files in a directory to a new path.


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
Reference: https://github.com/hashicorp/terraform-plugin-go/tree/main/internal/logging

The majority of these issues were in the gRPC server handling for some recent inclusion of logging that did not include other context handling. This adds some logic handoff trace logs to the helper/schema logger and starts an internal logging package, similar to the terraform-plugin-go implementation.

Previously:

```text
internal/plugintest/util.go:13:4: ineffectual assignment to err (ineffassign)
                        err = os.Chmod(dest, srcInfo.Mode())
                        ^
helper/schema/grpc_provider.go:75:2: ineffectual assignment to ctx (ineffassign)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:126:2: ineffectual assignment to ctx (ineffassign)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:230:2: ineffectual assignment to ctx (ineffassign)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:249:2: ineffectual assignment to ctx (ineffassign)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:501:2: ineffectual assignment to ctx (ineffassign)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:754:16: ineffectual assignment to err (ineffassign)
        plannedAttrs, err := diff.Apply(priorState.Attributes, schemaBlock)
                      ^
helper/schema/resource_data.go:531:2: ineffectual assignment to level (ineffassign)
        level := "set"
        ^
```