### PR TITLE
Introduce `NewLoggingHTTPTransport` and deprecate `NewTransport`

### DIFF
--- a/.changelog/1006.txt
+++ b/.changelog/1006.txt
@@ -1,0 +1,7 @@
+```release-note:feature
+helper/logging: New `NewLoggingHTTPTransport()` and `NewSubsystemLoggingHTTPTransport()` functions, providing `http.RoundTripper` Transport implementations that log request/response using [terraform-plugin-log](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log)
+```
+
+```release-note:note
+helper/logging: Existing `NewTransport()` is now deprecated in favour of using the new `NewLoggingHTTPTransport()` or `NewSubsystemLoggingHTTPTransport()`
+```

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go mod download
-      - uses: golangci/golangci-lint-action@v3.2.0
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
   terraform-provider-corner:
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 website-preview
+
+# Jetbrains IDEs
+.idea/
+*.iws

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,17 @@ WEBSITE_DOCKER_RUN_FLAGS=--interactive \
 
 default: test
 
-test: fmtcheck generate
+test: generate
 	go test ./...
+
+lint:
+	golangci-lint run
 
 generate:
 	go generate ./...
 
 fmt:
-	gofmt -w $(GOFMT_FILES)
-
-fmtcheck:
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	gofmt -s -w -e $(GOFMT_FILES)
 
 # Run the terraform.io website to preview local content changes 
 website:
@@ -55,4 +55,4 @@ website/build-local:
 	@docker build https://github.com/hashicorp/terraform-website.git\#$(WEBSITE_BRANCH) \
 		-t $(WEBSITE_DOCKER_IMAGE_LOCAL)
 
-.PHONY: default fmt fmtcheck generate test website website/local website/build-local
+.PHONY: default fmt lint generate test website website/local website/build-local

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-plugin-go v0.12.0
-	github.com/hashicorp/terraform-plugin-log v0.6.0
+	github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-plugin-go v0.12.0
-	github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111
+	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZb
 github.com/hashicorp/terraform-plugin-go v0.12.0 h1:6wW9mT1dSs0Xq4LR6HXj1heQ5ovr5GxXNJwkErZzpJw=
 github.com/hashicorp/terraform-plugin-go v0.12.0/go.mod h1:kwhmaWHNDvT1B3QiSJdAtrB/D4RaKSY/v3r2BuoWK4M=
 github.com/hashicorp/terraform-plugin-log v0.6.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
-github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111 h1:m0u1i1IWGJuhfeWk7pBETkO1lV1c7bFPTUoMgkVuOKM=
-github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
+github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
+github.com/hashicorp/terraform-plugin-log v0.7.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,9 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-go v0.12.0 h1:6wW9mT1dSs0Xq4LR6HXj1heQ5ovr5GxXNJwkErZzpJw=
 github.com/hashicorp/terraform-plugin-go v0.12.0/go.mod h1:kwhmaWHNDvT1B3QiSJdAtrB/D4RaKSY/v3r2BuoWK4M=
-github.com/hashicorp/terraform-plugin-log v0.6.0 h1:/Vq78uSIdUSZ3iqDc9PESKtwt8YqNKN6u+khD+lLjuw=
 github.com/hashicorp/terraform-plugin-log v0.6.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
