### PR TITLE
Enable gosimple linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - errcheck
     - exportloopref
     - gofmt
-    # - gosimple # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
+    - gosimple
     # - ineffassign # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     # - makezero # TODO: https://github.com/hashicorp/terraform-plugin-sdk/issues/865
     - nilerr

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -126,7 +126,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 				return sweeperRunList, fmt.Errorf("sweeper (%s) for region (%s) failed: %s", sweeper.Name, region, err)
 			}
 		}
-		elapsed := time.Now().Sub(start)
+		elapsed := time.Since(start)
 		log.Printf("Completed Sweepers for region (%s) in %s", region, elapsed)
 
 		log.Printf("Sweeper Tests for region (%s) ran successfully:\n", region)
@@ -239,7 +239,7 @@ func runSweeperWithRegion(region string, s *Sweeper, sweepers map[string]*Sweepe
 
 	start := time.Now()
 	runE := s.F(region)
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 
 	log.Printf("[DEBUG] Completed Sweeper (%s) in region (%s) in %s", s.Name, region, elapsed)
 

--- a/helper/schema/field_reader_map.go
+++ b/helper/schema/field_reader_map.go
@@ -159,11 +159,8 @@ func (r *MapFieldReader) readSet(
 		// "ports.1", but the "state" map might have those plus "ports.2".
 		// We don't want "ports.2"
 		countActual[idx] = struct{}{}
-		if len(countActual) >= countExpected {
-			return false
-		}
 
-		return true
+		return len(countActual) < countExpected
 	})
 	if !completed && err != nil {
 		return FieldReadResult{}, err

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -844,7 +844,7 @@ func validateResourceID(s *Schema) error {
 
 	// ID should at least be computed. If unspecified it will be set to Computed and Optional,
 	// but Optional is unnecessary if undesired.
-	if s.Computed != true {
+	if !s.Computed {
 		return fmt.Errorf(`the "id" attribute must be marked Computed`)
 	}
 	return nil

--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -3,12 +3,12 @@ package schema
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"reflect"
 	"sort"
 	"strconv"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/helper/hashcode"
 )
 
@@ -238,6 +238,6 @@ func (s *Set) listCode() []string {
 	for k := range s.m {
 		keys = append(keys, k)
 	}
-	sort.Sort(sort.StringSlice(keys))
+	sort.Strings(keys)
 	return keys
 }

--- a/helper/validation/float_test.go
+++ b/helper/validation/float_test.go
@@ -63,12 +63,12 @@ func TestValidateFloatAtLeast(t *testing.T) {
 		{
 			val:         1.5,
 			f:           FloatAtLeast(2.5),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(2\\.5\\d*\\), got 1\\.5\\d*"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\.5\d*\), got 1\.5\d*`),
 		},
 		{
 			val:         "2.5",
 			f:           FloatAtLeast(1.5),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be float"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be float`),
 		},
 	})
 }
@@ -86,12 +86,12 @@ func TestValidateFloatAtMost(t *testing.T) {
 		{
 			val:         2.5,
 			f:           FloatAtMost(1.5),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(1\\.5\\d*\\), got 2\\.5\\d*"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(1\.5\d*\), got 2\.5\d*`),
 		},
 		{
 			val:         "2.5",
 			f:           FloatAtMost(3.5),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be float"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be float`),
 		},
 	})
 }

