### PR TITLE
Extra `TestCheckFunc`s to check attribute's string length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# -------------------------------------------------------------------------- Go
+# Based on: https://github.com/github/gitignore/blob/main/Go.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# ------------------------------------------------------------------- Terraform
+# Based on: https://github.com/github/gitignore/blob/main/Terraform.gitignore
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# -------------------------------------------------------------------- Jetbrains
+.idea/
+*.iml

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -1031,6 +1031,36 @@ func testCheckResourceAttrPair(isFirst *terraform.InstanceState, nameFirst strin
 	return nil
 }
 
+// TestRangeLengthResourceAttr is a TestCheckFunc which checks that the length of the value
+// in state for the given name/key is within an expected (closed) range
+func TestRangeLengthResourceAttr(name, key string, min, max int) TestCheckFunc {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		valLen := len(is.Attributes[key])
+		if valLen < min || valLen > max {
+			return fmt.Errorf(
+				"%s: Attribute '%s' length is %d, not within the expected range [%d, %d]",
+				name,
+				key,
+				valLen,
+				min,
+				max)
+		}
+
+		return nil
+	})
+}
+
+// TestMatchLengthResourceAttr is a TestCheckFunc which checks that the length of the value
+// in state for the given name/key matches a specific length
+func TestMatchLengthResourceAttr(name, key string, length int) TestCheckFunc {
+	return TestRangeLengthResourceAttr(name, key, length, length)
+}
+
 // TestCheckOutput checks an output in the Terraform configuration
 func TestCheckOutput(name, value string) TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -874,6 +874,87 @@ func TestCheckResourceAttr_empty(t *testing.T) {
 	}
 }
 
+func TestTestRangeLengthResourceAttr(t *testing.T) {
+	resName := "test_resource"
+	resKey := "test_key"
+	resVal := "test_value"
+
+	s := terraform.NewState()
+	s.AddModuleState(&terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			resName: {
+				Primary: &terraform.InstanceState{
+					Attributes: map[string]string{
+						resKey: resVal,
+					},
+				},
+			},
+		},
+	})
+
+	t.Run("in_range", func(t *testing.T) {
+		check := TestRangeLengthResourceAttr(resName, resKey, 2, 20)
+		if err := check(s); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("out_of_range", func(t *testing.T) {
+		check := TestRangeLengthResourceAttr(resName, resKey, 20, 40)
+		if err := check(s); err == nil {
+			t.Fatal(fmt.Errorf("failed to detect attribute '%s.%s' value '%s' length is out of range",
+				resName,
+				resKey,
+				resVal))
+		}
+	})
+}
+
+func TestTestMatchLengthResourceAttr(t *testing.T) {
+	resName := "test_resource"
+	resKey := "test_key"
+	resVal := "test_value"
+
+	s := terraform.NewState()
+	s.AddModuleState(&terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			resName: {
+				Primary: &terraform.InstanceState{
+					Attributes: map[string]string{
+						resKey: resVal,
+					},
+				},
+			},
+		},
+	})
+
+	t.Run("matches_length", func(t *testing.T) {
+		check := TestMatchLengthResourceAttr(resName, resKey, 10)
+		if err := check(s); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("too_short", func(t *testing.T) {
+		check := TestMatchLengthResourceAttr(resName, resKey, 11)
+		if err := check(s); err == nil {
+			t.Fatal(fmt.Errorf("failed to detect attribute '%s.%s' value '%s' is too short",
+				resName,
+				resKey,
+				resVal))
+		}
+	})
+	t.Run("too_long", func(t *testing.T) {
+		check := TestMatchLengthResourceAttr(resName, resKey, 2)
+		if err := check(s); err == nil {
+			t.Fatal(fmt.Errorf("failed to detect attribute '%s.%s' value '%s' is too long",
+				resName,
+				resKey,
+				resVal))
+		}
+	})
+}
+
 func TestCheckNoResourceAttr_empty(t *testing.T) {
 	s := terraform.NewState()
 	s.AddModuleState(&terraform.ModuleState{


### PR DESCRIPTION
## Background

Sometimes, when writing tests for a provider, one needs to check that a value is a certain length or length range, while cannot rely on expecting a specific value to match. This is for example true for situations when the provider will generate a value entirely randomised, but that "should be at least this long/short".

## Solution proposed

2 additional functions in `helper/resource/testing.go`:

* `func TestRangeLengthResourceAttr(name, key string, min, max int) TestCheckFunc`
* `func TestMatchLengthResourceAttr(name, key string, length int) TestCheckFunc`

This PR comes with tests to exercise this utility.

## Optional: `.gitignore` was missing

I have taken the liberty to provide this repository with a `.gitignore`. To avoid basing it on personal taste alone, I have set it up based on https://github.com/github/gitignore.

If this is a problem, I'd be happy to move this to a separate, dedicated PR.
