### PR TITLE
boolean value passed in ENV taken care

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -409,6 +409,16 @@ func EnvDefaultFunc(k string, dv interface{}) SchemaDefaultFunc {
 
 		return dv, nil
 	}
+	return func() (interface{}, error) {
+		v := os.Getenv(k)
+		if v == "" {
+			return dv, nil
+		}
+		if v == "true" || v == "false" {
+			return strconv.ParseBool(v)
+		}
+		return v, nil
+	}
 }
 
 // MultiEnvDefaultFunc is a helper function that returns the value of the first

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -403,13 +403,6 @@ type SchemaDefaultFunc func() (interface{}, error)
 // otherwise.
 func EnvDefaultFunc(k string, dv interface{}) SchemaDefaultFunc {
 	return func() (interface{}, error) {
-		if v := os.Getenv(k); v != "" {
-			return v, nil
-		}
-
-		return dv, nil
-	}
-	return func() (interface{}, error) {
 		v := os.Getenv(k)
 		if v == "" {
 			return dv, nil


### PR DESCRIPTION
Boolean value passed from ENV value is treated as string and this would result in unknown behaviour in the provider.
Eg: a value "false" would be treated as boolean `true` earlier.

This PR fixes that.