--- a/helper/validation/int_test.go
+++ b/helper/validation/int_test.go
@@ -18,12 +18,12 @@ func TestValidationIntBetween(t *testing.T) {
 		{
 			val:         1,
 			f:           IntBetween(2, 3),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be in the range \\(2 - 3\\), got 1"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be in the range \(2 - 3\), got 1`),
 		},
 		{
 			val:         "1",
 			f:           IntBetween(2, 3),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be integer`),
 		},
 	})
 }
@@ -41,12 +41,12 @@ func TestValidationIntAtLeast(t *testing.T) {
 		{
 			val:         1,
 			f:           IntAtLeast(2),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(2\\), got 1"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got 1`),
 		},
 		{
 			val:         "1",
 			f:           IntAtLeast(2),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be integer`),
 		},
 	})
 }
@@ -64,12 +64,12 @@ func TestValidationIntAtMost(t *testing.T) {
 		{
 			val:         1,
 			f:           IntAtMost(0),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(0\\), got 1"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(0\), got 1`),
 		},
 		{
 			val:         "1",
 			f:           IntAtMost(0),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be integer`),
 		},
 	})
 }
@@ -119,12 +119,12 @@ func TestValidationIntInSlice(t *testing.T) {
 		{
 			val:         42,
 			f:           IntInSlice([]int{10, 20}),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[10 20\\], got 42"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[10 20\], got 42`),
 		},
 		{
 			val:         "InvalidValue",
 			f:           IntInSlice([]int{10, 20}),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be integer`),
 		},
 	})
 }

--- a/helper/validation/meta_test.go
+++ b/helper/validation/meta_test.go
@@ -52,7 +52,7 @@ func TestValidationAll(t *testing.T) {
 				StringLenBetween(5, 42),
 				StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric"),
 			),
-			expectedErr: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(5 - 42\\), got foo"),
+			expectedErr: regexp.MustCompile(`expected length of [\w]+ to be in the range \(5 - 42\), got foo`),
 		},
 		{
 			val: "!!!!!",
@@ -87,7 +87,7 @@ func TestValidationAny(t *testing.T) {
 				IntAtLeast(42),
 				IntAtMost(5),
 			),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(42\), got 7`),
 		},
 		{
 			val: 7,
@@ -95,7 +95,7 @@ func TestValidationAny(t *testing.T) {
 				IntAtLeast(42),
 				IntAtMost(5),
 			),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(5\), got 7`),
 		},
 	})
 }
@@ -122,7 +122,7 @@ func TestToDiagFunc(t *testing.T) {
 				IntAtLeast(42),
 				IntAtMost(5),
 			)),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(42\), got 7`),
 		},
 		{
 			val: 7,
@@ -130,7 +130,7 @@ func TestToDiagFunc(t *testing.T) {
 				IntAtLeast(42),
 				IntAtMost(5),
 			)),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be at most \(5\), got 7`),
 		},
 	})
 }

--- a/helper/validation/strings_test.go
+++ b/helper/validation/strings_test.go
@@ -290,17 +290,17 @@ func TestValidationStringInSlice(t *testing.T) {
 		{
 			val:         "VALIDVALUE",
 			f:           StringInSlice([]string{"ValidValue", "AnotherValidValue"}, false),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[ValidValue AnotherValidValue\\], got VALIDVALUE"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[ValidValue AnotherValidValue\], got VALIDVALUE`),
 		},
 		{
 			val:         "InvalidValue",
 			f:           StringInSlice([]string{"ValidValue", "AnotherValidValue"}, false),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[ValidValue AnotherValidValue\\], got InvalidValue"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[ValidValue AnotherValidValue\], got InvalidValue`),
 		},
 		{
 			val:         1,
 			f:           StringInSlice([]string{"ValidValue", "AnotherValidValue"}, false),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
 		},
 	})
 }
@@ -319,18 +319,18 @@ func TestValidationStringNotInSlice(t *testing.T) {
 		{
 			val:         "AnotherInvalidValue",
 			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, false),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got AnotherInvalidValue"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to not be any of \[InvalidValue AnotherInvalidValue\], got AnotherInvalidValue`),
 		},
 		// ignore case
 		{
 			val:         "INVALIDVALUE",
 			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, true),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got INVALIDVALUE"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to not be any of \[InvalidValue AnotherInvalidValue\], got INVALIDVALUE`),
 		},
 		{
 			val:         1,
 			f:           StringNotInSlice([]string{"InvalidValue", "AnotherInvalidValue"}, false),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
 		},
 	})
 }
