### PR TITLE
helper/resource: Additional Go documentation for TypeSet TestCheckFunc

### DIFF
--- a/helper/resource/testing_sets.go
+++ b/helper/resource/testing_sets.go
@@ -14,25 +14,46 @@ const (
 	sentinelIndex = "*"
 )
 
-// TestCheckTypeSetElemNestedAttrs is a TestCheckFunc that accepts a resource
-// name, an attribute path, which should use the sentinel value '*' for indexing
-// into a TypeSet. The function verifies that an element matches the whole value
-// map.
+// TestCheckTypeSetElemNestedAttrs ensures a subset map of values is stored in
+// state for the given name and key combination of attributes nested under a
+// list or set block. Use this TestCheckFunc in preference over non-set
+// variants to simplify testing code and ensure compatibility with indicies,
+// which can easily change with schema changes. State value checking is only
+// recommended for testing Computed attributes and attribute defaults.
 //
-// You may check for unset keys, however this will also match keys set to empty
-// string. Please provide a map with at least 1 non-empty value.
+// For managed resources, the name parameter is combination of the resource
+// type, a period (.), and the name label. The name for the below example
+// configuration would be "myprovider_thing.example".
 //
-//   map[string]string{
-//	     "key1": "value",
+//     resource "myprovider_thing" "example" { ... }
+//
+// For data sources, the name parameter is a combination of the keyword "data",
+// a period (.), the data source type, a period (.), and the name label. The
+// name for the below example configuration would be
+// "data.myprovider_thing.example".
+//
+//     data "myprovider_thing" "example" { ... }
+//
+// The key parameter is an attribute path in Terraform CLI 0.11 and earlier
+// "flatmap" syntax. Keys start with the attribute name of a top-level
+// attribute. Use the sentinel value '*' to replace the element indexing into
+// a list or set. The sentinel value can be used for each list or set index, if
+// there are multiple lists or sets in the attribute path.
+//
+// The values parameter is the map of attribute names to attribute values
+// expected to be nested under the list or set.
+//
+// You may check for unset nested attributes, however this will also match keys
+// set to empty string. Use a map with at least 1 non-empty value.
+//
+//     map[string]string{
+//       "key1": "value",
 //       "key2": "",
-//   }
+//     }
 //
-// Use this function over SDK provided TestCheckFunctions when validating a
-// TypeSet where its elements are a nested object with their own attrs/values.
-//
-// Please note, if the provided value map is not granular enough, there exists
-// the possibility you match an element you were not intending to, in the TypeSet.
-// Provide a full mapping of attributes to be sure the unique element exists.
+// If the values map is not granular enough, it is possible to match an element
+// you were not intending to in the set. Provide the most complete mapping of
+// attributes possible to be sure the unique element exists.
 func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string) TestCheckFunc {
 	return func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
@@ -64,17 +85,47 @@ func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string
 	}
 }
 
-// TestMatchTypeSetElemNestedAttrs is a TestCheckFunc similar to TestCheckTypeSetElemNestedAttrs
-// with the exception that it verifies that an element matches a *regexp.Regexp.
+// TestMatchTypeSetElemNestedAttrs ensures a subset map of values, compared by
+// regular expressions, is stored in state for the given name and key
+// combination of attributes nested under a list or set block. Use this
+// TestCheckFunc in preference over non-set variants to simplify testing code
+// and ensure compatibility with indicies, which can easily change with schema
+// changes. State value checking is only recommended for testing Computed
+// attributes and attribute defaults.
 //
-// You may check for unset keys, however this will also match keys set to empty
-// string. Please provide a map with at least 1 non-empty value e.g.
+// For managed resources, the name parameter is combination of the resource
+// type, a period (.), and the name label. The name for the below example
+// configuration would be "myprovider_thing.example".
 //
-//   map[string]*regexp.Regexp{
-//	     "key1": regexp.MustCompile("value"),
-//       "key2": regexp.MustCompile(""),
-//   }
+//     resource "myprovider_thing" "example" { ... }
 //
