### PR TITLE
Enable staticcheck linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - nilerr
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
-    # - staticcheck # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - staticcheck
     # - tenv # TODO: Enable when upgrading Go 1.16 to 1.17
     - unconvert
     - unparam

--- a/helper/resource/testing_new_import_state.go
+++ b/helper/resource/testing_new_import_state.go
@@ -144,7 +144,7 @@ func testStepNewImportState(t testing.T, c TestCase, helper *plugintest.Helper, 
 					break
 				}
 			}
-			if oldR == nil {
+			if oldR == nil || oldR.Primary == nil {
 				t.Fatalf(
 					"Failed state verification, resource with ID %s not found",
 					r.Primary.ID)

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -137,7 +137,13 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 
 				*timeout = rt
 			}
-			return nil
+
+			// This early return, which makes this function handle a single
+			// timeout configuration block, should likely not be here but the
+			// SDK has never raised an error for multiple blocks nor made any
+			// precedence decisions for them in the past.
+			// It is left here for compatibility reasons.
+			return nil //nolint:staticcheck
 		}
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3088,7 +3088,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"stream_enabled":   false,
 				"stream_view_type": "",
 			},
-			CustomizeDiff: func(_ context.Context, diff *ResourceDiff, v interface{}) error {
+			CustomizeDiff: func(_ context.Context, diff *ResourceDiff, _ interface{}) error {
 				v, ok := diff.GetOk("unrelated_set")
 				if ok {
 					return fmt.Errorf("Didn't expect unrelated_set: %#v", v)

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -3343,7 +3343,7 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 				"stream_enabled":   false,
 				"stream_view_type": "",
 			},
-			CustomizeDiff: func(_ context.Context, diff *ResourceDiff, v interface{}) error {
+			CustomizeDiff: func(_ context.Context, diff *ResourceDiff, _ interface{}) error {
 				v, ok := diff.GetOk("unrelated_set")
 				if ok {
 					return fmt.Errorf("Didn't expect unrelated_set: %#v", v)

--- a/helper/validation/strings.go
+++ b/helper/validation/strings.go
@@ -138,7 +138,7 @@ func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
 		}
 
 		for _, str := range valid {
-			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+			if v == str || (ignoreCase && strings.EqualFold(v, str)) {
 				return warnings, errors
 			}
 		}
@@ -160,7 +160,7 @@ func StringNotInSlice(invalid []string, ignoreCase bool) schema.SchemaValidateFu
 		}
 
 		for _, str := range invalid {
-			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+			if v == str || (ignoreCase && strings.EqualFold(v, str)) {
 				errors = append(errors, fmt.Errorf("expected %s to not be any of %v, got %s", k, invalid, v))
 				return warnings, errors
 			}

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -243,7 +243,7 @@ func (wd *WorkingDir) Import(resource, id string) error {
 
 // Refresh runs terraform refresh
 func (wd *WorkingDir) Refresh() error {
-	return wd.tf.Refresh(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.State(filepath.Join(wd.baseDir, "terraform.tfstate")))
+	return wd.tf.Refresh(context.Background(), tfexec.Reattach(wd.reattachInfo))
 }
 
 // Schemas returns an object describing the provider schemas.

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -421,20 +421,6 @@ func (s *State) removeInstance(r *ResourceState, v *InstanceState) {
 		r.Primary = nil
 		return
 	}
-
-	// Check lists
-	lists := [][]*InstanceState{r.Deposed}
-	for _, is := range lists {
-		for i, instance := range is {
-			if instance == v {
-				// Found it, remove it
-				is, is[len(is)-1] = append(is[:i], is[i+1:]...), nil
-
-				// Done
-				return
-			}
-		}
-	}
 }
 
 // RootModule returns the ModuleState for the root module


### PR DESCRIPTION
Closes #865
Reference: https://www.terraform.io/language/settings/backends/local#path

The removal of the deprecated `refresh` command `-state` flag in the acceptance testing framework should be safe as this is the default state location.

Previously:

```
internal/plugintest/working_dir.go:246:79: SA1019: tfexec.State is deprecated: The -state CLI flag is a legacy flag and should not be used. If you need a different state file for every run, you can instead use the local backend. See https://github.com/hashicorp/terraform/issues/25920#issuecomment-676560799 (staticcheck)
        return wd.tf.Refresh(context.Background(), tfexec.Reattach(wd.reattachInfo), tfexec.State(filepath.Join(wd.baseDir, "terraform.tfstate")))
                                                                                     ^
helper/schema/schema_test.go:3091:63: SA4009: argument v is overwritten before first use (staticcheck)
                        CustomizeDiff: func(_ context.Context, diff *ResourceDiff, v interface{}) error {
                                                                                   ^
helper/schema/schema_test.go:3092:5: SA4009(related information): assignment to v (staticcheck)
                                v, ok := diff.GetOk("unrelated_set")
                                ^
helper/schema/shims_test.go:3346:63: SA4009: argument v is overwritten before first use (staticcheck)
                        CustomizeDiff: func(_ context.Context, diff *ResourceDiff, v interface{}) error {
                                                                                   ^
helper/schema/shims_test.go:3347:5: SA4009(related information): assignment to v (staticcheck)
                                v, ok := diff.GetOk("unrelated_set")
                                ^
internal/plugintest/util.go:13:4: SA4006: this value of `err` is never used (staticcheck)
                        err = os.Chmod(dest, srcInfo.Mode())
                        ^
helper/schema/grpc_provider.go:75:2: SA4006: this value of `ctx` is never used (staticcheck)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:126:2: SA4006: this value of `ctx` is never used (staticcheck)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:229:2: SA4006: this value of `ctx` is never used (staticcheck)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:248:2: SA4006: this value of `ctx` is never used (staticcheck)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:500:2: SA4006: this value of `ctx` is never used (staticcheck)
        ctx = withLogger(ctx)
        ^
helper/schema/grpc_provider.go:753:2: SA4006: this value of `err` is never used (staticcheck)
        plannedAttrs, err := diff.Apply(priorState.Attributes, schemaBlock)
        ^
terraform/state.go:431:5: SA4006: this value of `is` is never used (staticcheck)
                                is, is[len(is)-1] = append(is[:i], is[i+1:]...), nil
                                ^
helper/validation/strings.go:141:34: SA6005: should use strings.EqualFold instead (staticcheck)
                        if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
                                                      ^
helper/validation/strings.go:163:34: SA6005: should use strings.EqualFold instead (staticcheck)
                        if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
                                                      ^
helper/resource/testing_new_import_state.go:174:27: SA5011: possible nil pointer dereference (staticcheck)
                        for k, v := range oldR.Primary.Attributes {
                                               ^
helper/resource/testing_new_import_state.go:147:7: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
                        if oldR == nil {
                           ^
helper/schema/resource_timeout.go:140:4: SA4004: the surrounding loop is unconditionally terminated (staticcheck)
                        return nil
                        ^
```