@@ -344,12 +344,12 @@ func TestValidationStringMatch(t *testing.T) {
 		{
 			val:         "bar",
 			f:           StringMatch(regexp.MustCompile(".*foo.*"), ""),
-			expectedErr: regexp.MustCompile("expected value of [\\w]+ to match regular expression " + regexp.QuoteMeta(`".*foo.*"`)),
+			expectedErr: regexp.MustCompile(`expected value of [\w]+ to match regular expression ` + regexp.QuoteMeta(`".*foo.*"`)),
 		},
 		{
 			val:         "bar",
 			f:           StringMatch(regexp.MustCompile(".*foo.*"), "value must contain foo"),
-			expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must contain foo\\)"),
+			expectedErr: regexp.MustCompile(`invalid value for [\w]+ \(value must contain foo\)`),
 		},
 	})
 }
@@ -363,12 +363,12 @@ func TestValidationStringDoesNotMatch(t *testing.T) {
 		{
 			val:         "bar",
 			f:           StringDoesNotMatch(regexp.MustCompile(".*bar.*"), ""),
-			expectedErr: regexp.MustCompile("expected value of [\\w]+ to not match regular expression " + regexp.QuoteMeta(`".*bar.*"`)),
+			expectedErr: regexp.MustCompile(`expected value of [\w]+ to not match regular expression ` + regexp.QuoteMeta(`".*bar.*"`)),
 		},
 		{
 			val:         "bar",
 			f:           StringDoesNotMatch(regexp.MustCompile(".*bar.*"), "value must not contain foo"),
-			expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must not contain foo\\)"),
+			expectedErr: regexp.MustCompile(`invalid value for [\w]+ \(value must not contain foo\)`),
 		},
 	})
 }

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -92,7 +92,6 @@ func parseModuleInstancePrefix(traversal hcl.Traversal) (ModuleInstance, hcl.Tra
 				"Invalid address operator",
 				"Module address prefix must be followed by dot and then a name.",
 			))
-			break
 		}
 
 		if next != "module" {
@@ -122,7 +121,6 @@ func parseModuleInstancePrefix(traversal hcl.Traversal) (ModuleInstance, hcl.Tra
 				"Invalid address operator",
 				"Prefix \"module.\" must be followed by a module name.",
 			))
