### PR TITLE
helper/schema: Additional Go documentation for Resource and Schema types

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -115,10 +115,11 @@ type Resource struct {
 	// The *ResourceData parameter contains the plan and state data for this
 	// managed resource instance. The available data in the Get* methods is the
 	// the proposed state, which is the merged data of the practitioner
-	// configuration and any CustomizeDiff field logic. The SetId method must
-	// be called with a non-empty value for the managed resource instance to be
-	// properly saved into the Terraform state and avoid a "inconsistent result
-	// after apply" error.
+	// configuration and any CustomizeDiff field logic.
+	//
+	// The SetId method must be called with a non-empty value for the managed
+	// resource instance to be properly saved into the Terraform state and
+	// avoid a "inconsistent result after apply" error.
 	//
 	// The interface{} parameter is the result of the Provider type
 	// ConfigureFunc field execution. If the Provider does not define
@@ -248,10 +249,11 @@ type Resource struct {
 	// The *ResourceData parameter contains the plan and state data for this
 	// managed resource instance. The available data in the Get* methods is the
 	// the proposed state, which is the merged data of the practitioner
-	// configuration and any CustomizeDiff field logic. The SetId method must
-	// be called with a non-empty value for the managed resource instance to be
-	// properly saved into the Terraform state and avoid a "inconsistent result
-	// after apply" error.
+	// configuration and any CustomizeDiff field logic.
+	//
+	// The SetId method must be called with a non-empty value for the managed
+	// resource instance to be properly saved into the Terraform state and
+	// avoid a "inconsistent result after apply" error.
 	//
 	// The interface{} parameter is the result of the Provider type
 	// ConfigureFunc field execution. If the Provider does not define
@@ -375,10 +377,11 @@ type Resource struct {
 	// The *ResourceData parameter contains the plan and state data for this
 	// managed resource instance. The available data in the Get* methods is the
 	// the proposed state, which is the merged data of the practitioner
-	// configuration and any CustomizeDiff field logic. The SetId method must
-	// be called with a non-empty value for the managed resource instance to be
-	// properly saved into the Terraform state and avoid a "inconsistent result
-	// after apply" error.
+	// configuration and any CustomizeDiff field logic.
+	//
+	// The SetId method must be called with a non-empty value for the managed
+	// resource instance to be properly saved into the Terraform state and
+	// avoid a "inconsistent result after apply" error.
 	//
 	// The interface{} parameter is the result of the Provider type
 	// ConfigureFunc field execution. If the Provider does not define

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -32,35 +32,44 @@ var ReservedResourceFields = []string{
 	"provisioner",
 }
 
-// Resource represents a thing in Terraform that has a set of configurable
-// attributes and a lifecycle (create, read, update, delete).
+// Resource is an abstraction for multiple Terraform concepts:
 //
-// The Resource schema is an abstraction that allows provider writers to
-// worry only about CRUD operations while off-loading validation, diff
-// generation, etc. to this higher level library.
+// - Managed Resource: An infrastructure component with a schema, lifecycle
+//                     operations such as create, read, update, and delete
+//                     (CRUD), and optional implementation details such as
+//                     import support, upgrade state support, and difference
+//                     customization.
+// - Data Resource: Also known as a data source. An infrastructure component
+//                  with a schema and only the read lifecycle operation.
+// - Block: When implemented within a Schema type Elem field, a configuration
+//          block that contains nested schema information such as attributes
+//          and blocks.
 //
-// In spite of the name, this struct is not used only for terraform resources,
-// but also for data sources. In the case of data sources, the Create,
-// Update and Delete functions must not be provided.
+// To fully implement managed resources, the Provider type ResourcesMap field
+// should include a reference to an implementation of this type. To fully
+// implement data resources, the Provider type DataSourcesMap field should
+// include a reference to an implementation of this type.
+//
+// Each field further documents any constraints based on the Terraform concept
+// being implemented.
 type Resource struct {
-	// Schema is the schema for the configuration of this resource.
+	// Schema is the structure and type information for this component. This
+	// field is required for all Resource concepts.
 	//
-	// The keys of this map are the configuration keys, and the values
-	// describe the schema of the configuration value.
-	//
-	// The schema is used to represent both configurable data as well
-	// as data that might be computed in the process of creating this
-	// resource.
+	// The keys of this map are the names used in a practitioner configuration,
+	// such as the attribute or block name. The values describe the structure
+	// and type information of that attribute or block.
 	Schema map[string]*Schema
 
 	// SchemaVersion is the version number for this resource's Schema
-	// definition. The current SchemaVersion stored in the state for each
-	// resource. Provider authors can increment this version number
-	// when Schema semantics change. If the State's SchemaVersion is less than
-	// the current SchemaVersion, the InstanceState is yielded to the
-	// MigrateState callback, where the provider can make whatever changes it
-	// needs to update the state to be compatible to the latest version of the
-	// Schema.
+	// definition. This field is only valid when the Resource is a managed
+	// resource.
+	//
+	// The current SchemaVersion stored in the state for each resource.
+	// Provider authors can increment this version number when Schema semantics
+	// change in an incompatible manner. If the state's SchemaVersion is less
+	// than the current SchemaVersion, the MigrateState and StateUpgraders
+	// functionality is executed to upgrade the state information.
 	//
 	// When unset, SchemaVersion defaults to 0, so provider authors can start
 	// their Versioning at any integer >= 1
@@ -68,6 +77,7 @@ type Resource struct {
 
 	// MigrateState is responsible for updating an InstanceState with an old
 	// version to the format expected by the current version of the Schema.
+	// This field is only valid when the Resource is a managed resource.
 	//
 	// It is called during Refresh if the State's stored SchemaVersion is less
 	// than the current SchemaVersion of the Resource.
@@ -87,7 +97,8 @@ type Resource struct {
 	// StateUpgraders contains the functions responsible for upgrading an
 	// existing state with an old schema version to a newer schema. It is
 	// called specifically by Terraform when the stored schema version is less
-	// than the current SchemaVersion of the Resource.
+	// than the current SchemaVersion of the Resource. This field is only valid
+	// when the Resource is a managed resource.
 	//
 	// StateUpgraders map specific schema versions to a StateUpgrader
 	// function. The registered versions are expected to be ordered,
@@ -96,57 +107,259 @@ type Resource struct {
 	// MigrateState.
 	StateUpgraders []StateUpgrader
 
-	// The functions below are the CRUD operations for this resource.
+	// Create is called when the provider must create a new instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Create, CreateContext, or
+	// CreateWithoutTimeout should be implemented.
 	//
-	// Deprecated: Please use the context aware equivalents instead. Only one of
-	// the operations or context aware equivalent can be set, not both.
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the practitioner
+	// configuration and any CustomizeDiff field logic. The SetId method must
+	// be called with a non-empty value for the managed resource instance to be
+	// properly saved into the Terraform state and avoid a "inconsistent result
+	// after apply" error.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The error return parameter, if not nil, will be converted into an error
+	// diagnostic when passed back to Terraform.
+	//
+	// Deprecated: Use CreateContext or CreateWithoutTimeout instead. This
+	// implementation does not support request cancellation initiated by
+	// Terraform, such as a system or practitioner sending SIGINT (Ctrl-c).
+	// This implementation also does not support warning diagnostics.
 	Create CreateFunc
-	// Deprecated: Please use the context aware equivalents instead.
+
+	// Read is called when the provider must refresh the state of a managed
+	// resource instance or data resource instance. This field is only valid
+	// when the Resource is a managed resource or data resource. Only one of
+	// Read, ReadContext, or ReadWithoutTimeout should be implemented.
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance or data resource instance.
+	//
+	// Managed resources can signal to Terraform that the managed resource
+	// instance no longer exists and potentially should be recreated by calling
+	// the SetId method with an empty string ("") parameter and without
+	// returning an error.
+	//
+	// Data resources that are designed to return state for a singular
+	// infrastructure component should conventionally return an error if that
+	// infrastructure does not exist and omit any calls to the
+	// SetId method.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The error return parameter, if not nil, will be converted into an error
+	// diagnostic when passed back to Terraform.
+	//
+	// Deprecated: Use ReadContext or ReadWithoutTimeout instead. This
+	// implementation does not support request cancellation initiated by
+	// Terraform, such as a system or practitioner sending SIGINT (Ctrl-c).
+	// This implementation also does not support warning diagnostics.
 	Read ReadFunc
-	// Deprecated: Please use the context aware equivalents instead.
+
+	// Update is called when the provider must update an instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Update, UpdateContext, or
+	// UpdateWithoutTimeout should be implemented.
+	//
+	// This implementation is optional. If omitted, all Schema must enable
+	// the ForceNew field and any practitioner changes that would have
+	// caused and update will instead destroy and recreate the infrastructure
+	// compontent.
+	//
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the prior state,
+	// practitioner configuration, and any CustomizeDiff field logic. The
+	// available data for the GetChange* and HasChange* methods is the prior
+	// state and proposed state.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The error return parameter, if not nil, will be converted into an error
+	// diagnostic when passed back to Terraform.
+	//
+	// Deprecated: Use UpdateContext or UpdateWithoutTimeout instead. This
+	// implementation does not support request cancellation initiated by
+	// Terraform, such as a system or practitioner sending SIGINT (Ctrl-c).
+	// This implementation also does not support warning diagnostics.
 	Update UpdateFunc
-	// Deprecated: Please use the context aware equivalents instead.
+
+	// Delete is called when the provider must destroy the instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Delete, DeleteContext, or
+	// DeleteWithoutTimeout should be implemented.
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The error return parameter, if not nil, will be converted into an error
+	// diagnostic when passed back to Terraform.
+	//
+	// Deprecated: Use DeleteContext or DeleteWithoutTimeout instead. This
+	// implementation does not support request cancellation initiated by
+	// Terraform, such as a system or practitioner sending SIGINT (Ctrl-c).
+	// This implementation also does not support warning diagnostics.
 	Delete DeleteFunc
 
 	// Exists is a function that is called to check if a resource still
-	// exists. If this returns false, then this will affect the diff
+	// exists. This field is only valid when the Resource is a managed
+	// resource.
+	//
+	// If this returns false, then this will affect the diff
 	// accordingly. If this function isn't set, it will not be called. You
 	// can also signal existence in the Read method by calling d.SetId("")
 	// if the Resource is no longer present and should be removed from state.
 	// The *ResourceData passed to Exists should _not_ be modified.
 	//
-	// Deprecated: ReadContext should be able to encapsulate the logic of Exists
+	// Deprecated: Remove in preference of ReadContext or ReadWithoutTimeout.
 	Exists ExistsFunc
 
-	// The functions below are the CRUD operations for this resource.
+	// CreateContext is called when the provider must create a new instance of
+	// a managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Create, CreateContext, or
+	// CreateWithoutTimeout should be implemented.
 	//
-	// The only optional operation is Update. If Update is not
-	// implemented, then updates will not be supported for this resource.
+	// The Context parameter stores SDK information, such as loggers and
+	// timeout deadlines. It also is wired to receive any cancellation from
+	// Terraform such as a system or practitioner sending SIGINT (Ctrl-c).
 	//
-	// The ResourceData parameter in the functions below are used to
-	// query configuration and changes for the resource as well as to set
-	// the ID, computed data, etc.
+	// By default, CreateContext has a 20 minute timeout. Use the Timeouts
+	// field to control the default duration or implement CreateWithoutTimeout
+	// instead of CreateContext to remove the default timeout.
 	//
-	// The interface{} parameter is the result of the ConfigureFunc in
-	// the provider for this resource. If the provider does not define
-	// a ConfigureFunc, this will be nil. This parameter should be used
-	// to store API clients, configuration structures, etc.
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the practitioner
+	// configuration and any CustomizeDiff field logic. The SetId method must
+	// be called with a non-empty value for the managed resource instance to be
+	// properly saved into the Terraform state and avoid a "inconsistent result
+	// after apply" error.
 	//
-	// These functions are passed a context configured to timeout with whatever
-	// was set as the timeout for this operation. Useful for forwarding on to
-	// backend SDK's that accept context. The context will also cancel if
-	// Terraform sends a cancellation signal.
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
 	//
-	// These functions return diagnostics, allowing developers to build
-	// a list of warnings and errors to be presented to the Terraform user.
-	// The AttributePath of those diagnostics should be built within these
-	// functions, please consult go-cty documentation for building a cty.Path
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	CreateContext CreateContextFunc
-	ReadContext   ReadContextFunc
+
+	// ReadContext is called when the provider must refresh the state of a managed
+	// resource instance or data resource instance. This field is only valid
+	// when the Resource is a managed resource or data resource. Only one of
+	// Read, ReadContext, or ReadWithoutTimeout should be implemented.
+	//
+	// The Context parameter stores SDK information, such as loggers and
+	// timeout deadlines. It also is wired to receive any cancellation from
+	// Terraform such as a system or practitioner sending SIGINT (Ctrl-c).
+	//
+	// By default, ReadContext has a 20 minute timeout. Use the Timeouts
+	// field to control the default duration or implement ReadWithoutTimeout
+	// instead of ReadContext to remove the default timeout.
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance or data resource instance.
+	//
+	// Managed resources can signal to Terraform that the managed resource
+	// instance no longer exists and potentially should be recreated by calling
+	// the SetId method with an empty string ("") parameter and without
+	// returning an error.
+	//
+	// Data resources that are designed to return state for a singular
+	// infrastructure component should conventionally return an error if that
+	// infrastructure does not exist and omit any calls to the
+	// SetId method.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
+	ReadContext ReadContextFunc
+
+	// UpdateContext is called when the provider must update an instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Update, UpdateContext, or
+	// UpdateWithoutTimeout should be implemented.
+	//
+	// This implementation is optional. If omitted, all Schema must enable
+	// the ForceNew field and any practitioner changes that would have
+	// caused and update will instead destroy and recreate the infrastructure
+	// compontent.
+	//
+	// The Context parameter stores SDK information, such as loggers and
+	// timeout deadlines. It also is wired to receive any cancellation from
+	// Terraform such as a system or practitioner sending SIGINT (Ctrl-c).
+	//
+	// By default, UpdateContext has a 20 minute timeout. Use the Timeouts
+	// field to control the default duration or implement UpdateWithoutTimeout
+	// instead of UpdateContext to remove the default timeout.
+	//
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the prior state,
+	// practitioner configuration, and any CustomizeDiff field logic. The
+	// available data for the GetChange* and HasChange* methods is the prior
+	// state and proposed state.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	UpdateContext UpdateContextFunc
+
+	// DeleteContext is called when the provider must destroy the instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Delete, DeleteContext, or
+	// DeleteWithoutTimeout should be implemented.
+	//
+	// The Context parameter stores SDK information, such as loggers and
+	// timeout deadlines. It also is wired to receive any cancellation from
+	// Terraform such as a system or practitioner sending SIGINT (Ctrl-c).
+	//
+	// By default, DeleteContext has a 20 minute timeout. Use the Timeouts
+	// field to control the default duration or implement DeleteWithoutTimeout
+	// instead of DeleteContext to remove the default timeout.
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	DeleteContext DeleteContextFunc
 
-	// CreateWithoutTimeout is equivalent to CreateContext with no context timeout.
+	// CreateWithoutTimeout is called when the provider must create a new
+	// instance of a managed resource. This field is only valid when the
+	// Resource is a managed resource. Only one of Create, CreateContext, or
+	// CreateWithoutTimeout should be implemented.
 	//
 	// Most resources should prefer CreateContext with properly implemented
 	// operation timeout values, however there are cases where operation
@@ -154,9 +367,33 @@ type Resource struct {
 	// logic, such as a mutex, to prevent remote system errors. Since these
 	// operations would have an indeterminate timeout that scales with the
 	// number of resources, this allows resources to control timeout behavior.
+	//
+	// The Context parameter stores SDK information, such as loggers. It also
+	// is wired to receive any cancellation from Terraform such as a system or
+	// practitioner sending SIGINT (Ctrl-c).
+	//
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the practitioner
+	// configuration and any CustomizeDiff field logic. The SetId method must
+	// be called with a non-empty value for the managed resource instance to be
+	// properly saved into the Terraform state and avoid a "inconsistent result
+	// after apply" error.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	CreateWithoutTimeout CreateContextFunc
 
-	// ReadWithoutTimeout is equivalent to ReadContext with no context timeout.
+	// ReadWithoutTimeout is called when the provider must refresh the state of
+	// a managed resource instance or data resource instance. This field is
+	// only valid when the Resource is a managed resource or data resource.
+	// Only one of Read, ReadContext, or ReadWithoutTimeout should be
+	// implemented.
 	//
 	// Most resources should prefer ReadContext with properly implemented
 	// operation timeout values, however there are cases where operation
@@ -164,9 +401,37 @@ type Resource struct {
 	// logic, such as a mutex, to prevent remote system errors. Since these
 	// operations would have an indeterminate timeout that scales with the
 	// number of resources, this allows resources to control timeout behavior.
+	//
+	// The Context parameter stores SDK information, such as loggers. It also
+	// is wired to receive any cancellation from Terraform such as a system or
+	// practitioner sending SIGINT (Ctrl-c).
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance or data resource instance.
+	//
+	// Managed resources can signal to Terraform that the managed resource
+	// instance no longer exists and potentially should be recreated by calling
+	// the SetId method with an empty string ("") parameter and without
+	// returning an error.
+	//
+	// Data resources that are designed to return state for a singular
+	// infrastructure component should conventionally return an error if that
+	// infrastructure does not exist and omit any calls to the
+	// SetId method.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	ReadWithoutTimeout ReadContextFunc
 
-	// UpdateWithoutTimeout is equivalent to UpdateContext with no context timeout.
+	// UpdateWithoutTimeout is called when the provider must update an instance
+	// of a managed resource. This field is only valid when the Resource is a
+	// managed resource. Only one of Update, UpdateContext, or
+	// UpdateWithoutTimeout should be implemented.
 	//
 	// Most resources should prefer UpdateContext with properly implemented
 	// operation timeout values, however there are cases where operation
@@ -174,9 +439,36 @@ type Resource struct {
 	// logic, such as a mutex, to prevent remote system errors. Since these
 	// operations would have an indeterminate timeout that scales with the
 	// number of resources, this allows resources to control timeout behavior.
+	//
+	// This implementation is optional. If omitted, all Schema must enable
+	// the ForceNew field and any practitioner changes that would have
+	// caused and update will instead destroy and recreate the infrastructure
+	// compontent.
+	//
+	// The Context parameter stores SDK information, such as loggers. It also
+	// is wired to receive any cancellation from Terraform such as a system or
+	// practitioner sending SIGINT (Ctrl-c).
+	//
+	// The *ResourceData parameter contains the plan and state data for this
+	// managed resource instance. The available data in the Get* methods is the
+	// the proposed state, which is the merged data of the prior state,
+	// practitioner configuration, and any CustomizeDiff field logic. The
+	// available data for the GetChange* and HasChange* methods is the prior
+	// state and proposed state.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	UpdateWithoutTimeout UpdateContextFunc
 
-	// DeleteWithoutTimeout is equivalent to DeleteContext with no context timeout.
+	// DeleteWithoutTimeout is called when the provider must destroy the
+	// instance of a managed resource. This field is only valid when the
+	// Resource is a managed resource. Only one of Delete, DeleteContext, or
+	// DeleteWithoutTimeout should be implemented.
 	//
 	// Most resources should prefer DeleteContext with properly implemented
 	// operation timeout values, however there are cases where operation
@@ -184,15 +476,37 @@ type Resource struct {
 	// logic, such as a mutex, to prevent remote system errors. Since these
 	// operations would have an indeterminate timeout that scales with the
 	// number of resources, this allows resources to control timeout behavior.
+	//
+	// The Context parameter stores SDK information, such as loggers. It also
+	// is wired to receive any cancellation from Terraform such as a system or
+	// practitioner sending SIGINT (Ctrl-c).
+	//
+	// The *ResourceData parameter contains the state data for this managed
+	// resource instance.
+	//
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
+	//
+	// The diagnostics return parameter, if not nil, can contain any
+	// combination and multiple of warning and/or error diagnostics.
 	DeleteWithoutTimeout DeleteContextFunc
 
-	// CustomizeDiff is a custom function for working with the diff that
-	// Terraform has created for this resource - it can be used to customize the
-	// diff that has been created, diff values not controlled by configuration,
-	// or even veto the diff altogether and abort the plan. It is passed a
-	// *ResourceDiff, a structure similar to ResourceData but lacking most write
-	// functions like Set, while introducing new functions that work with the
-	// diff such as SetNew, SetNewComputed, and ForceNew.
+	// CustomizeDiff is called after a difference (plan) has been generated
+	// for the Resource and allows for customizations, such as setting values
+	// not controlled by configuration, conditionally triggering resource
+	// recreation, or implementing additional validation logic to abort a plan.
+	// This field is only valid when the Resource is a managed resource.
+	//
+	// The Context parameter stores SDK information, such as loggers. It also
+	// is wired to receive any cancellation from Terraform such as a system or
+	// practitioner sending SIGINT (Ctrl-c).
+	//
+	// The *ResourceDiff parameter is similar to ResourceData but replaces the
+	// Set method with other difference handling methods, such as SetNew,
+	// SetNewComputed, and ForceNew. In general, only Schema with Computed
+	// enabled can have those methods executed against them.
 	//
 	// The phases Terraform runs this in, and the state available via functions
 	// like Get and GetChange, are as follows:
@@ -206,41 +520,60 @@ type Resource struct {
 	//
 	// This function needs to be resilient to support all scenarios.
 	//
-	// For the most part, only computed fields can be customized by this
-	// function.
+	// The interface{} parameter is the result of the Provider type
+	// ConfigureFunc field execution. If the Provider does not define
+	// a ConfigureFunc, this will be nil. This parameter is conventionally
+	// used to store API clients and other provider instance specific data.
 	//
-	// This function is only allowed on regular resources (not data sources).
+	// The error return parameter, if not nil, will be converted into an error
+	// diagnostic when passed back to Terraform.
 	CustomizeDiff CustomizeDiffFunc
 
-	// Importer is the ResourceImporter implementation for this resource.
+	// Importer is called when the provider must import an instance of a
+	// managed resource. This field is only valid when the Resource is a
+	// managed resource.
+	//
 	// If this is nil, then this resource does not support importing. If
 	// this is non-nil, then it supports importing and ResourceImporter
 	// must be validated. The validity of ResourceImporter is verified
 	// by InternalValidate on Resource.
 	Importer *ResourceImporter
 
-	// If non-empty, this string is emitted as a warning during Validate.
+	// If non-empty, this string is emitted as the details of a warning
+	// diagnostic during validation (validate, plan, and apply operations).
+	// This field is only valid when the Resource is a managed resource or
+	// data resource.
 	DeprecationMessage string
 
-	// Timeouts allow users to specify specific time durations in which an
-	// operation should time out, to allow them to extend an action to suit their
-	// usage. For example, a user may specify a large Creation timeout for their
-	// AWS RDS Instance due to it's size, or restoring from a snapshot.
-	// Resource implementors must enable Timeout support by adding the allowed
-	// actions (Create, Read, Update, Delete, Default) to the Resource struct, and
-	// accessing them in the matching methods.
+	// Timeouts configures the default time duration allowed before a create,
+	// read, update, or delete operation is considered timed out, which returns
+	// an error to practitioners. This field is only valid when the Resource is
+	// a managed resource or data resource.
+	//
+	// When implemented, practitioners can add a timeouts configuration block
+	// within their managed resource or data resource configuration to further
+	// customize the create, read, update, or delete operation timeouts. For
+	// example, a configuration may specify a longer create timeout for a
+	// database resource due to its data size.
+	//
+	// The ResourceData that is passed to create, read, update, and delete
+	// functionality can access the merged time duration of the Resource
+	// default timeouts configured in this field and the practitioner timeouts
+	// configuration via the Timeout method. Practitioner configuration
+	// always overrides any default values set here, whether shorter or longer.
 	Timeouts *ResourceTimeout
 
 	// Description is used as the description for docs, the language server and
 	// other user facing usage. It can be plain-text or markdown depending on the
-	// global DescriptionKind setting.
+	// global DescriptionKind setting. This field is valid for any Resource.
 	Description string
 
 	// UseJSONNumber should be set when state upgraders will expect
 	// json.Numbers instead of float64s for numbers. This is added as a
 	// toggle for backwards compatibility for type assertions, but should
 	// be used in all new resources to avoid bugs with sufficiently large
-	// user input.
+	// user input. This field is only valid when the Resource is a managed
+	// resource.
 	//
 	// See github.com/hashicorp/terraform-plugin-sdk/issues/655 for more
 	// details.

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -33,9 +33,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// Schema is used to describe the structure of a value.
+// Schema describes the structure and type information of a value, whether
+// sourced from configuration, plan, or state data. Schema is used in Provider
+// and Resource types (for managed resources and data resources) and is
+// fundamental to the implementations of ResourceData and ResourceDiff.
 //
-// Read the documentation of the struct elements for important details.
+// The Type field must always be set. At least one of Required, Optional,
+// Optional and Computed, or Computed must be enabled unless the Schema is
+// directly an implementation of an Elem field of another Schema.
 type Schema struct {
 	// Type is the type of the value and must be one of the ValueType values.
 	//
@@ -73,14 +78,37 @@ type Schema struct {
 	// behavior, and SchemaConfigModeBlock is not permitted.
 	ConfigMode SchemaConfigMode
 
-	// If one of these is set, then this item can come from the configuration.
-	// Both cannot be set. If Optional is set, the value is optional. If
-	// Required is set, the value is required.
-	//
-	// One of these must be set if the value is not computed. That is:
-	// value either comes from the config, is computed, or is both.
-	Optional bool
+	// Required indicates whether the practitioner must enter a value in the
+	// configuration for this attribute. Required cannot be used with Computed
+	// Default, DefaultFunc, DiffSuppressFunc, DiffSuppressOnRefresh,
+	// InputDefault, Optional, or StateFunc. At least one of Required,
+	// Optional, Optional and Computed, or Computed must be enabled.
 	Required bool
+
+	// Optional indicates whether the practitioner can choose to not enter
+	// a value in the configuration for this attribute. Optional cannot be used
+	// with Required.
+	//
+	// If also using Default or DefaultFunc, Computed should also be enabled,
+	// otherwise Terraform can output warning logs or "inconsistent result
+	// after apply" errors.
+	Optional bool
+
+	// Computed indicates whether the provider may return its own value for
+	// this attribute or not. Computed cannot be used with Required. If
+	// Required and Optional are both false, the attribute will be considered
+	// "read only" for the practitioner, with only the provider able to set
+	// its value.
+	Computed bool
+
+	// ForceNew indicates whether a change in this value requires the
+	// replacement (destroy and create) of the managed resource instance,
+	// rather than an in-place update. This field is only valid when the
+	// encapsulating Resource is a managed resource.
+	//
+	// If conditional replacement logic is needed, use the Resource type
+	// CustomizeDiff field to call the ResourceDiff type ForceNew method.
+	ForceNew bool
 
 	// If this is non-nil, the provided function will be used during diff
 	// of this field. If this is nil, a default diff for the type of the
@@ -129,29 +157,34 @@ type Schema struct {
 	// for existing providers if activated everywhere all at once.
 	DiffSuppressOnRefresh bool
 
-	// If this is non-nil, then this will be a default value that is used
-	// when this item is not set in the configuration.
+	// Default indicates a value to set if this attribute is not set in the
+	// configuration. Default cannot be used with DefaultFunc or Required.
+	// Default is only supported if the Type is TypeBool, TypeFloat, TypeInt,
+	// or TypeString. Default cannot be used if the Schema is directly an
+	// implementation of an Elem field of another Schema, such as trying to
+	// set a default value for a TypeList or TypeSet.
 	//
-	// DefaultFunc can be specified to compute a dynamic default.
-	// Only one of Default or DefaultFunc can be set. If DefaultFunc is
-	// used then its return value should be stable to avoid generating
-	// confusing/perpetual diffs.
+	// Changing either Default can be a breaking change, especially if the
+	// attribute has ForceNew enabled. If a default needs to change to align
+	// with changing assumptions in an upstream API, then it may be necessary
+	// to also implement resource state upgrade functionality to change the
+	// state to match or update read operation logic to align with the new
+	// default.
+	Default interface{}
+
+	// DefaultFunc can be specified to compute a dynamic default when this
+	// attribute is not set in the configuration. DefaultFunc cannot be used
+	// with Default. For legacy reasons, DefaultFunc can be used with Required
+	// attributes in a Provider schema, which will prompt practitioners for
+	// input if the result of this function is nil.
 	//
-	// Changing either Default or the return value of DefaultFunc can be
-	// a breaking change, especially if the attribute in question has
-	// ForceNew set. If a default needs to change to align with changing
-	// assumptions in an upstream API then it may be necessary to also use
-	// the MigrateState function on the resource to change the state to match,
-	// or have the Read function adjust the state value to align with the
-	// new default.
-	//
-	// If Required is true above, then Default cannot be set. DefaultFunc
-	// can be set with Required. If the DefaultFunc returns nil, then there
-	// will be no default and the user will be asked to fill it in.
-	//
-	// If either of these is set, then the user won't be asked for input
-	// for this key if the default is not nil.
-	Default     interface{}
+	// The return value should be stable to avoid generating confusing
+	// plan differences. Changing the return value can be a breaking change,
+	// especially if ForceNew is enabled. If a default needs to change to align
+	// with changing assumptions in an upstream API, then it may be necessary
+	// to also implement resource state upgrade functionality to change the
+	// state to match or update read operation logic to align with the new
+	// default.
 	DefaultFunc SchemaDefaultFunc
 
 	// Description is used as the description for docs, the language server and
@@ -164,85 +197,125 @@ type Schema struct {
 	// asked for. If Input is asked, this will be the default value offered.
 	InputDefault string
 
-	// The fields below relate to diffs.
-	//
-	// If Computed is true, then the result of this value is computed
-	// (unless specified by config) on creation.
-	//
-	// If ForceNew is true, then a change in this resource necessitates
-	// the creation of a new resource.
-	//
 	// StateFunc is a function called to change the value of this before
 	// storing it in the state (and likewise before comparing for diffs).
 	// The use for this is for example with large strings, you may want
 	// to simply store the hash of it.
-	Computed  bool
-	ForceNew  bool
 	StateFunc SchemaStateFunc
 
-	// The following fields are only set for a TypeList, TypeSet, or TypeMap.
+	// Elem represents the element type for a TypeList, TypeSet, or TypeMap
+	// attribute or block. The only valid types are *Schema and *Resource.
+	// Only TypeList and TypeSet support *Resource.
 	//
-	// Elem represents the element type. For a TypeMap, it must be a *Schema
-	// with a Type that is one of the primitives: TypeString, TypeBool,
-	// TypeInt, or TypeFloat. Otherwise it may be either a *Schema or a
-	// *Resource. If it is *Schema, the element type is just a simple value.
-	// If it is *Resource, the element type is a complex structure,
-	// potentially managed via its own CRUD actions on the API.
+	// If the Elem is a *Schema, the surrounding Schema represents a single
+	// attribute with a single element type for underlying elements. In
+	// practitioner configurations, an equals sign (=) is required to set
+	// the value. Refer to the following documentation:
+	//
+	//   https://www.terraform.io/docs/language/syntax/configuration.html
+	//
+	// The underlying *Schema is only required to implement Type. ValidateFunc
+	// or ValidateDiagFunc can be used to validate each element value.
+	//
+	// If the Elem is a *Resource, the surrounding Schema represents a
+	// configuration block. Blocks can contain underlying attributes or blocks.
+	// In practitioner configurations, an equals sign (=) cannot be used to
+	// set the value. Blocks are instead repeated as necessary, or require
+	// the use of dynamic block expressions. Refer to the following
+	// documentation:
+	//
+	//   https://www.terraform.io/docs/language/syntax/configuration.html
+	//   https://www.terraform.io/docs/language/expressions/dynamic-blocks.html
+	//
+	// The underlying *Resource must only implement the Schema field.
 	Elem interface{}
 
-	// The following fields are only set for a TypeList or TypeSet.
-	//
 	// MaxItems defines a maximum amount of items that can exist within a
-	// TypeSet or TypeList. Specific use cases would be if a TypeSet is being
-	// used to wrap a complex structure, however more than one instance would
-	// cause instability.
-	//
+	// TypeSet or TypeList.
+	MaxItems int
+
 	// MinItems defines a minimum amount of items that can exist within a
-	// TypeSet or TypeList. Specific use cases would be if a TypeSet is being
-	// used to wrap a complex structure, however less than one instance would
-	// cause instability.
+	// TypeSet or TypeList.
 	//
 	// If the field Optional is set to true then MinItems is ignored and thus
 	// effectively zero.
-	MaxItems int
 	MinItems int
 
-	// The following fields are only valid for a TypeSet type.
-	//
-	// Set defines a function to determine the unique ID of an item so that
-	// a proper set can be built.
+	// Set defines custom hash algorithm for each TypeSet element. If not
+	// defined, the SDK implements a default hash algorithm based on the
+	// underlying structure and type information of the Elem field.
 	Set SchemaSetFunc
 
 	// ComputedWhen is a set of queries on the configuration. Whenever any
 	// of these things is changed, it will require a recompute (this requires
 	// that Computed is set to true).
 	//
-	// NOTE: This currently does not work.
+	// Deprecated: This functionality is not implemented and this field
+	// declaration should be removed.
 	ComputedWhen []string
 
-	// ConflictsWith is a set of schema keys that conflict with this schema.
-	// This will only check that they're set in the _config_. This will not
-	// raise an error for a malfunctioning resource that sets a conflicting
-	// key.
+	// ConflictsWith is a set of attribute paths, including this attribute,
+	// whose configurations cannot be set simultaneously. This implements the
+	// validation logic declaratively within the schema and can trigger earlier
+	// in Terraform operations, rather than using create or update logic which
+	// only triggers during apply.
 	//
-	// ExactlyOneOf is a set of schema keys that, when set, only one of the
-	// keys in that list can be specified. It will error if none are
-	// specified as well.
-	//
-	// AtLeastOneOf is a set of schema keys that, when set, at least one of
-	// the keys in that list must be specified.
-	//
-	// RequiredWith is a set of schema keys that must be set simultaneously.
+	// Only absolute attribute paths, ones starting with top level attribute
+	// names, are supported. Attribute paths cannot be accurately declared
+	// for TypeList (if MaxItems is greater than 1), TypeMap, or TypeSet
+	// attributes. To reference an attribute under a single configuration block
+	// (TypeList with Elem of *Resource and MaxItems of 1), the syntax is
+	// "parent_block_name.0.child_attribute_name".
 	ConflictsWith []string
-	ExactlyOneOf  []string
-	AtLeastOneOf  []string
-	RequiredWith  []string
 
-	// When Deprecated is set, this attribute is deprecated.
+	// ExactlyOneOf is a set of attribute paths, including this attribute,
+	// where only one attribute out of all specified can be configured. It will
+	// return a validation error if none are specified as well. This implements
+	// the validation logic declaratively within the schema and can trigger
+	// earlier in Terraform operations, rather than using create or update
+	// logic which only triggers during apply.
 	//
-	// A deprecated field still works, but will probably stop working in near
-	// future. This string is the message shown to the user with instructions on
-	// how to address the deprecation.
+	// Only absolute attribute paths, ones starting with top level attribute
+	// names, are supported. Attribute paths cannot be accurately declared
+	// for TypeList (if MaxItems is greater than 1), TypeMap, or TypeSet
+	// attributes. To reference an attribute under a single configuration block
+	// (TypeList with Elem of *Resource and MaxItems of 1), the syntax is
+	// "parent_block_name.0.child_attribute_name".
+	ExactlyOneOf []string
+
+	// AtLeastOneOf is a set of attribute paths, including this attribute,
+	// in which at least one of the attributes must be configured. This
+	// implements the validation logic declaratively within the schema and can
+	// trigger earlier in Terraform operations, rather than using create or
+	// update logic which only triggers during apply.
+	//
+	// Only absolute attribute paths, ones starting with top level attribute
+	// names, are supported. Attribute paths cannot be accurately declared
+	// for TypeList (if MaxItems is greater than 1), TypeMap, or TypeSet
+	// attributes. To reference an attribute under a single configuration block
+	// (TypeList with Elem of *Resource and MaxItems of 1), the syntax is
+	// "parent_block_name.0.child_attribute_name".
+	AtLeastOneOf []string
+
+	// RequiredWith is a set of attribute paths, including this attribute,
+	// that must be set simultaneously. This implements the validation logic
+	// declaratively within the schema and can trigger earlier in Terraform
+	// operations, rather than using create or update logic which only triggers
+	// during apply.
+	//
+	// Only absolute attribute paths, ones starting with top level attribute
+	// names, are supported. Attribute paths cannot be accurately declared
+	// for TypeList (if MaxItems is greater than 1), TypeMap, or TypeSet
+	// attributes. To reference an attribute under a single configuration block
+	// (TypeList with Elem of *Resource and MaxItems of 1), the syntax is
+	// "parent_block_name.0.child_attribute_name".
+	RequiredWith []string
+
+	// Deprecated indicates the message to include in a warning diagnostic to
+	// practitioners when this attribute is configured. Typically this is used
+	// to signal that this attribute will be removed in the future and provide
+	// next steps to the practitioner, such as using a different attribute,
+	// different resource, or if it should just be removed.
 	Deprecated string
 
 	// ValidateFunc allows individual fields to define arbitrary validation
@@ -278,9 +351,28 @@ type Schema struct {
 	ValidateDiagFunc SchemaValidateDiagFunc
 
 	// Sensitive ensures that the attribute's value does not get displayed in
-	// logs or regular output. It should be used for passwords or other
-	// secret fields. Future versions of Terraform may encrypt these
-	// values.
+	// the Terraform user interface output. It should be used for password or
+	// other values which should be hidden.
+	//
+	// Terraform does not support conditional sensitivity, so if the value may
+	// only be sensitive in certain scenarios, a pragmatic choice will be
+	// necessary upfront of whether or not to always hide the value. Some
+	// providers may opt to split up resources based on sensitivity, to ensure
+	// that practitioners without sensitive values do not have values
+	// unnecessarily hidden.
+	//
+	// Terraform does not support passing sensitivity from configurations to
+	// providers. For example, if a sensitive value is configured via another
+	// attribute, this attribute is not marked Sensitive, and the value is used
+	// in this attribute value, the sensitivity is not transitive. The value
+	// will be displayed as normal.
+	//
+	// Sensitive values propagate when referenced in other parts of a
+	// configuration unless the nonsensitive() configuration function is used.
+	// Certain configuration usage may also expand the sensitivity. For
+	// example, including the sensitive value in a set may mark the whole set
+	// as sensitive. Any outputs containing a sensitive value must enable the
+	// output sensitive argument.
 	Sensitive bool
 }
 


### PR DESCRIPTION
Closes #467
Closes #601
Closes #705 
Closes #735

This also spends some cycles fixing the Go documentation for struct fields to be aligned with each field individually, so pkg.go.dev and the Go language server can appropriately show the matching documentation.