+// For data sources, the name parameter is a combination of the keyword "data",
+// a period (.), the data source type, a period (.), and the name label. The
+// name for the below example configuration would be
+// "data.myprovider_thing.example".
+//
+//     data "myprovider_thing" "example" { ... }
+//
+// The key parameter is an attribute path in Terraform CLI 0.11 and earlier
+// "flatmap" syntax. Keys start with the attribute name of a top-level
+// attribute. Use the sentinel value '*' to replace the element indexing into
+// a list or set. The sentinel value can be used for each list or set index, if
+// there are multiple lists or sets in the attribute path.
+//
+// The values parameter is the map of attribute names to regular expressions
+// for matching attribute values expected to be nested under the list or set.
+//
+// You may check for unset nested attributes, however this will also match keys
+// set to empty string. Use a map with at least 1 non-empty value.
+//
+//     map[string]*regexp.Regexp{
+//       "key1": regexp.MustCompile(`^value`),
+//       "key2": regexp.MustCompile(`^$`),
+//     }
+//
+// If the values map is not granular enough, it is possible to match an element
+// you were not intending to in the set. Provide the most complete mapping of
+// attributes possible to be sure the unique element exists.
 func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regexp.Regexp) TestCheckFunc {
 	return func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
@@ -113,6 +164,39 @@ func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regex
 //
 // Use this function over SDK provided TestCheckFunctions when validating a
 // TypeSet where its elements are a simple value
+
+// TestCheckTypeSetElemAttr ensures a specific value is stored in state for the
+// for the given name and key combination under a list or set. Use this
+// TestCheckFunc in preference over non-set variants to simplify testing code
+// and ensure compatibility with indicies, which can easily change with schema
+// changes. State value checking is only recommended for testing Computed
+// attributes and attribute defaults.
+//
+// For managed resources, the name parameter is combination of the resource
+// type, a period (.), and the name label. The name for the below example
+// configuration would be "myprovider_thing.example".
+//
+//     resource "myprovider_thing" "example" { ... }
+//
+// For data sources, the name parameter is a combination of the keyword "data",
+// a period (.), the data source type, a period (.), and the name label. The
+// name for the below example configuration would be
+// "data.myprovider_thing.example".
+//
+//     data "myprovider_thing" "example" { ... }
+//
+// The key parameter is an attribute path in Terraform CLI 0.11 and earlier
+// "flatmap" syntax. Keys start with the attribute name of a top-level
+// attribute. Use the sentinel value '*' to replace the element indexing into
+// a list or set. The sentinel value can be used for each list or set index, if
+// there are multiple lists or sets in the attribute path.
+//
+// The value parameter is the stringified data to check at the given key. Use
+// the following attribute type rules to set the value:
+//
+//     - Boolean: "false" or "true".
+//     - Float/Integer: Stringified number, such as "1.2" or "123".
+//     - String: No conversion necessary.
 func TestCheckTypeSetElemAttr(name, attr, value string) TestCheckFunc {
 	return func(s *terraform.State) error {
 		is, err := primaryInstanceState(s, name)
@@ -129,12 +213,32 @@ func TestCheckTypeSetElemAttr(name, attr, value string) TestCheckFunc {
 	}
 }
 
-// TestCheckTypeSetElemAttrPair is a TestCheckFunc that verifies a pair of name/key
-// combinations are equal where the first uses the sentinel value to index into a
-// TypeSet.
+// TestCheckTypeSetElemAttrPair ensures value equality in state between the
+// first given name and key combination and the second name and key
+// combination. State value checking is only recommended for testing Computed
+// attributes and attribute defaults.
 //
-// E.g., TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0")
-// E.g., TestCheckTypeSetElemAttrPair("aws_spot_fleet_request.bar", "launch_specification.*.instance_type", "data.data.aws_ec2_instance_type_offering.available", "instance_type")
+// For managed resources, the name parameter is combination of the resource
+// type, a period (.), and the name label. The name for the below example
+// configuration would be "myprovider_thing.example".
+//
+//     resource "myprovider_thing" "example" { ... }
+//
+// For data sources, the name parameter is a combination of the keyword "data",
+// a period (.), the data source type, a period (.), and the name label. The
+// name for the below example configuration would be
+// "data.myprovider_thing.example".
+//
+//     data "myprovider_thing" "example" { ... }
+//
+// The first and second names may use any combination of managed resources
+// and/or data sources.
+//
+// The key parameter is an attribute path in Terraform CLI 0.11 and earlier
+// "flatmap" syntax. Keys start with the attribute name of a top-level
+// attribute. Use the sentinel value '*' to replace the element indexing into
+// a list or set. The sentinel value can be used for each list or set index, if
+// there are multiple lists or sets in the attribute path.
 func TestCheckTypeSetElemAttrPair(nameFirst, keyFirst, nameSecond, keySecond string) TestCheckFunc {
 	return func(s *terraform.State) error {
 		isFirst, err := primaryInstanceState(s, nameFirst)

--- a/helper/resource/testing_sets.go
+++ b/helper/resource/testing_sets.go
@@ -21,7 +21,7 @@ const (
 // which can easily change with schema changes. State value checking is only
 // recommended for testing Computed attributes and attribute defaults.
 //
-// For managed resources, the name parameter is combination of the resource
+// For managed resources, the name parameter is a combination of the resource
 // type, a period (.), and the name label. The name for the below example
 // configuration would be "myprovider_thing.example".
 //
@@ -44,7 +44,7 @@ const (
 // expected to be nested under the list or set.
 //
 // You may check for unset nested attributes, however this will also match keys
-// set to empty string. Use a map with at least 1 non-empty value.
+// set to an empty string. Use a map with at least 1 non-empty value.
 //
 //     map[string]string{
 //       "key1": "value",
@@ -93,7 +93,7 @@ func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string
 // changes. State value checking is only recommended for testing Computed
 // attributes and attribute defaults.
 //
-// For managed resources, the name parameter is combination of the resource
+// For managed resources, the name parameter is a combination of the resource
 // type, a period (.), and the name label. The name for the below example
 // configuration would be "myprovider_thing.example".
 //
@@ -116,7 +116,7 @@ func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string
 // for matching attribute values expected to be nested under the list or set.
 //
 // You may check for unset nested attributes, however this will also match keys
-// set to empty string. Use a map with at least 1 non-empty value.
+// set to an empty string. Use a map with at least 1 non-empty value.
 //
 //     map[string]*regexp.Regexp{
 //       "key1": regexp.MustCompile(`^value`),
@@ -172,7 +172,7 @@ func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regex
 // changes. State value checking is only recommended for testing Computed
 // attributes and attribute defaults.
 //
-// For managed resources, the name parameter is combination of the resource
+// For managed resources, the name parameter is a combination of the resource
 // type, a period (.), and the name label. The name for the below example
 // configuration would be "myprovider_thing.example".
 //
@@ -218,7 +218,7 @@ func TestCheckTypeSetElemAttr(name, attr, value string) TestCheckFunc {
 // combination. State value checking is only recommended for testing Computed
 // attributes and attribute defaults.
 //
-// For managed resources, the name parameter is combination of the resource
+// For managed resources, the name parameter is a combination of the resource
 // type, a period (.), and the name label. The name for the below example
 // configuration would be "myprovider_thing.example".
 //

--- a/helper/resource/testing_sets.go
+++ b/helper/resource/testing_sets.go
@@ -166,11 +166,11 @@ func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regex
 // TypeSet where its elements are a simple value
 
 // TestCheckTypeSetElemAttr ensures a specific value is stored in state for the
-// for the given name and key combination under a list or set. Use this
-// TestCheckFunc in preference over non-set variants to simplify testing code
-// and ensure compatibility with indicies, which can easily change with schema
-// changes. State value checking is only recommended for testing Computed
-// attributes and attribute defaults.
+// given name and key combination under a list or set. Use this TestCheckFunc
+// in preference over non-set variants to simplify testing code and ensure
+// compatibility with indicies, which can easily change with schema changes.
+// State value checking is only recommended for testing Computed attributes and
+// attribute defaults.
 //
 // For managed resources, the name parameter is a combination of the resource
 // type, a period (.), and the name label. The name for the below example

--- a/helper/resource/testing_sets_example_test.go
+++ b/helper/resource/testing_sets_example_test.go
@@ -1,0 +1,159 @@
+package resource_test
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func ExampleTestCheckTypeSetElemAttr() {
+	// This function is typically implemented in a TestStep type Check field,
+	// wrapped with ComposeAggregateTestCheckFunc to combine results from
+	// multiple checks.
+	//
+	// Given the following example configuration:
+	//
+	//     resource "example_thing" "test" {
+	//       example_set_attribute = ["value1", "value2", "value3"]
+	//     }
+	//
+	// The following TestCheckTypeSetElemAttr can be written to assert against
+	// the expected state values.
+	//
+	// NOTE: State value checking is only necessary for Computed attributes,
+	//       as the testing framework will automatically return test failures
+	//       for configured attributes that mismatch the saved state, however
+	//       this configuration and test is shown for illustrative purposes.
+	resource.TestCheckTypeSetElemAttr("example_thing.test", "example_set_attribute.*", "value1")
+	resource.TestCheckTypeSetElemAttr("example_thing.test", "example_set_attribute.*", "value2")
+	resource.TestCheckTypeSetElemAttr("example_thing.test", "example_set_attribute.*", "value3")
+}
+
+func ExampleTestCheckTypeSetElemNestedAttrs() {
+	// This function is typically implemented in a TestStep type Check field,
+	// wrapped with ComposeAggregateTestCheckFunc to combine results from
+	// multiple checks.
+	//
+	// Given the following example configuration:
+	//
+	//     resource "example_thing" "test" {
+	//       example_set_block {
+	//         key1 = "value1a"
+	//         key2 = "value2a"
+	//         key3 = "value3a"
+	//       }
+	//
+	//       example_set_block {
+	//         key1 = "value1b"
+	//         key2 = "value2b"
+	//         key3 = "value3b"
+	//       }
+	//     }
+	//
+	// The following TestCheckTypeSetElemNestedAttrs can be written to assert
+	// against the expected state values.
+	//
+	// NOTE: State value checking is only necessary for Computed attributes,
+	//       as the testing framework will automatically return test failures
+	//       for configured attributes that mismatch the saved state, however
+	//       this configuration and test is shown for illustrative purposes.
+	resource.TestCheckTypeSetElemNestedAttrs(
+		"example_thing.test",
+		"example_set_block.*",
+		map[string]string{
+			"key1": "value1a",
+			"key2": "value2a",
+			"key3": "value3a",
+		},
+	)
+	resource.TestCheckTypeSetElemNestedAttrs(
+		"example_thing.test",
+		"example_set_block.*",
+		map[string]string{
+			"key1": "value1b",
+			"key2": "value2b",
+			"key3": "value3b",
+		},
+	)
+}
+
+func ExampleTestCheckTypeSetElemAttrPair() {
+	// This function is typically implemented in a TestStep type Check field,
+	// wrapped with ComposeAggregateTestCheckFunc to combine results from
+	// multiple checks.
+	//
+	// Given the following example configuration:
+	//
+	//     data "example_lookup" "test" {
+	//       example_string_attribute = "test-value"
+	//     }
+	//
+	//     resource "example_thing" "test" {
+	//       example_set_attribute = [
+	//         data.example_lookup.test.example_string_attribute,
+	//         "another-test-value",
+	//       ]
+	//     }
+	//
+	// The following TestCheckTypeSetElemAttrPair can be written to assert
+	// against the expected state values.
+	//
+	// NOTE: State value checking is only necessary for Computed attributes,
+	//       as the testing framework will automatically return test failures
+	//       for configured attributes that mismatch the saved state, however
+	//       this configuration and test is shown for illustrative purposes.
+	resource.TestCheckTypeSetElemAttrPair(
+		"example_thing.test",
+		"example_set_attribute.*",
+		"data.example_lookup.test",
+		"example_string_attribute",
+	)
+}
+
+func ExampleTestMatchTypeSetElemNestedAttrs() {
+	// This function is typically implemented in a TestStep type Check field,
+	// wrapped with ComposeAggregateTestCheckFunc to combine results from
+	// multiple checks.
+	//
+	// Given the following example configuration:
+	//
+	//     resource "example_thing" "test" {
+	//       example_set_block {
+	//         key1 = "value1a"
+	//         key2 = "value2a"
+	//         key3 = "value3a"
+	//       }
+	//
+	//       example_set_block {
+	//         key1 = "value1b"
+	//         key2 = "value2b"
+	//         key3 = "value3b"
+	//       }
+	//     }
+	//
+	// The following TestMatchTypeSetElemNestedAttrs can be written to assert
+	// against the expected state values.
+	//
+	// NOTE: State value checking is only necessary for Computed attributes,
+	//       as the testing framework will automatically return test failures
+	//       for configured attributes that mismatch the saved state, however
+	//       this configuration and test is shown for illustrative purposes.
+	resource.TestMatchTypeSetElemNestedAttrs(
+		"example_thing.test",
+		"example_set_block.*",
+		map[string]*regexp.Regexp{
+			"key1": regexp.MustCompile(`1a$`),
+			"key2": regexp.MustCompile(`2a$`),
+			"key3": regexp.MustCompile(`3a$`),
+		},
+	)
+	resource.TestMatchTypeSetElemNestedAttrs(
+		"example_thing.test",
+		"example_set_block.*",
+		map[string]*regexp.Regexp{
+			"key1": regexp.MustCompile(`1b$`),
+			"key2": regexp.MustCompile(`2b$`),
+			"key3": regexp.MustCompile(`3b$`),
+		},
+	)
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/pull/911

Additional glow up for the `TypeSet` functions, similar to the others.