-			break
 		}
 		remain = remain[1:]
 		step := ModuleInstanceStep{

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -93,13 +93,13 @@ func AttributePathToPath(ap *tftypes.AttributePath) cty.Path {
 		return p
 	}
 	for _, step := range ap.Steps() {
-		switch step.(type) {
+		switch step := step.(type) {
 		case tftypes.AttributeName:
-			p = p.GetAttr(string(step.(tftypes.AttributeName)))
+			p = p.GetAttr(string(step))
 		case tftypes.ElementKeyString:
-			p = p.Index(cty.StringVal(string(step.(tftypes.ElementKeyString))))
+			p = p.Index(cty.StringVal(string(step)))
 		case tftypes.ElementKeyInt:
-			p = p.Index(cty.NumberIntVal(int64(step.(tftypes.ElementKeyInt))))
+			p = p.Index(cty.NumberIntVal(int64(step)))
 		}
 	}
 	return p

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1023,7 +1023,7 @@ func (m *ModuleState) String() string {
 		}
 
 		if len(rs.Dependencies) > 0 {
-			buf.WriteString(fmt.Sprintf("\n  Dependencies:\n"))
+			buf.WriteString("\n  Dependencies:\n")
 			for _, dep := range rs.Dependencies {
 				buf.WriteString(fmt.Sprintf("    %s\n", dep))
 			}
@@ -1237,11 +1237,7 @@ func (s *ResourceState) Equal(other *ResourceState) bool {
 	}
 
 	// States must be equal
-	if !s.Primary.Equal(other.Primary) {
-		return false
-	}
-
-	return true
+	return s.Primary.Equal(other.Primary)
 }
 
 // Taint marks a resource as tainted.


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/865

Previously:

```text
helper/validation/float_test.go:66:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(2\\.5\\d*\\), got 1\\.5\\d*"),
                                     ^
helper/validation/float_test.go:71:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be float"),
                                     ^
helper/validation/float_test.go:89:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(1\\.5\\d*\\), got 2\\.5\\d*"),
                                     ^
helper/validation/float_test.go:94:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be float"),
                                     ^
helper/validation/int_test.go:21:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be in the range \\(2 - 3\\), got 1"),
                                     ^
helper/validation/int_test.go:26:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
                                     ^
helper/validation/int_test.go:44:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(2\\), got 1"),
                                     ^
helper/validation/int_test.go:49:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
                                     ^
helper/validation/int_test.go:67:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(0\\), got 1"),
                                     ^
helper/validation/int_test.go:72:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
                                     ^
helper/validation/int_test.go:122:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[10 20\\], got 42"),
                                     ^
helper/validation/int_test.go:127:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be integer"),
                                     ^
helper/validation/meta_test.go:55:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(5 - 42\\), got foo"),
                                     ^
helper/validation/meta_test.go:90:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
                                     ^
helper/validation/meta_test.go:98:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
                                     ^
helper/validation/meta_test.go:125:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at least \\(42\\), got 7"),
                                     ^
helper/validation/meta_test.go:133:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be at most \\(5\\), got 7"),
                                     ^
helper/validation/strings_test.go:293:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[ValidValue AnotherValidValue\\], got VALIDVALUE"),
                                     ^
helper/validation/strings_test.go:298:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[ValidValue AnotherValidValue\\], got InvalidValue"),
                                     ^
helper/validation/strings_test.go:303:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
                                     ^
helper/validation/strings_test.go:322:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got AnotherInvalidValue"),
                                     ^
helper/validation/strings_test.go:328:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected [\\w]+ to not be any of \\[InvalidValue AnotherInvalidValue\\], got INVALIDVALUE"),
                                     ^
helper/validation/strings_test.go:333:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("expected type of [\\w]+ to be string"),
                                     ^
helper/validation/strings_test.go:352:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must contain foo\\)"),
                                     ^
helper/validation/strings_test.go:371:17: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
                        expectedErr: regexp.MustCompile("invalid value for [\\w]+ \\(value must not contain foo\\)"),
                                     ^
internal/plugin/convert/diagnostics.go:96:10: S1034: assigning the result of this type assertion to a variable (switch step := step.(type)) could eliminate type assertions in switch cases (gosimple)
                switch step.(type) {
                       ^
internal/plugin/convert/diagnostics.go:98:25: S1034(related information): could eliminate this type assertion (gosimple)
                        p = p.GetAttr(string(step.(tftypes.AttributeName)))
                                             ^
internal/plugin/convert/diagnostics.go:100:37: S1034(related information): could eliminate this type assertion (gosimple)
                        p = p.Index(cty.StringVal(string(step.(tftypes.ElementKeyString))))
                                                         ^
internal/plugin/convert/diagnostics.go:102:39: S1034(related information): could eliminate this type assertion (gosimple)
                        p = p.Index(cty.NumberIntVal(int64(step.(tftypes.ElementKeyInt))))
                                                           ^
internal/addrs/module_instance.go:95:4: S1023: redundant break statement (gosimple)
                        break
                        ^
internal/addrs/module_instance.go:125:4: S1023: redundant break statement (gosimple)
                        break
                        ^
helper/resource/testing.go:129:14: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
                elapsed := time.Now().Sub(start)
                           ^
helper/resource/testing.go:242:13: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
        elapsed := time.Now().Sub(start)
                   ^
helper/schema/set.go:241:2: S1032: should use sort.Strings(...) instead of sort.Sort(sort.StringSlice(...)) (gosimple)
        sort.Sort(sort.StringSlice(keys))
        ^
helper/schema/resource.go:847:5: S1002: should omit comparison to bool constant, can be simplified to `!s.Computed` (gosimple)
        if s.Computed != true {
           ^
helper/schema/field_reader_map.go:162:3: S1008: should use 'return len(countActual) < countExpected' instead of 'if len(countActual) >= countExpected { return false }; return true' (gosimple)
                if len(countActual) >= countExpected {
                ^
terraform/state.go:1026:20: S1039: unnecessary use of fmt.Sprintf (gosimple)
                        buf.WriteString(fmt.Sprintf("\n  Dependencies:\n"))
                                        ^
terraform/state.go:1240:2: S1008: should use 'return s.Primary.Equal(other.Primary)' instead of 'if !s.Primary.Equal(other.Primary) { return false }; return true' (gosimple)
        if !s.Primary.Equal(other.Primary) {
```