### PR TITLE
all: Replace various log.Printf calls with tfsdklog calls

### DIFF
--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -330,7 +329,7 @@ func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *pl
 	// started.
 	err := f()
 	if err != nil {
-		log.Printf("[WARN] Got error running Terraform: %s", err)
+		logging.HelperResourceWarn(ctx, "Error running Terraform CLI command", map[string]interface{}{logging.KeyError: err})
 	}
 
 	logging.HelperResourceTrace(ctx, "Called wrapped Terraform CLI command")

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -75,11 +75,11 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 	}
 
 	resp.Provider = &tfprotov5.Schema{
-		Block: convert.ConfigSchemaToProto(s.getProviderSchemaBlock()),
+		Block: convert.ConfigSchemaToProto(ctx, s.getProviderSchemaBlock()),
 	}
 
 	resp.ProviderMeta = &tfprotov5.Schema{
-		Block: convert.ConfigSchemaToProto(s.getProviderMetaSchemaBlock()),
+		Block: convert.ConfigSchemaToProto(ctx, s.getProviderMetaSchemaBlock()),
 	}
 
 	for typ, res := range s.provider.ResourcesMap {
@@ -87,7 +87,7 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 
 		resp.ResourceSchemas[typ] = &tfprotov5.Schema{
 			Version: int64(res.SchemaVersion),
-			Block:   convert.ConfigSchemaToProto(res.CoreConfigSchema()),
+			Block:   convert.ConfigSchemaToProto(ctx, res.CoreConfigSchema()),
 		}
 	}
 
@@ -96,7 +96,7 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 
 		resp.DataSourceSchemas[typ] = &tfprotov5.Schema{
 			Version: int64(dat.SchemaVersion),
-			Block:   convert.ConfigSchemaToProto(dat.CoreConfigSchema()),
+			Block:   convert.ConfigSchemaToProto(ctx, dat.CoreConfigSchema()),
 		}
 	}
 

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -266,7 +266,7 @@ func (p *Provider) Configure(ctx context.Context, c *terraform.ResourceConfig) d
 	}
 
 	if p.configured {
-		log.Printf("[WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.")
+		logging.HelperSchemaWarn(ctx, "Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.")
 	}
 
 	sm := schemaMap(p.Schema)

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -779,16 +778,16 @@ func (r *Resource) Apply(
 	rt := ResourceTimeout{}
 	if _, ok := d.Meta[TimeoutKey]; ok {
 		if err := rt.DiffDecode(d); err != nil {
-			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+			logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
 		}
 	} else if s != nil {
 		if _, ok := s.Meta[TimeoutKey]; ok {
 			if err := rt.StateDecode(s); err != nil {
-				log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+				logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
 			}
 		}
 	} else {
-		log.Printf("[DEBUG] No meta timeoutkey found in Apply()")
+		logging.HelperSchemaDebug(ctx, "No meta timeoutkey found in Apply()")
 	}
 	data.timeouts = &rt
 
@@ -873,10 +872,10 @@ func (r *Resource) Diff(
 
 	if instanceDiff != nil {
 		if err := t.DiffEncode(instanceDiff); err != nil {
-			log.Printf("[ERR] Error encoding timeout to instance diff: %s", err)
+			logging.HelperSchemaError(ctx, "Error encoding timeout to instance diff", map[string]interface{}{logging.KeyError: err})
 		}
 	} else {
-		log.Printf("[DEBUG] Instance Diff is nil in Diff()")
+		logging.HelperSchemaDebug(ctx, "Instance Diff is nil in Diff()")
 	}
 
 	return instanceDiff, err
@@ -972,7 +971,7 @@ func (r *Resource) RefreshWithoutUpgrade(
 	rt := ResourceTimeout{}
 	if _, ok := s.Meta[TimeoutKey]; ok {
 		if err := rt.StateDecode(s); err != nil {
-			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+			logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
 		}
 	}
 

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -649,7 +650,7 @@ func TestSetNew(t *testing.T) {
 				return
 			}
 			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+				if err := m.diff(context.Background(), k, m[k], tc.Diff, d, false); err != nil {
 					t.Fatalf("bad: %s", err)
 				}
 			}
@@ -676,7 +677,7 @@ func TestSetNewComputed(t *testing.T) {
 				return
 			}
 			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+				if err := m.diff(context.Background(), k, m[k], tc.Diff, d, false); err != nil {
 					t.Fatalf("bad: %s", err)
 				}
 			}
@@ -945,7 +946,7 @@ func TestForceNew(t *testing.T) {
 				return
 			}
 			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+				if err := m.diff(context.Background(), k, m[k], tc.Diff, d, false); err != nil {
 					t.Fatalf("bad: %s", err)
 				}
 			}
