### PR TITLE
Check for practioner-set timeout during ReadDataApply

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -939,6 +939,14 @@ func (r *Resource) ReadDataApply(
 		return nil, diag.FromErr(err)
 	}
 
+	rt := ResourceTimeout{}
+	if _, ok := d.Meta[TimeoutKey]; ok {
+		if err := rt.DiffDecode(d); err != nil {
+			logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
+		}
+	}
+	data.timeouts = &rt
+
 	logging.HelperSchemaTrace(ctx, "Calling downstream")
 	diags := r.read(ctx, data, meta)
 	logging.HelperSchemaTrace(ctx, "Called downstream")

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -940,9 +940,11 @@ func (r *Resource) ReadDataApply(
 	}
 
 	rt := ResourceTimeout{}
-	if _, ok := d.Meta[TimeoutKey]; ok {
-		if err := rt.DiffDecode(d); err != nil {
-			logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
+	if d != nil {
+		if _, ok := d.Meta[TimeoutKey]; ok {
+			if err := rt.DiffDecode(d); err != nil {
+				logging.HelperSchemaError(ctx, "Error decoding ResourceTimeout", map[string]interface{}{logging.KeyError: err})
+			}
 		}
 	}
 	data.timeouts = &rt


### PR DESCRIPTION
Fixes:
- https://github.com/hashicorp/terraform-plugin-sdk/issues/1038
- https://github.com/hashicorp/terraform-provider-hcp/issues/377

To test, pull this commit into your provider's go.mod. Set any datasource timeout to 1 min. Apply.
```
var readTimeout = time.Minute * 1
...
Timeouts: &schema.ResourceTimeout{
	Read: &readTimeout,
},
```