### PR TITLE
Use StateFunc when generating hashes for set elements

### DIFF
--- a/helper/schema/serialize.go
+++ b/helper/schema/serialize.go
@@ -109,9 +109,15 @@ func SerializeResourceForHash(buf *bytes.Buffer, val interface{}, resource *Reso
 			continue
 		}
 
+		innerVal := m[k]
+		if innerSchema.StateFunc != nil {
+			// Normalize the value used to calculate the hash so that
+			// Plan/Apply values match.
+			innerVal = innerSchema.StateFunc(innerVal)
+		}
+
 		buf.WriteString(k)
 		buf.WriteRune(':')
-		innerVal := m[k]
 		SerializeValueForHash(buf, innerVal, innerSchema)
 	}
 }

--- a/helper/schema/serialize_test.go
+++ b/helper/schema/serialize_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestSerializeForHash(t *testing.T) {
@@ -147,6 +148,37 @@ func TestSerializeForHash(t *testing.T) {
 				"woo",
 			}),
 			Expected: "{woo;hello;};",
+		},
+
+		// test StateFunc nested in TypeSet: GH-160
+		{
+			Schema: &Schema{
+				Type: TypeSet,
+				Elem: &Resource{
+					Schema: map[string]*Schema{
+						"duration": {
+							Type:     TypeString,
+							Required: true,
+							StateFunc: func(v any) string {
+								d, err := time.ParseDuration(v.(string))
+								if err != nil {
+									panic(err)
+								}
+								return d.String()
+							},
+						},
+					},
+				},
+			},
+			Value: NewSet(func(v interface{}) int {
+				d := v.(map[string]interface{})["duration"]
+				return len(d.(string))
+			}, []interface{}{
+				map[string]interface{}{
+					"duration": "100s",
+				},
+			}),
+			Expected: "{<duration:1m40s;>;};",
 		},
 
 		{


### PR DESCRIPTION
Fixes hashicorp/terraform-plugin-sdk#160 and verified [repro](https://github.com/prashantv/terraform-schemaset-repro) passes with the fix.

When a set type is used with a nested schema, and one of the attributes
has a `StateFunc`, the Plan/Apply generate separate hashes for
the set element, resulting in an unexpected element being added
to the set.

The Plan stage will use the original config value currently, so if we
have a StateFunc that converts "100s" to "1m40s", then we get:
```
Plan diff:
- remove set.hash(100s).duration
- adds NewExtra for this hash with 100s

Apply diff:
- remove set.hash(1m40s).duration
- sees NewExtra for set.Hash(100s) that is missing in the operations
  and adds it as a new field
```

This apply diff results in a new element being added to the set
unexpectedly.

Using the same hash for Plan/Apply avoids this mismatch, resulting in no
unexpected added diff.