+github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111 h1:m0u1i1IWGJuhfeWk7pBETkO1lV1c7bFPTUoMgkVuOKM=
+github.com/hashicorp/terraform-plugin-log v0.6.1-0.20220724091104-b3ff5d724111/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/helper/logging/logging_http_transport.go
+++ b/helper/logging/logging_http_transport.go
@@ -1,0 +1,210 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	// FieldHttpOperationType is the field key used by NewLoggingHTTPTransport when logging the type of operation via tflog.
+	FieldHttpOperationType = "__HTTP_OP_TYPE__"
+
+	// OperationHttpRequest is the field value used by NewLoggingHTTPTransport when logging a request via tflog.
+	OperationHttpRequest = "HTTP_REQ"
+
+	// FieldHttpRequestMethod is the field key used by NewLoggingHTTPTransport when logging a request method via tflog.
+	FieldHttpRequestMethod = "__HTTP_REQ_METHOD__"
+
+	// FieldHttpRequestUri is the field key used by NewLoggingHTTPTransport when logging a request URI via tflog.
+	FieldHttpRequestUri = "__HTTP_REQ_URI__"
+
+	// FieldHttpRequestVersion is the field key used by NewLoggingHTTPTransport when logging a request HTTP version via tflog.
+	FieldHttpRequestVersion = "__HTTP_REQ_VERSION__"
+
+	// OperationHttpResponse is the field value used by NewLoggingHTTPTransport when logging a response via tflog.
+	OperationHttpResponse = "HTTP_RES"
+
+	// FieldHttpResponseVersion is the field key used by NewLoggingHTTPTransport when logging a response HTTP version via tflog.
+	FieldHttpResponseVersion = "__HTTP_RES_VERSION__"
+
+	// FieldHttpResponseStatusCode is the field key used by NewLoggingHTTPTransport when logging a response status code via tflog.
+	FieldHttpResponseStatusCode = "__HTTP_RES_STATUS__"
+
+	// FieldHttpResponseReason is the field key used by NewLoggingHTTPTransport when logging a response reason phrase via tflog.
+	FieldHttpResponseReason = "__HTTP_RES_REASON__"
+)
+
+// ConfigureReqCtxFunc is the type of function accepted by loggingHTTPTransport.WithConfigureRequestContext,
+// to configure the request subsystem logging context before the actual logging.
+type ConfigureReqCtxFunc func(ctx context.Context, subsystem string) context.Context
+
+type loggingHTTPTransport struct {
+	subsystem       string
+	transport       http.RoundTripper
+	configureReqCtx ConfigureReqCtxFunc
+}
+
+func (t *loggingHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Create a new subsystem logging context from the request context
+	ctx := tflog.NewSubsystem(req.Context(), t.subsystem)
+
+	// If set, allow for further configuration of the new subsystem logging context
+	if t.configureReqCtx != nil {
+		ctx = t.configureReqCtx(ctx, t.subsystem)
+	}
+
+	if IsDebugOrHigher() {
+		// Grub the outgoing request bytes
+		reqDump, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			tflog.SubsystemError(ctx, t.subsystem, "HTTP Request introspection failed", map[string]interface{}{
+				"error": fmt.Sprintf("%#v", err),
+			})
+		}
+
+		// Decompose the request bytes in a message (HTTP body) and fields (HTTP headers), then log it
+		msg, fields := decomposeRequestBytes(reqDump)
+		tflog.SubsystemDebug(ctx, t.subsystem, msg, fields)
+	}
+
+	// Invoke the wrapped RoundTrip now
+	res, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return res, err
+	}
+
+	if IsDebugOrHigher() {
+		// Grub the incoming response bytes
+		resDump, err := httputil.DumpResponse(res, true)
+		if err != nil {
+			tflog.SubsystemError(ctx, t.subsystem, "HTTP Response introspection error", map[string]interface{}{
+				"error": fmt.Sprintf("%#v", err),
+			})
+		}
+
+		// Decompose the response bytes in a message (HTTP body) and fields (HTTP headers), then log it
+		msg, fields := decomposeResponseBytes(resDump)
+		tflog.SubsystemDebug(ctx, t.subsystem, msg, fields)
+	}
+
+	return res, nil
+}
+
+// NewLoggingHTTPTransport creates a wrapper around a *http.RoundTripper,
+// designed to be used for the `Transport` field of http.Client.
+//
+// This logs each pair of HTTP request/response that it handles.
+// The logging is done via `tflog`, that is part of the terraform-plugin-log
+// library, included by this SDK.
+//
+// The request/response is logged via tflog.SubsystemDebug, and the `subsystem`
+// is the one provide here.
+//
+// IMPORTANT: For logging to work, it's mandatory that each http.Request it handles
+// is configured with the Context (i.e. `Request.WithContext(ctx)`)
+// that the SDK passes into all resources/data-sources/provider entry-points
+// (i.e. schema.Resource fields like `CreateContext`, `ReadContext`, etc.).
+func NewLoggingHTTPTransport(subsystem string, t http.RoundTripper) *loggingHTTPTransport {
+	return &loggingHTTPTransport{subsystem, t, nil}
+}
+
+// WithConfigureRequestContext allows to optionally configure a callback ConfigureReqCtxFunc.
+// This is used by the underlying structure to allow user to configure the
+// http.Request context.Context, before the request is executed and the logger
+// tflog.SubsystemDebug invoked.
+//
+// Log entries will be structured to contain:
+//
+//   * the HTTP message first line, broken up into "fields" (see `FieldHttp*` constants)
+//   * the Headers, each as "fields" of the log
+//   * the Request/Response Body as "message" of the log
+//
+// For example, here is how to add an extra field to each log emitted here,
+// as well as masking fields that have a specific key:
+//
+//   t.WithConfigureRequestContext(func (ctx context.Context, subsystem string) context.Context {
+//     ctx = tflog.SetField(ctx, "additional_key", "additional_value")
+//     ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "secret", "token", "Authorization")
+//   })
+//
+func (t *loggingHTTPTransport) WithConfigureRequestContext(callback ConfigureReqCtxFunc) *loggingHTTPTransport {
+	t.configureReqCtx = callback
+	return t
+}
+
+func decomposeRequestBytes(b []byte) (string, map[string]interface{}) {
+	parts := strings.Split(string(b), "\r\n")
+
+	// We will end up with a number of fields equivalent to the number of parts + 1:
+	// - the first will be split into 3 parts
+	// - the last 2 are "end of headers" and "body"
+	// - one extra for the operation type
+	fields := make(map[string]interface{}, len(parts)+1)
+	fields[FieldHttpOperationType] = OperationHttpRequest
+
+	// HTTP Request Line
+	reqLineParts := strings.Split(parts[0], " ")
+	fields[FieldHttpRequestMethod] = reqLineParts[0]
+	fields[FieldHttpRequestUri] = reqLineParts[1]
+	fields[FieldHttpRequestVersion] = reqLineParts[2]
+
+	// HTTP Request Headers
+	var i int
+	for i = 1; i < len(parts)-2; i++ {
+		// Check if we reached the end of the headers
+		if parts[i] == "" {
+			break
+		}
+
+		headerParts := strings.Split(parts[i], ": ")
+		fields[headerParts[0]] = headerParts[1]
+	}
+
+	// HTTP Response Body: the last part is always the body (can be empty)
+	return parts[len(parts)-1], fields
+}
+
+func decomposeResponseBytes(b []byte) (string, map[string]interface{}) {
+	parts := strings.Split(string(b), "\r\n")
+
+	// We will end up with a number of fields equivalent to the number of parts:
+	// - the first will be split into 3 parts
+	// - the last 2 are "end of headers" and "body"
+	// - one extra for the operation type
+	fields := make(map[string]interface{}, len(parts))
+	fields[FieldHttpOperationType] = OperationHttpResponse
+
+	// HTTP Message Status Line
+	reqLineParts := strings.Split(parts[0], " ")
+	fields[FieldHttpResponseVersion] = reqLineParts[0]
+	// NOTE: Unlikely, but if we can't parse the status code,
+	// we set its field value to string
+	statusCode, err := strconv.Atoi(reqLineParts[1])
+	if err != nil {
+		fields[FieldHttpResponseStatusCode] = reqLineParts[1]
+	} else {
+		fields[FieldHttpResponseStatusCode] = statusCode
+	}
+	fields[FieldHttpResponseReason] = reqLineParts[2]
+
+	// HTTP Response Headers
+	var i int
+	for i = 1; i < len(parts)-2; i++ {
+		// Check if we reached the end of the headers
+		if parts[i] == "" {
+			break
+		}
+
+		headerParts := strings.Split(parts[i], ": ")
+		fields[headerParts[0]] = headerParts[1]
+	}
+
+	// HTTP Response Body: the last part is always the body (can be empty)
+	return parts[len(parts)-1], fields
+}

