### PR TITLE
feat(set): add Map method

### DIFF
--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -92,6 +92,17 @@ func (s *Set) Len() int {
 	return len(s.m)
 }
 
+// Map returns the internal map of the set that cannot be modified.
+func (s *Set) Map() map[string]interface{} {
+	m := make(map[string]interface{}, len(s.m))
+
+	for k, v := range s.m {
+		m[k] = v
+	}
+
+	return m
+}
+
 // List returns the elements of this set in slice format.
 //
 // The order of the returned elements is deterministic. Given the same


### PR DESCRIPTION
adds `Map` method to `schema.Set` that returns a cloned version of the internal map that is used in the `Set`

this is useful, for example, when you are trying to build a tree of keys when you iterate over schema's fields, and you need to retrieve all the hashed keys from the `Set`