### PR TITLE
Updating Sidebar to Match Design Spec

### DIFF
--- a/website/data/plugin-sdk-nav-data.json
+++ b/website/data/plugin-sdk-nav-data.json
@@ -36,7 +36,19 @@
       }
     ]
   },
-  {"title": "Overview", "path": "Logging"},
+{
+  "title": "Logging",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "logging"
+      },
+      {
+        "title": "HTTP Transport",
+        "path": "logging/http-transport"
+      }
+    ]
+  },
   {
     "title": "Testing",
     "routes": [

--- a/website/data/plugin-sdk-nav-data.json
+++ b/website/data/plugin-sdk-nav-data.json
@@ -36,7 +36,7 @@
       }
     ]
   },
-  {"title": "Overview", "path": "logging"},
+  {"title": "Overview", "path": "Logging"},
   {
     "title": "Testing",
     "routes": [

--- a/website/data/plugin-sdk-nav-data.json
+++ b/website/data/plugin-sdk-nav-data.json
@@ -2,10 +2,6 @@
   { "heading": "SDKv2" },
   { "title": "Overview", "path": "" },
   {
-    "title": "Tutorials: Custom Providers",
-    "href": "https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS"
-  },
-  {
     "title": "Schemas",
     "routes": [
       { "title": "Overview", "path": "schemas" },
@@ -40,27 +36,7 @@
       }
     ]
   },
-  {
-    "title": "Logging",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "logging"
-      },
-      {
-        "title": "Writing Logs",
-        "href": "/plugin/log/writing"
-      },
-      {
-        "title": "Filtering Logs",
-        "href": "/plugin/log/filtering"
-      },
-      {
-        "title": "HTTP Transport",
-        "path": "logging/http-transport"
-      }
-    ]
-  },
+  {"title": "Overview", "path": "logging"},
   {
     "title": "Testing",
     "routes": [


### PR DESCRIPTION
The DevDot process flagged two issues with the sidebar:
- The logging pages that are actually links to an entire other docs section (but this isn't necessarily obvious to users before they click them)
- The link to learn tutorials. We don't need this anymore! tutorials will be integrated into devdot.

This PR removes the learn link and limits the logging section to one pointer page and the page about HTTP transport. These pages DO exist in this documentation set but then points users to the external logging documentation set. I think this is a happy medium that will get users where they need to go, let them know logging stuff exists, but not provide unexpected links to another doc set.

## New Sidebar
<img width="210" alt="Screen Shot 2022-09-02 at 4 33 21 PM" src="https://user-images.githubusercontent.com/83350965/188231567-1e3a6a5f-509a-4ad5-b054-8a4be8a63b22.png">