### PR TITLE
helper/logging: Update test Content-Type header to match terraform.io change

### DIFF
--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -172,7 +172,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 		"@level":                    "debug",
 		"@module":                   "provider.test-subsystem",
 		"@message":                  "Received HTTP Response",
-		"Content-Type":              "text/html",
+		"Content-Type":              "text/html; charset=utf-8",
 		"tf_http_op_type":           "response",
 		"tf_http_res_status_code":   float64(200),
 		"tf_http_res_version":       "HTTP/2.0",

--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -81,7 +81,7 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 		"@level":                    "debug",
 		"@module":                   "provider",
 		"@message":                  "Received HTTP Response",
-		"Content-Type":              "text/html",
+		"Content-Type":              "text/html; charset=utf-8",
 		"tf_http_op_type":           "response",
 		"tf_http_res_status_code":   float64(200),
 		"tf_http_res_version":       "HTTP/2.0",


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/actions/runs/2970165412

Previously:

```
--- FAIL: TestNewLoggingHTTPTransport (0.27s)
    /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging_http_transport_test.go:93: Unexpected value for field "Content-Type"; expected "text/html", got "text/html; charset=utf-8"
```

Double checking the current situation with `curl`:

```console
$ curl -I -s https://www.terraform.io | grep -i content-type
content-type: text/html; charset=utf-8
```