### PR TITLE
Enable predeclared linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     # - makezero # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - nilerr # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
-    # - predeclared # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - predeclared
     # - staticcheck # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - tenv # TODO: Enable when upgrading Go 1.16 to 1.17
     - unconvert

--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -120,8 +120,8 @@ func RandIpAddress(s string) (string, error) {
 	last.SetBytes([]byte(lastIp))
 	r := &big.Int{}
 	r.Sub(last, first)
-	if len := r.BitLen(); len > 31 {
-		return "", fmt.Errorf("CIDR range is too large: %d", len)
+	if bitLen := r.BitLen(); bitLen > 31 {
+		return "", fmt.Errorf("CIDR range is too large: %d", bitLen)
 	}
 
 	max := int(r.Int64())

--- a/helper/customdiff/computed_test.go
+++ b/helper/customdiff/computed_test.go
@@ -31,9 +31,9 @@ func TestComputedIf(t *testing.T) {
 				// updated.
 
 				condCalls++
-				old, new := d.GetChange("foo")
-				gotOld = old.(string)
-				gotNew = new.(string)
+				oldValue, newValue := d.GetChange("foo")
+				gotOld = oldValue.(string)
+				gotNew = newValue.(string)
 
 				return true
 			}),
@@ -86,9 +86,9 @@ func TestComputedIf(t *testing.T) {
 			},
 			ComputedIf("comp", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 				condCalls++
-				old, new := d.GetChange("foo")
-				gotOld = old.(string)
-				gotNew = new.(string)
+				oldValue, newValue := d.GetChange("foo")
+				gotOld = oldValue.(string)
+				gotNew = newValue.(string)
 
 				return false
 			}),

