### PR TITLE
helper/schema: Schema.DiffSuppressOnRefresh

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -638,6 +638,7 @@ func (r *Resource) RefreshWithoutUpgrade(
 		state = nil
 	}
 
+	schemaMap(r.Schema).handleDiffSuppressOnRefresh(s, state)
 	return r.recordCurrentSchemaVersion(state), diags
 }
 

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -1143,6 +1143,53 @@ func TestResourceRefresh(t *testing.T) {
 	}
 }
 
+func TestResourceRefresh_DiffSuppressOnRefresh(t *testing.T) {
+	r := &Resource{
+		SchemaVersion: 2,
+		Schema: map[string]*Schema{
+			"foo": {
+				Type:     TypeString,
+				Optional: true,
+				DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
+			},
+		},
+	}
+
+	r.Read = func(d *ResourceData, m interface{}) error {
+		return d.Set("foo", "howdy")
+	}
+
+	s := &terraform.InstanceState{
+		ID: "bar",
+		Attributes: map[string]string{
+			"foo": "hello",
+		},
+	}
+
+	expected := &terraform.InstanceState{
+		ID: "bar",
+		Attributes: map[string]string{
+			"id":  "bar",
+			"foo": "hello", // new value was suppressed
+		},
+		Meta: map[string]interface{}{
+			"schema_version": "2",
+		},
+	}
+
+	actual, diags := r.RefreshWithoutUpgrade(context.Background(), s, 42)
+	if diags.HasError() {
+		t.Fatalf("err: %s", diagutils.ErrorDiags(diags))
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestResourceRefresh_blankId(t *testing.T) {
 	r := &Resource{
 		Schema: map[string]*Schema{

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/hcl2shim"
@@ -4799,6 +4800,29 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"DiffSuppressOnRefresh without DiffSuppressFunc": {
+			map[string]*Schema{
+				"string": {
+					Type:                  TypeString,
+					Optional:              true,
+					DiffSuppressOnRefresh: true,
+				},
+			},
+			true,
+		},
+
+		"DiffSuppressOnRefresh with DiffSuppressFunc": {
+			map[string]*Schema{
+				"string": {
+					Type:                  TypeString,
+					Optional:              true,
+					DiffSuppressFunc:      func(k, oldValue, newValue string, d *ResourceData) bool { return false },
+					DiffSuppressOnRefresh: true,
+				},
+			},
+			false,
+		},
+
 		"Computed-only with ExactlyOneOf": {
 			map[string]*Schema{
 				"string_one": {
@@ -5313,6 +5337,214 @@ func TestSchemaMap_DiffSuppress(t *testing.T) {
 
 			if !reflect.DeepEqual(tc.ExpectedDiff, d) {
 				t.Fatalf("#%q:\n\nexpected:\n%#v\n\ngot:\n%#v", tn, tc.ExpectedDiff, d)
+			}
+		})
+	}
+}
+
+func TestSchema_DiffSuppressOnRefresh(t *testing.T) {
+	cases := map[string]struct {
+		Schema     schemaMap
+		PriorState map[string]string
+		SetKey     string
+		SetVal     interface{}
+		WantState  map[string]string
+	}{
+		"no suppress func string": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeString,
+					Optional: true,
+				},
+			},
+			PriorState: map[string]string{
+				"v": "hello",
+			},
+			SetKey: "v",
+			SetVal: "howdy",
+			WantState: map[string]string{
+				"v": "howdy", // set was honored
+			},
+		},
+		"suppress func string but not always": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+						return true
+					},
+				},
+			},
+			PriorState: map[string]string{
+				"v": "hello",
+			},
+			SetKey: "v",
+			SetVal: "howdy",
+			WantState: map[string]string{
+				"v": "howdy", // set was honored
+			},
+		},
+		"suppress func string always": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+						return true
+					},
+					DiffSuppressOnRefresh: true,
+				},
+			},
+			PriorState: map[string]string{
+				"v": "hello",
+			},
+			SetKey: "v",
+			SetVal: "howdy",
+			WantState: map[string]string{
+				"v": "hello", // set was ignored
+			},
+		},
+		"suppress func string always no prior": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeString,
+					Optional: true,
+					DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+						return true
+					},
+					DiffSuppressOnRefresh: true,
+				},
+			},
+			PriorState: map[string]string{},
+			SetKey:     "v",
+			SetVal:     "howdy",
+			WantState: map[string]string{
+				"v": "howdy", // set was honored
+			},
+		},
+		"suppress func nested string but not always": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"w": {
+								Type: TypeString,
+								DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+									return true
+								},
+							},
+						},
+					},
+				},
+			},
+			PriorState: map[string]string{
+				"v.#":   "1",
+				"v.0.w": "hello",
+			},
+			SetKey: "v",
+			SetVal: []map[string]interface{}{{"w": "howdy"}},
+			WantState: map[string]string{
+				"v.#":   "1",
+				"v.0.w": "howdy", // set was honored
+			},
+		},
+		"suppress func nested string always": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"w": {
+								Type: TypeString,
+								DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+									return true
+								},
+								DiffSuppressOnRefresh: true,
+							},
+						},
+					},
+				},
+				"unrelated": {
+					Type:     TypeString,
+					Optional: true,
+				},
+			},
+			PriorState: map[string]string{
+				"v.#":       "1",
+				"v.0.w":     "hello",
+				"unrelated": "hi",
+			},
+			SetKey: "v",
+			SetVal: []map[string]interface{}{{"w": "howdy"}},
+			WantState: map[string]string{
+				"v.#":       "1",
+				"v.0.w":     "hello", // set was ignored
+				"unrelated": "hi",
+			},
+		},
+		"suppress func nested string always no prior": {
+			Schema: schemaMap{
+				"v": {
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"w": {
+								Type: TypeString,
+								DiffSuppressFunc: func(key, old, new string, d *ResourceData) bool {
+									return true
+								},
+								DiffSuppressOnRefresh: true,
+							},
+						},
+					},
+				},
+			},
+			PriorState: map[string]string{
+				"v.#": "0",
+			},
+			SetKey: "v",
+			SetVal: []map[string]interface{}{{"w": "howdy"}},
+			WantState: map[string]string{
+				"v.#":   "1",
+				"v.0.w": "howdy", // set was honored
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			schema := tc.Schema
+			priorState := &terraform.InstanceState{
+				Attributes: tc.PriorState,
+			}
+
+			d, err := schema.Data(priorState, nil)
+			if err != nil {
+				t.Fatalf("failed to create ResourceData: %s", err)
+			}
+
+			d.SetId("-") // just to make d.State think this object exists
+
+			err = d.Set(tc.SetKey, tc.SetVal)
+			if err != nil {
+				t.Fatalf("failed to Set: %s", err)
+			}
+
+			newState := d.State()
+			schema.handleDiffSuppressOnRefresh(priorState, newState)
+			var newStateAttrs map[string]string
+			if newState != nil {
+				newStateAttrs = newState.Attributes
+				delete(newStateAttrs, "id")
+			}
+
+			if diff := cmp.Diff(tc.WantState, newStateAttrs); diff != "" {
+				t.Errorf("wrong result state\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Unfortunately in the original design of `DiffSuppressFunc` we made it work only during planning, and so the normalization vs. drift classification it does isn't honored in any other situation.

Unilaterally enabling it for both refresh and apply would be too risky at this late stage where so many existing provider behaviors rely on these subtle details, but here we introduce a more surgical _opt-in_ mechanism whereby specific attributes can be set to also check the Refresh result against `DiffSuppressFunc`, and so avoid reporting any normalization done by the remote system as if it were drift.

```go
    DiffSuppressFunc: /* as before, unmodified */,
    DiffSuppressOnRefresh: true, // enables the new behavior
```

This behavior will be primarily useful for strings containing complex data serialized into some particular microsyntax which allows expressing the same information multiple ways. In particular, existing situations where we classify whitespace changes and other such immaterial changes in JSON values as normalization vs. drift would be a good candidate to enable this flag, so that we can get the same results during refreshing and thus avoid churning any downstream resources that refer to the
unexpectedly-updated result.

This deals with only the most visible problem previously discussed over in hashicorp/terraform-plugin-framework#70 -- creating value churn during the refresh phase -- because the risk of a more systematic change to the legacy SDK at this point is too high. Hopefully eventually the new framework will address this more completely (also handling it during the apply step, for example), but I intend this PR as a pragmatic way to help provider developers more easily resolve bug reports related to incorrect classification of normalization by relying on the `DiffSuppressFunc` implementations already written against this old SDK, so they can be addressed with only minimal schema changes and in particular without switching to the new framework.

My primary goal here is that this should cause absolutely no observable difference in result for any existing schema that doesn't set this new flag, and so the presence of this new code would have no effect on any existing provider unless they _also_ opt in a particular attribute to it. I tried by best to code defensively to avoid e.g. introducing new panics in weird edge cases, but this legacy SDK does have a fair number of weird edge cases and so if you can spot one I didn't think of please let me know!