--- a/helper/logging/logging_http_transport.go
+++ b/helper/logging/logging_http_transport.go
@@ -108,13 +108,6 @@ const (
 	// and NewSubsystemLoggingHTTPTransport when logging an HTTP response body via tflog.
 	FieldHttpResponseBody = "tf_http_res_body"
 
-	// MessageHttpRequest is the message used by NewLoggingHTTPTransport
-	// and NewSubsystemLoggingHTTPTransport when logging an HTTP request via tflog.
-	MessageHttpRequest = "Sending HTTP Request"
-
-	// MessageHttpResponse is the message used by NewLoggingHTTPTransport
-	// and NewSubsystemLoggingHTTPTransport when logging an HTTP response via tflog.
-	MessageHttpResponse = "Received HTTP Response"
 )
 
 type loggingHttpTransport struct {
@@ -132,7 +125,7 @@ func (t *loggingHttpTransport) RoundTrip(req *http.Request) (*http.Response, err
 			"error": err,
 		})
 	} else {
-		t.Debug(ctx, MessageHttpRequest, fields)
+		t.Debug(ctx, "Sending HTTP Request", fields)
 	}
 
 	// Invoke the wrapped RoundTrip now
@@ -148,7 +141,7 @@ func (t *loggingHttpTransport) RoundTrip(req *http.Request) (*http.Response, err
 			"error": err,
 		})
 	} else {
-		t.Debug(ctx, MessageHttpResponse, fields)
+		t.Debug(ctx, "Received HTTP Response", fields)
 	}
 
 	return res, nil

