### PR TITLE
website: Replace interface{} with any

### DIFF
--- a/website/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/website/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -96,7 +96,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     existingAttribute := d.Get("existing_attribute").(string)
@@ -106,7 +106,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("existing_attribute", /* ... */)
@@ -115,7 +115,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     existingAttribute := d.Get("existing_attribute").(string)
@@ -155,7 +155,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     existingAttribute, existingAttributeOk := d.GetOk("existing_attribute")
@@ -173,7 +173,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if _, ok := d.GetOk("existing_attribute"); ok {
@@ -186,7 +186,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     existingAttribute, existingAttributeOk := d.GetOk("existing_attribute")
@@ -227,7 +227,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     newAttribute := d.Get("new_attribute").(string)
@@ -237,7 +237,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("new_attribute", /* ... */)
@@ -246,7 +246,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     newAttribute := d.Get("new_attribute").(string)
@@ -304,7 +304,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("existing_attribute"); ok {
@@ -315,7 +315,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("existing_attribute", /* ... */)
@@ -324,7 +324,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("existing_attribute"); ok {
@@ -365,7 +365,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("existing_attribute"); ok {
@@ -378,7 +378,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("existing_attribute"); ok {
@@ -391,7 +391,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("existing_attribute"); ok {
@@ -427,7 +427,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetCreate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("new_attribute"); ok {
@@ -438,7 +438,7 @@ func resourceExampleWidgetCreate(d *schema.ResourceData, meta interface{}) error
     return resourceExampleWidgetRead(d, meta)
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("new_attribute", /* ... */)
@@ -447,7 +447,7 @@ func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
     return nil
 }
 
-func resourceExampleWidgetUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetUpdate(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     if v, ok := d.GetOk("new_attribute"); ok {
@@ -494,7 +494,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("existing_attribute", /* ... */)
@@ -529,7 +529,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("existing_attribute", /* ... */)
@@ -560,7 +560,7 @@ func resourceExampleWidget() *schema.Resource {
     }
 }
 
-func resourceExampleWidgetRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleWidgetRead(d *schema.ResourceData, meta any) error {
     // ... other logic ...
 
     d.Set("new_attribute", /* ... */)
@@ -647,10 +647,10 @@ func resourceExampleWidget() *schema.Resource {
     return &schema.Resource{
         // ... other configuration ...
 
-        Create: func(d *schema.ResourceData, meta interface{}) error {
+        Create: func(d *schema.ResourceData, meta any) error {
             return errors.New("use example_thing resource instead")
         },
-        Read: func(d *schema.ResourceData, meta interface{}) error {
+        Read: func(d *schema.ResourceData, meta any) error {
             return errors.New("use example_thing resource instead")
         },
     }
@@ -759,10 +759,10 @@ func resourceExampleExistingWidget() *schema.Resource {
     return &schema.Resource{
         // ... other configuration ...
 
-        Create: func(d *schema.ResourceData, meta interface{}) error {
+        Create: func(d *schema.ResourceData, meta any) error {
             return errors.New("use example_new_widget resource instead")
         },
-        Read: func(d *schema.ResourceData, meta interface{}) error {
+        Read: func(d *schema.ResourceData, meta any) error {
             return errors.New("use example_new_widget resource instead")
         },
     }

--- a/website/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/website/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -49,7 +49,7 @@ func resourceExampleSimple() *schema.Resource {
     }
 }
 
-func resourceExampleSimpleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleSimpleRead(d *schema.ResourceData, meta any) error {
    client := meta.(*ProviderApi).client
    resource, _ := client.GetResource(d.Id())
    d.Set("name", resource.Name)
@@ -97,7 +97,7 @@ reconcile the diff. Because of this, it is standard practice to call `READ` at
 the end of all modifications to synchronize immediately and avoid that diff.
 
 ```go
-func resourceExampleSimpleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleSimpleRead(d *schema.ResourceData, meta any) error {
    client := meta.(*ProviderApi).client
    resource, _ := client.GetResource(d.Id())
    d.Set("name", resource.Name)
@@ -105,7 +105,7 @@ func resourceExampleSimpleRead(d *schema.ResourceData, meta interface{}) error {
    return nil
 }
 
-func resourceExampleSimpleCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleSimpleCreate(d *schema.ResourceData, meta any) error {
    client := meta.(*ProviderApi).client
    name := d.Get("name").(string)
    client.CreateResource(name)
@@ -161,7 +161,7 @@ func resourceExampleSimple() *schema.Resource {
     }
 }
 
-func resourceExampleSimpleRead(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleSimpleRead(d *schema.ResourceData, meta any) error {
    client := meta.(*ProviderApi).client
    resource, err := client.GetResource(d.Id())
    if err != nil {

--- a/website/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/website/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -225,7 +225,7 @@ each time certain other attributes are updated, you can use
 to reflect that in the plan:
 
 ```go
-    CustomizeDiff: customdiff.ComputedIf("version", func(d *schema.ResourceDiff, meta interface{}) bool {
+    CustomizeDiff: customdiff.ComputedIf("version", func(d *schema.ResourceDiff, meta any) bool {
         return d.HasChange("content") || d.HasChange("content_type")
     })
 ```

--- a/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -113,8 +113,8 @@ context-aware versions (`helper/schema.CreateContextFunc`,
 deprecated, and we recommend you upgrade to the context-aware versions to get
 their improvements, but the old versions will continue working for now.
 Upgrading involves changing your function signature from
-`func(*helper/schema.ResourceData, interface{}) error` to
-`func(context.Context, *helper/schema.ResourceData, interface{})
+`func(*helper/schema.ResourceData, any) error` to
+`func(context.Context, *helper/schema.ResourceData, any)
 diag.Diagnostics`. (We’ll talk about `diag.Diagnostics` in the next section.)
 
 Not everything could have this backwards compatibility, however; some functions
@@ -141,7 +141,7 @@ This exposes diagnostics support when creating, reading, updating, deleting,
 and validating your resources.
 
 ```go
-func Create(ctx context.Context, *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func Create(ctx context.Context, *schema.ResourceData, meta any) diag.Diagnostics {
     // do some stuff
     if err != nil {
         // this is the standard way to convert a Go error to Diagnostics

--- a/website/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/website/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -32,7 +32,7 @@ func New() (*schema.Provider, error) {
     return &schema.Provider{
         // omitting the rest of the schema definition
 
-        ConfigureContextFunc: func (ctx context.Context, rsc *schema.ResourceData) (interface{}, diag.Diagnostics) {
+        ConfigureContextFunc: func (ctx context.Context, rsc *schema.ResourceData) (any, diag.Diagnostics) {
 
             // omitting provider-specific configuration logic
 

--- a/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -39,7 +39,7 @@ func resourceExampleInstance() *schema.Resource {
             },
         },
         CustomizeDiff: customdiff.All(
-            customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+            customdiff.ValidateChange("size", func (old, new, meta any) error {
                 // If we are increasing "size" then the new value must be
                 // a multiple of the old value.
                 if new.(int) <= old.(int) {
@@ -50,7 +50,7 @@ func resourceExampleInstance() *schema.Resource {
                 }
                 return nil
             }),
-            customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+            customdiff.ForceNewIfChange("size", func (old, new, meta any) bool {
                 // "size" can only increase in-place, so we must create a new resource
                 // if it is decreased.
                 return new.(int) < old.(int)

--- a/website/docs/plugin/sdkv2/resources/import.mdx
+++ b/website/docs/plugin/sdkv2/resources/import.mdx
@@ -133,7 +133,7 @@ func resourceExampleThing() *schema.Resource {
   return &schema.Resource{
     /* ... other Resource functions ... */
     Importer: &schema.ResourceImporter{
-      State:  func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+      State:  func(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
         // d.Id() here is the last argument passed to the `terraform import RESOURCE_TYPE.RESOURCE_NAME RESOURCE_ID` command
         // Here we use a function to parse the import ID (like the example above) to simplify our logic
         attribute1, attribute2, err := resourceServiceThingExampleThingParseId(d.Id())
@@ -200,7 +200,7 @@ The Terraform import framework supports importing multiple resources from a sing
 Given our fictitious example resource, if the API supported many associations with it, we could perform an API lookup during the resource import function to find those associations and add them to the Terraform state during import.
 
 ```go
-func resourceExampleThingImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceExampleThingImportState(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
   // Perform API lookup using the import ID (d.Id()) and save those into a variable named associations
 
   results := []*schema.ResourceData{d}

--- a/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -81,7 +81,7 @@ The retry helper takes a timeout and a retry function.
 In the context of a `CREATE` function, once the backend responds with the desired state, invoke the `READ` function. If `READ` errors, return that error wrapped with `resource.NonRetryableError`. Otherwise, return `nil` (no error) from the retry function.
 
 ```go
-func resourceExampleInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleInstanceCreate(d *schema.ResourceData, meta any) error {
     name := d.Get("name").(string)
     client := meta.(*ExampleClient)
     resp, err := client.CreateInstance(name)
@@ -120,7 +120,7 @@ func resourceExampleInstanceCreate(d *schema.ResourceData, meta interface{}) err
 Use `resource.StateChangeConf` when your resource has multiple states to progress though, you require fine grained control of retry and delay timing, or you want to ensure a minimum number of occurrences of a target state is reached (this is very common when dealing with eventually consistent APIs, where a response can reply back with an old state between calls before becoming consistent).
 
 ```go
-func resourceExampleInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceExampleInstanceCreate(d *schema.ResourceData, meta any) error {
     name := d.Get("name").(string)
     client := meta.(*ExampleClient)
     resp, err := client.CreateInstance(name)
@@ -135,7 +135,7 @@ func resourceExampleInstanceCreate(d *schema.ResourceData, meta interface{}) err
         Target: []string{
             client.ExampleInstanceStateCreateComplete,
         },
-        Refresh: func() (interface{}, string, error) {
+        Refresh: func() (any, string, error) {
             resp, err := client.DescribeInstance(name)
             if err != nil {
                 0, "", err

--- a/website/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/website/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -76,7 +76,7 @@ func resourceExampleInstance() *schema.Resource {
             "name": {
                 Type:     schema.TypeString,
                 Required: true,
-                ValidateFunc: func(v interface{}, k string) (warns []string, errs []error) {
+                ValidateFunc: func(v any, k string) (warns []string, errs []error) {
                     if !strings.HasSuffix(v.(string), ".") {
                         errs = append(errs, fmt.Errorf("%q must end with a period '.'", k))
                     }
@@ -106,7 +106,7 @@ func resourceExampleInstanceResourceV0() *schema.Resource {
     }
 }
 
-func resourceExampleInstanceStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceExampleInstanceStateUpgradeV0(rawState map[string]any, meta any) (map[string]any, error) {
     rawState["name"] = rawState["name"] + "."
 
     return rawState, nil
@@ -116,15 +116,15 @@ func resourceExampleInstanceStateUpgradeV0(rawState map[string]interface{}, meta
 To unit test this migration, the following can be written:
 
 ```go
-func testResourceExampleInstanceStateDataV0() map[string]interface{} {
-    return map[string]interface{}{
+func testResourceExampleInstanceStateDataV0() map[string]any {
+    return map[string]any{
         "name": "test",
     }
 }
 
-func testResourceExampleInstanceStateDataV1() map[string]interface{} {
+func testResourceExampleInstanceStateDataV1() map[string]any {
     v0 := testResourceExampleInstanceStateDataV0()
-    return map[string]interface{}{
+    return map[string]any{
         "name": v0["name"] + ".",
     }
 }
@@ -193,7 +193,7 @@ func resourceExampleInstance() *schema.Resource {
             "name": {
                 Type:     schema.TypeString,
                 Required: true,
-                ValidateFunc: func(v interface{}, k string) (warns []string, errs []error) {
+                ValidateFunc: func(v any, k string) (warns []string, errs []error) {
                     if !strings.HasSuffix(v.(string), ".") {
                         errs = append(errs, fmt.Errorf("%q must end with a period '.'", k))
                     }
@@ -210,7 +210,7 @@ func resourceExampleInstance() *schema.Resource {
 To trigger the migration we set the `SchemaVersion` to `1`. When Terraform saves state it also sets the `SchemaVersion` at the time, that way when differences are calculated, if the saved `SchemaVersion` is less than what the Resource is currently set to, the state is run through the `MigrateState` function.
 
 ```go
-func resourceExampleInstanceMigrateState(v int, inst *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceExampleInstanceMigrateState(v int, inst *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
     switch v {
     case 0:
         log.Println("[INFO] Found Example Instance State v0; migrating to v1")
@@ -239,7 +239,7 @@ func migrateExampleInstanceStateV0toV1(inst *terraform.InstanceState) (*terrafor
 Although not required, it's a good idea to break the migration function up into version jumps. As the provider developer you will have to account for migrations that are larger than one version upgrade, using the switch/case pattern above will allow you to create codepaths for states coming from all the versions of state in the wild. Please be careful to allow all legacy versions to migrate to the latest schema. Consider the code now where the `name` attribute has moved to an attribute called `fqdn`.
 
 ```go
-func resourceExampleInstanceMigrateState(v int, inst *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceExampleInstanceMigrateState(v int, inst *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
     var err error
     switch v {
     case 0:
@@ -271,4 +271,4 @@ func migrateExampleInstanceStateV1toV2(inst *terraform.InstanceState) (*terrafor
 }
 ```
 
-The fallthrough allows a very old state to move from 0 to 1 and now to 2. Sometimes state migrations are more complicated, and requires making API calls, to allow this the configured `meta interface{}` is also passed to the `MigrateState` function.
+The fallthrough allows a very old state to move from 0 to 1 and now to 2. Sometimes state migrations are more complicated, and requires making API calls, to allow this the configured `meta any` is also passed to the `MigrateState` function.

--- a/website/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -265,7 +265,7 @@ default value of `us-west` is given.
 "region": {
   Type:     schema.TypeString,
   Required: true,
-  DefaultFunc: func() (interface{}, error) {
+  DefaultFunc: func() (any, error) {
     if v := os.Getenv("PROVIDER_REGION"); v != "" {
       return v, nil
     }
@@ -319,7 +319,7 @@ In this example, the `StateFunc` converts a string value to all lower case.
   Type:     schema.TypeString,
   ForceNew: true,
   Required: true,
-  StateFunc: func(val interface{}) string {
+  StateFunc: func(val any) string {
     return strings.ToLower(val.(string))
   },
 },
@@ -361,7 +361,7 @@ In this example, the `ValidateFunc` ensures the integer provided is a value betw
 "amount": &schema.Schema{
  Type:     schema.TypeInt,
  Required: true,
- ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+ ValidateFunc: func(val any, key string) (warns []string, errs []error) {
    v := val.(int)
    if v < 0 || v > 10 {
      errs = append(errs, fmt.Errorf("%q must be between 0 and 10 inclusive, got: %d", key, v))
@@ -399,7 +399,7 @@ In this example, the `ValidateDiagFunc` ensures the string is `abc`.
 "sample": &schema.Schema{
  Type:             schema.TypeString,
  Required:         true,
- ValidateDiagFunc: func(v interface{}, p cty.Path) diag.Diagnostics {
+ ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
 		value := v.(string)
     expected := "abc"
 		var diags diag.Diagnostics

--- a/website/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -54,7 +54,7 @@ DiffSuppressFunc SchemaDiffSuppressFunc
 //
 // If either of these is set, then the user won't be asked for input
 // for this key if the default is not nil.
-Default     interface{}
+Default     any
 DefaultFunc SchemaDefaultFunc
 
 // Description is used as the description for docs or asking for user
@@ -90,7 +90,7 @@ StateFunc SchemaStateFunc
 // *Resource. If it is *Schema, the element type is just a simple value.
 // If it is *Resource, the element type is a complex structure,
 // potentially with its own lifecycle.
-Elem interface{}
+Elem any
 
 // The following fields are only set for a TypeList or TypeSet.
 //
@@ -159,7 +159,7 @@ Deprecated string
 Removed string
 
 // ValidateFunc allows individual fields to define arbitrary validation
-// logic. It is yielded the provided config value as an interface{} that is
+// logic. It is yielded the provided config value as an any that is
 // guaranteed to be of the proper Schema type, and it can yield warnings or
 // errors based on inspection of that value.
 //

--- a/website/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -216,7 +216,7 @@ resource "example_resource" "ex" {
 
 ### TypeMap
 
-**Data structure:** [map](https://golang.org/doc/effective_go#maps): `map[string]interface{}`
+**Data structure:** [map](https://golang.org/doc/effective_go#maps): `map[string]any`
 
 **Example:** `key = value`
 
@@ -260,7 +260,7 @@ items in a map is denoted by the `%` index:
 
 ### TypeList
 
-**Data structure:** [Slice](https://golang.org/doc/effective_go#slices): `[]interface{}`
+**Data structure:** [Slice](https://golang.org/doc/effective_go#slices): `[]any`
 
 **Example:** `[]interface{"2", "3", "4"}`
 

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 }
 
 // sharedClientForRegion returns a common provider client configured for the specified region
-func sharedClientForRegion(region string) (interface{}, error) {
+func sharedClientForRegion(region string) (any, error) {
   ...
   return client, nil
 }


### PR DESCRIPTION
Closes #834

Updates the website documentation to use Go 1.18+ `any` instead of an empty interface (`interface{}`) as the latter can be confusing to those unfamiliar with Go.

Code updates within this Go module can be refactored at some other point, if necessary or desired.