### PR TITLE
helper/resource: Set CHECKPOINT_DISABLE environment variable outside terraform-exec

### DIFF
--- a/.changelog/pending.txt
+++ b/.changelog/pending.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helper/resource: Prevented regression since 2.13.0 with the removal of environment variables, including `TF_VAR_*`, when calling Terraform CLI commands
+```

--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -43,6 +43,14 @@ func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *pl
 	// plugins.
 	os.Setenv("PLUGIN_PROTOCOL_VERSIONS", "5")
 
+	// Acceptance testing does not need to call checkpoint as the output
+	// is not accessible, nor desirable if explicitly using
+	// TF_ACC_TERRAFORM_PATH or TF_ACC_TERRAFORM_VERSION environment variables.
+	//
+	// Avoid calling (tfexec.Terraform).SetEnv() as it will stop copying
+	// os.Environ() and prevents TF_VAR_ environment variable usage.
+	os.Setenv("CHECKPOINT_DISABLE", "1")
+
 	// Terraform 0.12.X and 0.13.X+ treat namespaceless providers
 	// differently in terms of what namespace they default to. So we're
 	// going to set both variations, as we don't know which version of

--- a/internal/plugintest/environment_variables.go
+++ b/internal/plugintest/environment_variables.go
@@ -2,9 +2,6 @@ package plugintest
 
 // Environment variables
 const (
-	// Disables checkpoint.hashicorp.com calls in Terraform CLI.
-	EnvCheckpointDisable = "CHECKPOINT_DISABLE"
-
 	// Environment variable with acceptance testing temporary directory for
 	// testing files and Terraform CLI installation, if installation is
 	// required. By default, the operating system temporary directory is used.

--- a/internal/plugintest/helper.go
+++ b/internal/plugintest/helper.go
@@ -124,14 +124,6 @@ func (h *Helper) NewWorkingDir(ctx context.Context) (*WorkingDir, error) {
 		return nil, fmt.Errorf("unable to create terraform-exec instance: %w", err)
 	}
 
-	err = tf.SetEnv(map[string]string{
-		EnvCheckpointDisable: "1",
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to set terraform-exec environment variables: %w", err)
-	}
-
 	return &WorkingDir{
 		h:             h,
 		tf:            tf,


### PR DESCRIPTION
Closes #935

When using `(tfexec.Terraform).SetEnv()`, it will no longer copy `os.Environ()`. It is also not possible for the code to call `tfexec.CleanEnv(os.Environ())` with the additional environment variable as it would strip previously accepted `TF_VAR_` environment variables. There are no plans to change this behavior in terraform-exec.