### PR TITLE
Enable nilerr linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     # - gosimple # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - ineffassign # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - makezero # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
-    # - nilerr # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - nilerr
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     # - predeclared # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - staticcheck # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -203,7 +203,7 @@ func (r *ConfigFieldReader) readMap(k string, schema *Schema) (FieldReadResult, 
 
 	err := mapValuesToPrimitive(k, result, schema)
 	if err != nil {
-		return FieldReadResult{}, nil
+		return FieldReadResult{}, nil //nolint:nilerr // Leave legacy flatmap handling
 	}
 
 	var value interface{}

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -128,7 +128,7 @@ func (r *DiffFieldReader) readMap(
 	key := address[len(address)-1]
 	err = mapValuesToPrimitive(key, result, schema)
 	if err != nil {
-		return FieldReadResult{}, nil
+		return FieldReadResult{}, nil //nolint:nilerr // Leave legacy flatmap handling
 	}
 
 	var resultVal interface{}

--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -63,7 +63,7 @@ func (r *MapFieldReader) readMap(k string, schema *Schema) (FieldReadResult, err
 
 	err := mapValuesToPrimitive(k, result, schema)
 	if err != nil {
-		return FieldReadResult{}, nil
+		return FieldReadResult{}, nil //nolint:nilerr // Leave legacy flatmap handling
 	}
 
 	var resultVal interface{}

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -168,8 +168,7 @@ func (s *GRPCProviderServer) PrepareProviderConfig(ctx context.Context, req *tfp
 		// find a default value if it exists
 		def, err := attrSchema.DefaultValue()
 		if err != nil {
-			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("error getting default for %q: %s", getAttr.Name, err))
-			return val, err
+			return val, fmt.Errorf("error getting default for %q: %w", getAttr.Name, err)
 		}
 
 		// no default
@@ -189,13 +188,13 @@ func (s *GRPCProviderServer) PrepareProviderConfig(ctx context.Context, req *tfp
 
 		val, err = ctyconvert.Convert(tmpVal, val.Type())
 		if err != nil {
-			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("error setting default for %q: %s", getAttr.Name, err))
+			return val, fmt.Errorf("error setting default for %q: %w", getAttr.Name, err)
 		}
 
-		return val, err
+		return val, nil
 	})
 	if err != nil {
-		// any error here was already added to the diagnostics
+		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
 		return resp, nil
 	}
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

The field reader/writing handling of this codebase is generally considered frozen, but we want to catch and fix other potential `nilerr` issues.

Previously:

```text
helper/schema/field_reader_config.go:206:3: error is not nil (line 204) but it returns nil (nilerr)
                return FieldReadResult{}, nil
                ^
helper/schema/field_reader_diff.go:131:3: error is not nil (line 129) but it returns nil (nilerr)
                return FieldReadResult{}, nil
                ^
helper/schema/field_reader_map.go:66:3: error is not nil (line 64) but it returns nil (nilerr)
                return FieldReadResult{}, nil
                ^
helper/schema/grpc_provider.go:199:3: error is not nil (line 139) but it returns nil (nilerr)
                return resp, nil
                ^
```