### PR TITLE
Add final sweeper error to logs

### DIFF
--- a/.changelog/983.txt
+++ b/.changelog/983.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+helper/resource: Ensured errors are always logged.
+```

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -119,6 +119,7 @@ func TestMain(m interface {
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
 
 		if _, err := runSweepers(regions, sweepers, *flagSweepAllowFailures); err != nil {
+			log.Printf("[ERROR] Running sweepers: %s", err)
 			os.Exit(1)
 		}
 	} else {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -119,7 +119,6 @@ func TestMain(m interface {
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
 
 		if _, err := runSweepers(regions, sweepers, *flagSweepAllowFailures); err != nil {
-			log.Printf("[ERROR] Running sweepers: %s", err)
 			os.Exit(1)
 		}
 	} else {
@@ -238,6 +237,7 @@ func runSweeperWithRegion(region string, s *Sweeper, sweepers map[string]*Sweepe
 		depSweeper, ok := sweepers[dep]
 
 		if !ok {
+			log.Printf("[ERROR] Sweeper (%s) has dependency (%s), but that sweeper was not found", s.Name, dep)
 			return fmt.Errorf("sweeper (%s) has dependency (%s), but that sweeper was not found", s.Name, dep)
 		}
 


### PR DESCRIPTION
If the sweeper framework returns an error, such as a missing sweeper dependency, the error is not displayed to the user.

```
...
2022/06/14 13:06:18 [DEBUG] Sweeper (aws_redshift_scheduled_action) already ran in region (us-west-2)
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	58.064s
FAIL
make: *** [sweep] Error 1
```

Now logs the error

```
...
2022/06/14 14:21:45 [DEBUG] Sweeper (aws_appconfig_configuration_profile) already ran in region (us-west-2)
2022/06/14 14:21:45 [ERROR] Sweeper (aws_docdb_global_cluster) has dependency (aws_docdb_cluster), but that sweeper was not found
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	60.860s
FAIL
make: *** [sweep] Error 1
```