### PR TITLE
docs: customdiff.{ValidateChange,ForceNewIfChange,ComputedIf} take a context.Context

### DIFF
--- a/helper/customdiff/compose.go
+++ b/helper/customdiff/compose.go
@@ -21,7 +21,7 @@ import (
 //	&schema.Resource{
 //	    // ...
 //	    CustomizeDiff: customdiff.All(
-//	        customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//	        customdiff.ValidateChange("size", func (ctx context.Context, old, new, meta interface{}) error {
 //	            // If we are increasing "size" then the new value must be
 //	            // a multiple of the old value.
 //	            if new.(int) <= old.(int) {
@@ -32,12 +32,12 @@ import (
 //	            }
 //	            return nil
 //	        }),
-//	        customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//	        customdiff.ForceNewIfChange("size", func (ctx context.Context, old, new, meta interface{}) bool {
 //	            // "size" can only increase in-place, so we must create a new resource
 //	            // if it is decreased.
 //	            return new.(int) < old.(int)
 //	        }),
-//	        customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//	        customdiff.ComputedIf("version_id", func (ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 //	            // Any change to "content" causes a new "version_id" to be allocated.
 //	            return d.HasChange("content")
 //	        }),

--- a/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -39,7 +39,7 @@ func resourceExampleInstance() *schema.Resource {
             },
         },
         CustomizeDiff: customdiff.All(
-            customdiff.ValidateChange("size", func (old, new, meta any) error {
+            customdiff.ValidateChange("size", func (ctx context.Context, old, new, meta any) error {
                 // If we are increasing "size" then the new value must be
                 // a multiple of the old value.
                 if new.(int) <= old.(int) {
@@ -50,7 +50,7 @@ func resourceExampleInstance() *schema.Resource {
                 }
                 return nil
             }),
-            customdiff.ForceNewIfChange("size", func (old, new, meta any) bool {
+            customdiff.ForceNewIfChange("size", func (ctx context.Context, old, new, meta any) bool {
                 // "size" can only increase in-place, so we must create a new resource
                 // if it is decreased.
                 return new.(int) < old.(int)


### PR DESCRIPTION
These functions all take a `context.Context` as their first argument now.

https://github.com/hashicorp/terraform-plugin-sdk/blob/9bdb216a4ab835003a624b0a15ac39c58ef2861e/helper/customdiff/validate.go#L12

https://github.com/hashicorp/terraform-plugin-sdk/blob/2f7133b9729bf59bd8a59e006f15e4f845556284/helper/customdiff/condition.go#L15

https://github.com/hashicorp/terraform-plugin-sdk/blob/2f7133b9729bf59bd8a59e006f15e4f845556284/helper/customdiff/condition.go#L11

