### PR TITLE
Improve "unsupported test mode" message

### DIFF
--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -197,7 +197,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 			continue
 		}
 
-		t.Fatal("Unsupported test mode")
+		t.Fatalf("Step %d/%d, unsupported test mode",  i+1, len(c.Steps))
 	}
 }
 

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -197,7 +197,7 @@ func runNewTest(ctx context.Context, t testing.T, c TestCase, helper *plugintest
 			continue
 		}
 
-		t.Fatalf("Step %d/%d, unsupported test mode",  i+1, len(c.Steps))
+		t.Fatalf("Step %d/%d, unsupported test mode", i+1, len(c.Steps))
 	}
 }
 


### PR DESCRIPTION
The "unsupported test mode" message does not tell you which step of the test failed, unlike the other fatal errors in the `runNewTest` function here. This change adds the step number to the error message to make it more useful and more consistent.