### PR TITLE
Improve error reporting and avoid repeating `DiscoveryConfig` when unnecessary in `plugintest`

### DIFF
--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -78,7 +78,7 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	installer := install.NewInstaller()
 	tfExec, err := installer.Ensure(context.Background(), sources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ensure intallation of Terraform from %+v: %w", sources, err)
+		return nil, fmt.Errorf("failed to find or install Terraform CLI from %+v: %w", sources, err)
 	}
 
 	ctx = logging.TestTerraformPathContext(ctx, tfExec)

--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -78,7 +78,7 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	installer := install.NewInstaller()
 	tfExec, err := installer.Ensure(context.Background(), sources)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to ensure intallation of Terraform from %+v: %w", sources, err)
 	}
 
 	ctx = logging.TestTerraformPathContext(ctx, tfExec)


### PR DESCRIPTION
Context: #923, https://github.com/hashicorp/terraform-plugin-sdk/issues/923#issuecomment-1087398496

With this change I'm addressing ~~2~~ 1 issue~~s~~:

1. make sure that when we call [hc-install](https://github.com/hashicorp/hc-install) `installer.Ensure`, we contextualise the error a bit. Admittedly, `hc-install` errors should be a bit more verbose too.

~~2. avoid pointless "work" by making sure the calls to `DiscoverConfig` are cached and serialized with a `sync.Mutex`. Given a specific `sourceDir`, the discovery should happen only once, even when highly parallel testing is applied~~

### Update

After talking with @bflad I understand that the way the tests get setup by the SDK prevent that 2 installations of Terraform might be happening in the same directory. This renders my whole "add a critical section with a `mutex`" approach unnecessary.

I'm keeping though the error message "contextualization": this can help future issues to better understand what step of the issue reported in #923 is being hit.

I'll write an update also on #923 on what the user can do to help reduce the chance of this issue happening.