### PR TITLE
Fix panic message to show correct unhandled type rather than the parent type

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -2109,7 +2109,7 @@ func validateMapValues(k string, m map[string]interface{}, schema *Schema, path 
 				})
 			}
 		default:
-			panic(fmt.Sprintf("Unknown validation type: %#v", schema.Type))
+			panic(fmt.Sprintf("Unknown validation type: %#v", valueType))
 		}
 	}
 	return diags


### PR DESCRIPTION
I was trying to model a block that had `map[string][]string` as it's schema, but the code was panicking with:

```
Unknown validation type: 6
```

Debugging, and it became clear that non-primitive types are not supported in the switch, but I was puzzled as to why it was reporting that a `TypeMap` was not a valid map value.

The switch is against `valueType`, so it makes sense (to me at least) that the panic should report that as the unknown validation type.

With this change, the code would report:

```
Unknown validation type: 7
```

Where 7 equates to `TypeSet` (aka. the string slice value of the map)