@@ -1194,7 +1195,7 @@ func TestClear(t *testing.T) {
 				return
 			}
 			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+				if err := m.diff(context.Background(), k, m[k], tc.Diff, d, false); err != nil {
 					t.Fatalf("bad: %s", err)
 				}
 			}
@@ -1436,7 +1437,7 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 			keys := d.GetChangedKeysPrefix(tc.Key)
 
 			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+				if err := m.diff(context.Background(), k, m[k], tc.Diff, d, false); err != nil {
 					t.Fatalf("bad: %s", err)
 				}
 			}

--- a/internal/logging/helper_schema.go
+++ b/internal/logging/helper_schema.go
@@ -16,6 +16,11 @@ func HelperSchemaDebug(ctx context.Context, msg string, additionalFields ...map[
 	tfsdklog.SubsystemDebug(ctx, SubsystemHelperSchema, msg, additionalFields...)
 }
 
+// HelperSchemaError emits a helper/schema subsystem log at ERROR level.
+func HelperSchemaError(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
+	tfsdklog.SubsystemError(ctx, SubsystemHelperSchema, msg, additionalFields...)
+}
+
 // HelperSchemaTrace emits a helper/schema subsystem log at TRACE level.
 func HelperSchemaTrace(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
 	tfsdklog.SubsystemTrace(ctx, SubsystemHelperSchema, msg, additionalFields...)

--- a/internal/plugin/convert/schema_test.go
+++ b/internal/plugin/convert/schema_test.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -186,7 +187,7 @@ func TestConvertSchemaBlocks(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			converted := ProtoToConfigSchema(tc.Block)
+			converted := ProtoToConfigSchema(context.Background(), tc.Block)
 			if !cmp.Equal(converted, tc.Want, typeComparer, valueComparer, equateEmpty) {
 				t.Fatal(cmp.Diff(converted, tc.Want, typeComparer, valueComparer, equateEmpty))
 			}
@@ -362,7 +363,7 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			converted := ConfigSchemaToProto(tc.Block)
+			converted := ConfigSchemaToProto(context.Background(), tc.Block)
 			if !cmp.Equal(converted, tc.Want, typeComparer, equateEmpty) {
 				t.Fatal(cmp.Diff(converted, tc.Want, typeComparer, equateEmpty))
 			}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/863

By default, the standard library `log` package will include the short timestamp and date flags, which when output will prefix any messaging, e.g.

```text
# From log.Printf("[DEBUG] Test message")
2022/01/26 16:25:33 [DEBUG] Test message
```

When a provider is running in production and the log output is being sent across the go-plugin boundary, Terraform CLI generally expects a hc-log formatted entry (square bracket log level prefixed message) or will output the raw message. So in many cases, this class of logging shows up in production logs as the raw message and the log level is not recognized, which is confusing for practitioners and provider developers:

```text
2022-01-26T16:25:33.123-0800 [INFO] provider.terraform-provider-example_v9.9.9_x5: 2022/01/26 16:25:33 [DEBUG] Test Message: timestamp=2022-01-26T16:25:33.123-0800
```

Setting the `log` package default logger to not include those flags via `log.SetFlags(0)` early in the SDK lifecycle may represent a breaking change for any providers depending on the current behavior, so this easier class of fix is not acceptable.

Now that this SDK implements the `tfsdklog` package, logging can be converted to that style, which fixes the above issue and these messages will now also include all the gathered logging context up to the call such as the RPC name and a request UUID.

There are quite a few other `log.Printf()` calls across the project, however they are non-trivial to update as:

* The logging context is not present or not guaranteed to be present (as is the case with `(helper/resource.StateChangeConf).WaitContext()`)
* The functions/methods are exported, so changing the signature is an unacceptable change
* The functions/methods while unexported are eventually surfaced via an exported type/function, so it could indirectly require breaking changes

Given that `helper/resource.StateChangeConf`, which also underlies `helper/resource.Retry*` functionality, is quite common across provider usage, a separate custom logging solution may be introduced there as a separate change.