--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
@@ -42,6 +43,19 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 		t.Fatalf("unexpected amount of logs produced; expected 2, got %d", len(entries))
 	}
 
+	if transId, ok := entries[0]["tf_http_trans_id"]; !ok || transId != entries[1]["tf_http_trans_id"] {
+		t.Fatalf("expected to find the same 'tf_http_trans_id' in both req/res entries, got %q", transId)
+	}
+
+	transId, ok := entries[0]["tf_http_trans_id"].(string)
+	if !ok {
+		t.Fatalf("expected 'tf_http_trans_id' to be a string, got %T", transId)
+	}
+
+	if _, err := uuid.ParseUUID(transId); err != nil {
+		t.Fatalf("expected 'tf_http_trans_id' to be contain a valid UUID, but got an error: %v", err)
+	}
+
 	reqEntry := entries[0]
 	if diff := cmp.Diff(reqEntry, map[string]interface{}{
 		"@level":              "debug",
@@ -52,6 +66,7 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 		"tf_http_req_uri":     "/",
 		"tf_http_req_version": "HTTP/1.1",
 		"tf_http_req_body":    "An example multiline request body",
+		"tf_http_trans_id":    transId,
 		"Accept-Encoding":     "gzip",
 		"Host":                "www.terraform.io",
 		"User-Agent":          "Go-http-client/1.1",
@@ -70,6 +85,7 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 		"tf_http_res_status_code":   float64(200),
 		"tf_http_res_version":       "HTTP/2.0",
 		"tf_http_res_status_reason": "200 OK",
+		"tf_http_trans_id":          transId,
 	}
 	for ek, ev := range expectedResEntryFields {
 		if resEntry[ek] != ev {
@@ -118,6 +134,19 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 		t.Fatalf("unexpected amount of logs produced; expected 2, got %d", len(entries))
 	}
 
+	if transId, ok := entries[0]["tf_http_trans_id"]; !ok || transId != entries[1]["tf_http_trans_id"] {
+		t.Fatalf("expected to find the same 'tf_http_trans_id' in both req/res entries, got %q", transId)
+	}
+
+	transId, ok := entries[0]["tf_http_trans_id"].(string)
+	if !ok {
+		t.Fatalf("expected 'tf_http_trans_id' to be a string, got %T", transId)
+	}
+
+	if _, err := uuid.ParseUUID(transId); err != nil {
+		t.Fatalf("expected 'tf_http_trans_id' to be contain a valid UUID, but got an error: %v", err)
+	}
+
 	reqEntry := entries[0]
 	if diff := cmp.Diff(reqEntry, map[string]interface{}{
 		"@level":              "debug",
@@ -128,6 +157,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 		"tf_http_req_uri":     "/",
 		"tf_http_req_version": "HTTP/1.1",
 		"tf_http_req_body":    "An example multiline request body",
+		"tf_http_trans_id":    transId,
 		"Accept-Encoding":     "gzip",
 		"Host":                "www.terraform.io",
 		"User-Agent":          "Go-http-client/1.1",
@@ -146,6 +176,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 		"tf_http_res_status_code":   float64(200),
 		"tf_http_res_version":       "HTTP/2.0",
 		"tf_http_res_status_reason": "200 OK",
+		"tf_http_trans_id":          transId,
 	}
 	for ek, ev := range expectedResEntryFields {
 		if resEntry[ek] != ev {

--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -1,0 +1,122 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+func TestNewLoggingHTTPTransport(t *testing.T) {
+	ctx, loggerOutput := setupRootLogger(t)
+
+	transport := logging.NewLoggingHTTPTransport("test", http.DefaultTransport)
+	client := http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+
+	req, _ := http.NewRequest("GET", "https://www.terraform.io", nil)
+	res, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	entries, err := tflogtest.MultilineJSONDecode(loggerOutput)
+	if err != nil {
+		t.Fatalf("log outtput parsing failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("unexpected amount of logs produced; expected 2, got %d", len(entries))
+	}
+
+	reqEntry := entries[0]
+	if diff := cmp.Diff(reqEntry, map[string]interface{}{
+		"@level":               "debug",
+		"@message":             "",
+		"@module":              "provider.test",
+		"__HTTP_OP_TYPE__":     "HTTP_REQ",
+		"__HTTP_REQ_METHOD__":  "GET",
+		"__HTTP_REQ_URI__":     "/",
+		"__HTTP_REQ_VERSION__": "HTTP/1.1",
+		"Accept-Encoding":      "gzip",
+		"Host":                 "www.terraform.io",
+		"User-Agent":           "Go-http-client/1.1",
+	}); diff != "" {
+		t.Fatalf("unexpected difference for logging of the request:\n%s", diff)
+	}
+
+	resEntry := entries[1]
+	expectedResEntryFields := map[string]interface{}{
+		"@level":               "debug",
+		"@module":              "provider.test",
+		"Content-Type":         "text/html",
+		"__HTTP_OP_TYPE__":     "HTTP_RES",
+		"__HTTP_RES_STATUS__":  float64(200),
+		"__HTTP_RES_VERSION__": "HTTP/2.0",
+		"__HTTP_RES_REASON__":  "OK",
+	}
+	for ek, ev := range expectedResEntryFields {
+		if resEntry[ek] != ev {
+			t.Fatalf("Unexpected value for field %q; expected %q, got %q", ek, ev, resEntry[ek])
+		}
+	}
+}
+
+func TestNewLoggingHTTPTransport_LogMasking(t *testing.T) {
+	ctx, loggerOutput := setupRootLogger(t)
+
+	transport := logging.NewLoggingHTTPTransport("test", http.DefaultTransport)
+	transport.WithConfigureRequestContext(func(ctx context.Context, subsystem string) context.Context {
+		ctx = tflog.SubsystemMaskFieldValuesWithFieldKeys(ctx, subsystem, "__HTTP_OP_TYPE__")
+		ctx = tflog.SubsystemMaskMessageRegexes(ctx, subsystem, regexp.MustCompile(`<html>.*</html>`))
+		return ctx
+	})
+	client := http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+
+	req, _ := http.NewRequest("GET", "https://www.terraform.io", nil)
+	res, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	entries, err := tflogtest.MultilineJSONDecode(loggerOutput)
+	if err != nil {
+		t.Fatalf("log outtput parsing failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("unexpected amount of logs produced; expected 2, got %d", len(entries))
+	}
+
+	expectedMaskedEntryFields := map[string]interface{}{
+		"__HTTP_OP_TYPE__": "***",
+		"@message":         "<!DOCTYPE html>***",
+	}
+	for _, entry := range entries {
+		for ek, ev := range expectedMaskedEntryFields {
+			if entry[ek] != "" && entry[ek] != ev {
+				t.Fatalf("Unexpected value for field %q; expected %q, got %q", ek, ev, entry[ek])
+			}
+		}
+	}
+}
+
+func setupRootLogger(t *testing.T) (context.Context, *bytes.Buffer) {
+	t.Setenv(logging.EnvLog, "TRACE")
+	var output bytes.Buffer
+	return tflogtest.RootLogger(context.Background(), &output), &output
+}

--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -45,11 +45,11 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 // designed to be used for the `Transport` field of http.Client.
 //
 // This logs each pair of HTTP request/response that it handles.
-// The logging is done via standard `log`.
+// The logging is done via Go standard library `log` package.
 //
 // Deprecated: This will log the content of every http request/response
 // at `[DEBUG]` level, without any filtering. Any sensitive information
-// will appear as-is in your logs. Please use NewLoggingHTTPTransport instead.
+// will appear as-is in your logs. Please use NewSubsystemLoggingHTTPTransport instead.
 func NewTransport(name string, t http.RoundTripper) *transport {
 	return &transport{name, t}
 }

--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -41,6 +41,15 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+// NewTransport creates a wrapper around a *http.RoundTripper,
+// designed to be used for the `Transport` field of http.Client.
+//
+// This logs each pair of HTTP request/response that it handles.
+// The logging is done via standard `log`.
+//
+// Deprecated: This will log the content of every http request/response
+// at `[DEBUG]` level, without any filtering. Any sensitive information
+// will appear as-is in your logs. Please use NewLoggingHTTPTransport instead.
 func NewTransport(name string, t http.RoundTripper) *transport {
 	return &transport{name, t}
 }

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -1002,8 +1002,7 @@ func TestProviderUserAgentAppendViaEnvVar(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			os.Unsetenv(uaEnvVar)
-			os.Setenv(uaEnvVar, tc.envVarValue)
+			t.Setenv(uaEnvVar, tc.envVarValue)
 			p := &Provider{TerraformVersion: "4.5.6"}
 			givenUA := p.UserAgent(tc.providerName, tc.providerVersion)
 			if givenUA != tc.expected {


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform-provider-tfe/pull/479
Related: #2 
Closes: #546

## Background

Current SDK offers an helper `http.RoundTripper` in `helpers/logging`, that is created via `logging.NewTransport()`. This `http.RountTripper` can then be used as `.Transport` in an `http.Client`.

When logging level is _debug or higher_, it does a simple dump of the whole content of the request and of the following response.

This exposes any sensitive information that might be going over HTTP, and there is no way for developers using this code, to setup any filtering.

## Proposal

This PR introduced a 2 new implementations of `http.RoundTripper`, one designed to log via the provider root logger, the other via a user-defined subsystem.

```golang
func NewLoggingHTTPTransport(t http.RoundTripper) *loggingHttpTransport {
	return &loggingHttpTransport{"", false, t}
}

func NewSubsystemLoggingHTTPTransport(subsystem string, t http.RoundTripper) *loggingHttpTransport {
	return &loggingHttpTransport{subsystem, true, t}
}
```

This transport can be used exactly like the previous one, but it's built around the `tflog` package of [terraform-plugin-log](https://github.com/hashicorp/terraform-plugin-log), and offers an opt-in hook to configure the HTTP Request `context.Context`.

For example, if the user wants to setup log filtering against the provider root logger, and ensure that it's applied to each request handled by this transport:

```golang
// ctx == context.Context, provided by the SDK...

ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "MY_SENSITIVE_FIELD")
ctx = tflog.MaskMessageStrings(ctx, "MY_SECRET_STRING")

transport := logging.NewLoggingHTTPTransport(http.DefaultTransport)
client := http.Client{
  Transport: transport,
}

req, _ := http.NewRequest("GET", "https://www.terraform.io", nil)

res, err := client.Do(req.WithContext(ctx))
```

As a consequence, the existing `NewTransport` would be documented as deprecated.

## Related

* How to setup [log filtering](https://www.terraform.io/plugin/log/filtering) with `terraform-plugin-log`
* Fast follow-up: #1007