--- a/helper/customdiff/condition.go
+++ b/helper/customdiff/condition.go
@@ -12,7 +12,7 @@ type ResourceConditionFunc func(ctx context.Context, d *schema.ResourceDiff, met
 
 // ValueChangeConditionFunc is a function type that makes a boolean decision
 // by comparing two values.
-type ValueChangeConditionFunc func(ctx context.Context, old, new, meta interface{}) bool
+type ValueChangeConditionFunc func(ctx context.Context, oldValue, newValue, meta interface{}) bool
 
 // ValueConditionFunc is a function type that makes a boolean decision based
 // on a given value.
@@ -41,8 +41,8 @@ func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.Customize
 // given CustomizeDiffFunc only if the condition function returns true.
 func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-		old, new := d.GetChange(key)
-		if cond(ctx, old, new, meta) {
+		oldValue, newValue := d.GetChange(key)
+		if cond(ctx, oldValue, newValue, meta) {
 			return f(ctx, d, meta)
 		}
 		return nil

--- a/helper/customdiff/condition_test.go
+++ b/helper/customdiff/condition_test.go
@@ -23,9 +23,9 @@ func TestIf(t *testing.T) {
 			If(
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 					condCalled = true
-					old, new := d.GetChange("foo")
-					gotOld = old.(string)
-					gotNew = new.(string)
+					oldValue, newValue := d.GetChange("foo")
+					gotOld = oldValue.(string)
+					gotNew = newValue.(string)
 					return true
 				},
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
@@ -81,9 +81,9 @@ func TestIf(t *testing.T) {
 			If(
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 					condCalled = true
-					old, new := d.GetChange("foo")
-					gotOld = old.(string)
-					gotNew = new.(string)
+					oldValue, newValue := d.GetChange("foo")
+					gotOld = oldValue.(string)
+					gotNew = newValue.(string)
 					return false
 				},
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
@@ -138,10 +138,10 @@ func TestIfValueChange(t *testing.T) {
 			},
 			IfValueChange(
 				"foo",
-				func(_ context.Context, old, new, meta interface{}) bool {
+				func(_ context.Context, oldValue, newValue, meta interface{}) bool {
 					condCalled = true
-					gotOld = old.(string)
-					gotNew = new.(string)
+					gotOld = oldValue.(string)
+					gotNew = newValue.(string)
 					return true
 				},
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
@@ -196,10 +196,10 @@ func TestIfValueChange(t *testing.T) {
 			},
 			IfValueChange(
 				"foo",
-				func(_ context.Context, old, new, meta interface{}) bool {
+				func(_ context.Context, oldValue, newValue, meta interface{}) bool {
 					condCalled = true
-					gotOld = old.(string)
-					gotNew = new.(string)
+					gotOld = oldValue.(string)
+					gotNew = newValue.(string)
 					return false
 				},
 				func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {

--- a/helper/customdiff/force_new.go
+++ b/helper/customdiff/force_new.go
@@ -36,8 +36,8 @@ func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
 // only the specific field value.
 func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-		old, new := d.GetChange(key)
-		if f(ctx, old, new, meta) {
+		oldValue, newValue := d.GetChange(key)
+		if f(ctx, oldValue, newValue, meta) {
 			if err := d.ForceNew(key); err != nil {
 				return fmt.Errorf("unable to set %q to require replacement: %w", key, err)
 			}

--- a/helper/customdiff/force_new_test.go
+++ b/helper/customdiff/force_new_test.go
@@ -27,15 +27,15 @@ func TestForceNewIf(t *testing.T) {
 				// updated.
 
 				condCalls++
-				old, new := d.GetChange("foo")
+				oldValue, newValue := d.GetChange("foo")
 
 				switch condCalls {
 				case 1:
-					gotOld1 = old.(string)
-					gotNew1 = new.(string)
+					gotOld1 = oldValue.(string)
+					gotNew1 = newValue.(string)
 				case 2:
-					gotOld2 = old.(string)
-					gotNew2 = new.(string)
+					gotOld2 = oldValue.(string)
+					gotNew2 = newValue.(string)
 				}
 
 				return true
@@ -90,9 +90,9 @@ func TestForceNewIf(t *testing.T) {
 			},
 			ForceNewIf("foo", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 				condCalls++
-				old, new := d.GetChange("foo")
-				gotOld = old.(string)
-				gotNew = new.(string)
+				oldValue, newValue := d.GetChange("foo")
+				gotOld = oldValue.(string)
+				gotNew = newValue.(string)
 
 				return false
 			}),
@@ -141,7 +141,7 @@ func TestForceNewIfChange(t *testing.T) {
 					Optional: true,
 				},
 			},
-			ForceNewIfChange("foo", func(_ context.Context, old, new, meta interface{}) bool {
+			ForceNewIfChange("foo", func(_ context.Context, oldValue, newValue, meta interface{}) bool {
 				// When we set "ForceNew", our CustomizeDiff function is actually
 				// called a second time to construct the "create" portion of
 				// the replace diff. On the second call, the old value is masked
@@ -152,11 +152,11 @@ func TestForceNewIfChange(t *testing.T) {
 
 				switch condCalls {
 				case 1:
-					gotOld1 = old.(string)
-					gotNew1 = new.(string)
+					gotOld1 = oldValue.(string)
+					gotNew1 = newValue.(string)
 				case 2:
-					gotOld2 = old.(string)
-					gotNew2 = new.(string)
+					gotOld2 = oldValue.(string)
+					gotNew2 = newValue.(string)
 				}
 
 				return true
@@ -209,10 +209,10 @@ func TestForceNewIfChange(t *testing.T) {
 					Optional: true,
 				},
 			},
-			ForceNewIfChange("foo", func(_ context.Context, old, new, meta interface{}) bool {
+			ForceNewIfChange("foo", func(_ context.Context, oldValue, newValue, meta interface{}) bool {
 				condCalls++
-				gotOld = old.(string)
-				gotNew = new.(string)
+				gotOld = oldValue.(string)
+				gotNew = newValue.(string)
 
 				return false
 			}),

--- a/helper/customdiff/testing_test.go
+++ b/helper/customdiff/testing_test.go
@@ -18,16 +18,16 @@ func testProvider(s map[string]*schema.Schema, cd schema.CustomizeDiffFunc) *sch
 	}
 }
 
-func testDiff(provider *schema.Provider, old, new map[string]string) (*terraform.InstanceDiff, error) {
-	newI := make(map[string]interface{}, len(new))
-	for k, v := range new {
+func testDiff(provider *schema.Provider, oldValue, newValue map[string]string) (*terraform.InstanceDiff, error) {
+	newI := make(map[string]interface{}, len(newValue))
+	for k, v := range newValue {
 		newI[k] = v
 	}
 
 	return provider.ResourcesMap["test"].Diff(
 		context.Background(),
 		&terraform.InstanceState{
-			Attributes: old,
+			Attributes: oldValue,
 		},
 		&terraform.ResourceConfig{
 			Config: newI,

--- a/helper/customdiff/validate.go
+++ b/helper/customdiff/validate.go
@@ -9,7 +9,7 @@ import (
 // ValueChangeValidationFunc is a function type that validates the difference
 // (or lack thereof) between two values, returning an error if the change
 // is invalid.
-type ValueChangeValidationFunc func(ctx context.Context, old, new, meta interface{}) error
+type ValueChangeValidationFunc func(ctx context.Context, oldValue, newValue, meta interface{}) error
 
 // ValueValidationFunc is a function type that validates a particular value,
 // returning an error if the value is invalid.
@@ -19,8 +19,8 @@ type ValueValidationFunc func(ctx context.Context, value, meta interface{}) erro
 // function to the change for the given key, returning any error produced.
 func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-		old, new := d.GetChange(key)
-		return f(ctx, old, new, meta)
+		oldValue, newValue := d.GetChange(key)
+		return f(ctx, oldValue, newValue, meta)
 	}
 }
 

--- a/helper/customdiff/validate_test.go
+++ b/helper/customdiff/validate_test.go
@@ -19,10 +19,10 @@ func TestValidateChange(t *testing.T) {
 				Optional: true,
 			},
 		},
-		ValidateChange("foo", func(_ context.Context, old, new, meta interface{}) error {
+		ValidateChange("foo", func(_ context.Context, oldValue, newValue, meta interface{}) error {
 			called = true
-			gotOld = old.(string)
-			gotNew = new.(string)
+			gotOld = oldValue.(string)
+			gotNew = newValue.(string)
 			return errors.New("bad")
 		}),
 	)

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -124,13 +124,13 @@ func testStepNewImportState(t testing.T, c TestCase, helper *plugintest.Helper, 
 
 	// Verify that all the states match
 	if step.ImportStateVerify {
-		new := importState.RootModule().Resources
-		old := state.RootModule().Resources
+		newResources := importState.RootModule().Resources
+		oldResources := state.RootModule().Resources
 
-		for _, r := range new {
+		for _, r := range newResources {
 			// Find the existing resource
 			var oldR *terraform.ResourceState
-			for r2Key, r2 := range old {
+			for r2Key, r2 := range oldResources {
 				// Ensure that we do not match against data sources as they
 				// cannot be imported and are not what we want to verify.
 				// Mode is not present in ResourceState so we use the

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -270,16 +270,16 @@ func (d *ResourceDiff) GetChangedKeysPrefix(prefix string) []string {
 // diffChange helps to implement resourceDiffer and derives its change values
 // from ResourceDiff's own change data, in addition to existing diff, config, and state.
 func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool, bool) {
-	old, new, customized := d.getChange(key)
+	oldValue, newValue, customized := d.getChange(key)
 
-	if !old.Exists {
-		old.Value = nil
+	if !oldValue.Exists {
+		oldValue.Value = nil
 	}
-	if !new.Exists || d.removed(key) {
-		new.Value = nil
+	if !newValue.Exists || d.removed(key) {
+		newValue.Value = nil
 	}
 
-	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), new.Computed, customized
+	return oldValue.Value, newValue.Value, !reflect.DeepEqual(oldValue.Value, newValue.Value), newValue.Computed, customized
 }
 
 // SetNew is used to set a new diff value for the mentioned key. The value must
@@ -308,12 +308,12 @@ func (d *ResourceDiff) SetNewComputed(key string) error {
 }
 
 // setDiff performs common diff setting behaviour.
-func (d *ResourceDiff) setDiff(key string, new interface{}, computed bool) error {
+func (d *ResourceDiff) setDiff(key string, newValue interface{}, computed bool) error {
 	if err := d.clear(key); err != nil {
 		return err
 	}
 
-	if err := d.newWriter.WriteField(strings.Split(key, "."), new, computed); err != nil {
+	if err := d.newWriter.WriteField(strings.Split(key, "."), newValue, computed); err != nil {
 		return fmt.Errorf("Cannot set new diff value for key %s: %s", key, err)
 	}
 
@@ -374,8 +374,8 @@ func (d *ResourceDiff) Get(key string) interface{} {
 // results from the exact levels for the new diff, then from state and diff as
 // per normal.
 func (d *ResourceDiff) GetChange(key string) (interface{}, interface{}) {
-	old, new, _ := d.getChange(key)
-	return old.Value, new.Value
+	oldValue, newValue, _ := d.getChange(key)
+	return oldValue.Value, newValue.Value
 }
 
 // GetOk functions the same way as ResourceData.GetOk, but it also checks the
@@ -435,16 +435,16 @@ func (d *ResourceDiff) HasChanges(keys ...string) bool {
 // HasChange checks to see if there is a change between state and the diff, or
 // in the overridden diff.
 func (d *ResourceDiff) HasChange(key string) bool {
-	old, new := d.GetChange(key)
+	oldValue, newValue := d.GetChange(key)
 
 	// If the type implements the Equal interface, then call that
 	// instead of just doing a reflect.DeepEqual. An example where this is
 	// needed is *Set
-	if eq, ok := old.(Equal); ok {
-		return !eq.Equal(new)
+	if eq, ok := oldValue.(Equal); ok {
+		return !eq.Equal(newValue)
 	}
 
-	return !reflect.DeepEqual(old, new)
+	return !reflect.DeepEqual(oldValue, newValue)
 }
 
 // Id returns the ID of this resource.
@@ -516,16 +516,16 @@ func (d *ResourceDiff) GetRawPlan() cty.Value {
 // results from the exact levels for the new diff, then from state and diff as
 // per normal.
 func (d *ResourceDiff) getChange(key string) (getResult, getResult, bool) {
-	old := d.get(strings.Split(key, "."), "state")
-	var new getResult
+	oldValue := d.get(strings.Split(key, "."), "state")
+	var newValue getResult
 	for p := range d.updatedKeys {
 		if childAddrOf(key, p) {
-			new = d.getExact(strings.Split(key, "."), "newDiff")
-			return old, new, true
+			newValue = d.getExact(strings.Split(key, "."), "newDiff")
+			return oldValue, newValue, true
 		}
 	}
-	new = d.get(strings.Split(key, "."), "newDiff")
-	return old, new, false
+	newValue = d.get(strings.Split(key, "."), "newDiff")
+	return oldValue, newValue, false
 }
 
 // removed checks to see if the key is present in the existing, pre-customized

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -353,20 +353,20 @@ func expectedForValues(create, read, update, del, def int) map[string]interface{
 	return ex
 }
 
-func expectedConfigForValues(create, read, update, delete, def int) map[string]interface{} {
+func expectedConfigForValues(createMin, readMin, updateMin, deleteMin, def int) map[string]interface{} {
 	ex := make(map[string]interface{}, 0)
 
-	if create != 0 {
-		ex["create"] = fmt.Sprintf("%dm", create)
+	if createMin != 0 {
+		ex["create"] = fmt.Sprintf("%dm", createMin)
 	}
-	if read != 0 {
-		ex["read"] = fmt.Sprintf("%dm", read)
+	if readMin != 0 {
+		ex["read"] = fmt.Sprintf("%dm", readMin)
 	}
-	if update != 0 {
-		ex["update"] = fmt.Sprintf("%dm", update)
+	if updateMin != 0 {
+		ex["update"] = fmt.Sprintf("%dm", updateMin)
 	}
-	if delete != 0 {
-		ex["delete"] = fmt.Sprintf("%dm", delete)
+	if deleteMin != 0 {
+		ex["delete"] = fmt.Sprintf("%dm", deleteMin)
 	}
 
 	if def != 0 {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -264,7 +264,7 @@ const (
 // suppress it from the plan if necessary.
 //
 // Return true if the diff should be suppressed, false to retain it.
-type SchemaDiffSuppressFunc func(k, old, new string, d *ResourceData) bool
+type SchemaDiffSuppressFunc func(k, oldValue, newValue string, d *ResourceData) bool
 
 // SchemaDefaultFunc is a function called to return a default value for
 // a field.
@@ -491,11 +491,11 @@ func (m schemaMap) Data(
 // DeepCopy returns a copy of this schemaMap. The copy can be safely modified
 // without affecting the original.
 func (m *schemaMap) DeepCopy() schemaMap {
-	copy, err := copystructure.Config{Lock: true}.Copy(m)
+	copiedMap, err := copystructure.Config{Lock: true}.Copy(m)
 	if err != nil {
 		panic(err)
 	}
-	return *copy.(*schemaMap)
+	return *copiedMap.(*schemaMap)
 }
 
 // Diff returns the diff for a resource given the schema map,

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4793,7 +4793,7 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 				"string": {
 					Type:             TypeString,
 					Computed:         true,
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool { return false },
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool { return false },
 				},
 			},
 			true,
@@ -5059,7 +5059,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 				"availability_zone": {
 					Type:     TypeString,
 					Optional: true,
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool {
 						// Always suppress any diff
 						return true
 					},
@@ -5082,7 +5082,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 				"availability_zone": {
 					Type:     TypeString,
 					Optional: true,
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool {
 						// Always suppress any diff
 						return false
 					},
@@ -5113,7 +5113,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 					Type:     TypeString,
 					Optional: true,
 					Default:  "foo",
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool {
 						return true
 					},
 				},
@@ -5134,7 +5134,7 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 					Type:     TypeString,
 					Optional: true,
 					Default:  "foo",
-					DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool {
 						return false
 					},
 				},

--- a/helper/structure/suppress_json_diff.go
+++ b/helper/structure/suppress_json_diff.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
-	oldMap, err := ExpandJsonFromString(old)
+func SuppressJsonDiff(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(oldValue)
 	if err != nil {
 		return false
 	}
 
-	newMap, err := ExpandJsonFromString(new)
+	newMap, err := ExpandJsonFromString(newValue)
 	if err != nil {
 		return false
 	}

--- a/helper/structure/suppress_json_diff_test.go
+++ b/helper/structure/suppress_json_diff_test.go
@@ -4,48 +4,49 @@ import (
 	"testing"
 )
 
-func TestSuppressJsonDiff_same(t *testing.T) {
-	original := `{ "enabled": true }`
-	new := `{ "enabled": true }`
-	expected := true
+func TestSuppressJsonDiff(t *testing.T) {
+	t.Parallel()
 
-	actual := SuppressJsonDiff("test", original, new, nil)
-	if actual != expected {
-		t.Fatal("[ERROR] Identical JSON values shouldn't cause a diff")
+	testCases := map[string]struct {
+		oldValue string
+		newValue string
+		expected bool
+	}{
+		"different-structure": {
+			oldValue: `{ "enabled": true }`,
+			newValue: `{ "enabled": true, "world": "round" }`,
+			expected: false,
+		},
+		"different-value": {
+			oldValue: `{ "enabled": true }`,
+			newValue: `{ "enabled": false }`,
+			expected: false,
+		},
+		"same": {
+			oldValue: `{ "enabled": true }`,
+			newValue: `{ "enabled": true }`,
+			expected: true,
+		},
+		"same-whitespace": {
+			oldValue: `{
+				"enabled": true
+			}`,
+			newValue: `{ "enabled": true }`,
+			expected: true,
+		},
 	}
-}
 
-func TestSuppressJsonDiff_sameWithWhitespace(t *testing.T) {
-	original := `{
-	  "enabled": true
-	}`
-	new := `{ "enabled": true }`
-	expected := true
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
 
-	actual := SuppressJsonDiff("test", original, new, nil)
-	if actual != expected {
-		t.Fatal("[ERROR] Identical JSON values shouldn't cause a diff")
-	}
-}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-func TestSuppressJsonDiff_differentValue(t *testing.T) {
-	original := `{ "enabled": true }`
-	new := `{ "enabled": false }`
-	expected := false
+			actual := SuppressJsonDiff("test", testCase.oldValue, testCase.newValue, nil)
 
-	actual := SuppressJsonDiff("test", original, new, nil)
-	if actual != expected {
-		t.Fatal("[ERROR] Different JSON values should cause a diff")
-	}
-}
-
-func TestSuppressJsonDiff_newValue(t *testing.T) {
-	original := `{ "enabled": true }`
-	new := `{ "enabled": false, "world": "round" }`
-	expected := false
-
-	actual := SuppressJsonDiff("test", original, new, nil)
-	if actual != expected {
-		t.Fatal("[ERROR] Different JSON values should cause a diff")
+			if actual != testCase.expected {
+				t.Fatalf("expected %t, got %t", testCase.expected, actual)
+			}
+		})
 	}
 }

--- a/helper/validation/map.go
+++ b/helper/validation/map.go
@@ -17,12 +17,12 @@ func MapKeyLenBetween(min, max int) schema.SchemaValidateDiagFunc {
 		var diags diag.Diagnostics
 
 		for _, key := range sortedKeys(v.(map[string]interface{})) {
-			len := len(key)
-			if len < min || len > max {
+			keyLen := len(key)
+			if keyLen < min || keyLen > max {
 				diags = append(diags, diag.Diagnostic{
 					Severity:      diag.Error,
 					Summary:       "Bad map key length",
-					Detail:        fmt.Sprintf("Map key lengths should be in the range (%d - %d): %s (length = %d)", min, max, key, len),
+					Detail:        fmt.Sprintf("Map key lengths should be in the range (%d - %d): %s (length = %d)", min, max, key, keyLen),
 					AttributePath: append(path, cty.IndexStep{Key: cty.StringVal(key)}),
 				})
 			}
@@ -53,12 +53,12 @@ func MapValueLenBetween(min, max int) schema.SchemaValidateDiagFunc {
 				continue
 			}
 
-			len := len(val.(string))
-			if len < min || len > max {
+			valLen := len(val.(string))
+			if valLen < min || valLen > max {
 				diags = append(diags, diag.Diagnostic{
 					Severity:      diag.Error,
 					Summary:       "Bad map value length",
-					Detail:        fmt.Sprintf("Map value lengths should be in the range (%d - %d): %s => %v (length = %d)", min, max, key, val, len),
+					Detail:        fmt.Sprintf("Map value lengths should be in the range (%d - %d): %s => %v (length = %d)", min, max, key, val, valLen),
 					AttributePath: append(path, cty.IndexStep{Key: cty.StringVal(key)}),
 				})
 			}

--- a/internal/configs/hcl2shim/flatmap.go
+++ b/internal/configs/hcl2shim/flatmap.go
@@ -85,15 +85,15 @@ func flatmapValueFromHCL2Map(m map[string]string, prefix string, val cty.Value) 
 		return
 	}
 
-	len := 0
+	valLen := 0
 	for it := val.ElementIterator(); it.Next(); {
 		ak, av := it.Element()
 		name := ak.AsString()
 		flatmapValueFromHCL2Value(m, prefix+name, av)
-		len++
+		valLen++
 	}
 	if !val.Type().IsObjectType() { // objects don't have an explicit count included, since their attribute count is fixed
-		m[prefix+"%"] = strconv.Itoa(len)
+		m[prefix+"%"] = strconv.Itoa(valLen)
 	}
 }
 

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -154,13 +154,13 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 	}
 
 	// Copy, this will copy all the exported attributes
-	copy, err := copystructure.Config{Lock: true}.Copy(c)
+	copiedConfig, err := copystructure.Config{Lock: true}.Copy(c)
 	if err != nil {
 		panic(err)
 	}
 
 	// Force the type
-	result := copy.(*ResourceConfig)
+	result := copiedConfig.(*ResourceConfig)
 
 	return result
 }

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -197,16 +197,16 @@ func TestResourceConfigGet(t *testing.T) {
 
 		// Test copying and equality
 		t.Run(fmt.Sprintf("copy-and-equal-%d", i), func(t *testing.T) {
-			copy := rc.DeepCopy()
-			if !reflect.DeepEqual(copy, rc) {
-				t.Fatalf("bad:\n\n%#v\n\n%#v", copy, rc)
+			copiedConfig := rc.DeepCopy()
+			if !reflect.DeepEqual(copiedConfig, rc) {
+				t.Fatalf("bad:\n\n%#v\n\n%#v", copiedConfig, rc)
 			}
 
-			if !copy.Equal(rc) {
-				t.Fatalf("copy != rc:\n\n%#v\n\n%#v", copy, rc)
+			if !copiedConfig.Equal(rc) {
+				t.Fatalf("copiedConfig != rc:\n\n%#v\n\n%#v", copiedConfig, rc)
 			}
-			if !rc.Equal(copy) {
-				t.Fatalf("rc != copy:\n\n%#v\n\n%#v", copy, rc)
+			if !rc.Equal(copiedConfig) {
+				t.Fatalf("rc != copiedConfig:\n\n%#v\n\n%#v", copiedConfig, rc)
 			}
 		})
 	}

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -562,12 +562,12 @@ func (s *State) DeepCopy() *State {
 		return nil
 	}
 
-	copy, err := copystructure.Config{Lock: true}.Copy(s)
+	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
 		panic(err)
 	}
 
-	return copy.(*State)
+	return copiedState.(*State)
 }
 
 func (s *State) Init() {
@@ -1430,12 +1430,12 @@ func (s *InstanceState) Set(from *InstanceState) {
 }
 
 func (s *InstanceState) DeepCopy() *InstanceState {
-	copy, err := copystructure.Config{Lock: true}.Copy(s)
+	copiedState, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
 		panic(err)
 	}
 
-	return copy.(*InstanceState)
+	return copiedState.(*InstanceState)
 }
 
 func (s *InstanceState) Empty() bool {


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

Shadowing language keywords can cause confusing programming issues and may not provide enough clarity on the purpose of a variable.

Previously:

```text
helper/acctest/random.go:123:5: variable len has same name as predeclared identifier (predeclared)
        if len := r.BitLen(); len > 31 {
           ^
helper/customdiff/condition.go:15:62: param new has same name as predeclared identifier (predeclared)
type ValueChangeConditionFunc func(ctx context.Context, old, new, meta interface{}) bool
                                                             ^
helper/customdiff/condition.go:44:8: variable new has same name as predeclared identifier (predeclared)
                old, new := d.GetChange(key)
                     ^
helper/customdiff/force_new.go:39:8: variable new has same name as predeclared identifier (predeclared)
                old, new := d.GetChange(key)
                     ^
helper/customdiff/validate.go:12:63: param new has same name as predeclared identifier (predeclared)
type ValueChangeValidationFunc func(ctx context.Context, old, new, meta interface{}) error
                                                              ^
helper/customdiff/validate.go:22:8: variable new has same name as predeclared identifier (predeclared)
                old, new := d.GetChange(key)
                     ^
helper/customdiff/computed_test.go:34:10: variable new has same name as predeclared identifier (predeclared)
                                old, new := d.GetChange("foo")
                                     ^
helper/customdiff/computed_test.go:89:10: variable new has same name as predeclared identifier (predeclared)
                                old, new := d.GetChange("foo")
                                     ^
helper/customdiff/condition_test.go:26:11: variable new has same name as predeclared identifier (predeclared)
                                        old, new := d.GetChange("foo")
                                             ^
helper/customdiff/condition_test.go:84:11: variable new has same name as predeclared identifier (predeclared)
                                        old, new := d.GetChange("foo")
                                             ^
helper/customdiff/condition_test.go:141:34: param new has same name as predeclared identifier (predeclared)
                                func(_ context.Context, old, new, meta interface{}) bool {
                                                             ^
helper/customdiff/condition_test.go:199:34: param new has same name as predeclared identifier (predeclared)
                                func(_ context.Context, old, new, meta interface{}) bool {
                                                             ^
helper/customdiff/force_new_test.go:30:10: variable new has same name as predeclared identifier (predeclared)
                                old, new := d.GetChange("foo")
                                     ^
helper/customdiff/force_new_test.go:93:10: variable new has same name as predeclared identifier (predeclared)
                                old, new := d.GetChange("foo")
                                     ^
helper/customdiff/force_new_test.go:144:57: param new has same name as predeclared identifier (predeclared)
                        ForceNewIfChange("foo", func(_ context.Context, old, new, meta interface{}) bool {
                                                                             ^
helper/customdiff/force_new_test.go:212:57: param new has same name as predeclared identifier (predeclared)
                        ForceNewIfChange("foo", func(_ context.Context, old, new, meta interface{}) bool {
                                                                             ^
helper/customdiff/testing_test.go:21:47: param new has same name as predeclared identifier (predeclared)
func testDiff(provider *schema.Provider, old, new map[string]string) (*terraform.InstanceDiff, error) {
                                              ^
helper/customdiff/validate_test.go:22:54: param new has same name as predeclared identifier (predeclared)
                ValidateChange("foo", func(_ context.Context, old, new, meta interface{}) error {
                                                                   ^
helper/resource/testing_new_import_state.go:127:3: variable new has same name as predeclared identifier (predeclared)
                new := importState.RootModule().Resources
                ^
helper/schema/resource_diff.go:273:7: variable new has same name as predeclared identifier (predeclared)
        old, new, customized := d.getChange(key)
             ^
helper/schema/resource_diff.go:311:44: param new has same name as predeclared identifier (predeclared)
func (d *ResourceDiff) setDiff(key string, new interface{}, computed bool) error {
                                           ^
helper/schema/resource_diff.go:377:7: variable new has same name as predeclared identifier (predeclared)
        old, new, _ := d.getChange(key)
             ^
helper/schema/resource_diff.go:438:7: variable new has same name as predeclared identifier (predeclared)
        old, new := d.GetChange(key)
             ^
helper/schema/resource_diff.go:520:6: variable new has same name as predeclared identifier (predeclared)
        var new getResult
            ^
helper/schema/schema.go:267:42: param new has same name as predeclared identifier (predeclared)
type SchemaDiffSuppressFunc func(k, old, new string, d *ResourceData) bool
                                         ^
helper/schema/schema.go:494:2: variable copy has same name as predeclared identifier (predeclared)
        copy, err := copystructure.Config{Lock: true}.Copy(m)
        ^
helper/schema/resource_timeout_test.go:356:52: param delete has same name as predeclared identifier (predeclared)
func expectedConfigForValues(create, read, update, delete, def int) map[string]interface{} {
                                                   ^
helper/schema/schema_test.go:4796:37: param new has same name as predeclared identifier (predeclared)
                                        DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool { return false },
                                                                       ^
helper/schema/schema_test.go:5062:37: param new has same name as predeclared identifier (predeclared)
                                        DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
                                                                       ^
helper/schema/schema_test.go:5085:37: param new has same name as predeclared identifier (predeclared)
                                        DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
                                                                       ^
helper/schema/schema_test.go:5116:37: param new has same name as predeclared identifier (predeclared)
                                        DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
                                                                       ^
helper/schema/schema_test.go:5137:37: param new has same name as predeclared identifier (predeclared)
                                        DiffSuppressFunc: func(k, old, new string, d *ResourceData) bool {
                                                                       ^
helper/structure/suppress_json_diff.go:9:31: param new has same name as predeclared identifier (predeclared)
func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
                              ^
helper/structure/suppress_json_diff_test.go:9:2: variable new has same name as predeclared identifier (predeclared)
        new := `{ "enabled": true }`
        ^
helper/structure/suppress_json_diff_test.go:22:2: variable new has same name as predeclared identifier (predeclared)
        new := `{ "enabled": true }`
        ^
helper/structure/suppress_json_diff_test.go:33:2: variable new has same name as predeclared identifier (predeclared)
        new := `{ "enabled": false }`
        ^
helper/structure/suppress_json_diff_test.go:44:2: variable new has same name as predeclared identifier (predeclared)
        new := `{ "enabled": false, "world": "round" }`
        ^
helper/validation/map.go:20:4: variable len has same name as predeclared identifier (predeclared)
                        len := len(key)
                        ^
helper/validation/map.go:56:4: variable len has same name as predeclared identifier (predeclared)
                        len := len(val.(string))
                        ^
internal/configs/hcl2shim/flatmap.go:88:2: variable len has same name as predeclared identifier (predeclared)
        len := 0
        ^
terraform/resource.go:157:2: variable copy has same name as predeclared identifier (predeclared)
        copy, err := copystructure.Config{Lock: true}.Copy(c)
        ^
terraform/state.go:565:2: variable copy has same name as predeclared identifier (predeclared)
        copy, err := copystructure.Config{Lock: true}.Copy(s)
        ^
terraform/state.go:1433:2: variable copy has same name as predeclared identifier (predeclared)
        copy, err := copystructure.Config{Lock: true}.Copy(s)
        ^
terraform/resource_test.go:200:4: variable copy has same name as predeclared identifier (predeclared)
                        copy := rc.DeepCopy()
                        ^
```