### PR TITLE
all: Remove deprecated io/ioutil package usage

### DIFF
--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -32,7 +31,7 @@ var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
 // environment variable. Calls to tflog.* will have their output managed by the
 // tfsdklog sink.
 func LogOutput(t testing.T) (logOutput io.Writer, err error) {
-	logOutput = ioutil.Discard
+	logOutput = io.Discard
 
 	logLevel := LogLevel()
 	if logLevel == "" {
@@ -88,7 +87,7 @@ func LogOutput(t testing.T) (logOutput io.Writer, err error) {
 
 // SetOutput checks for a log destination with LogOutput, and calls
 // log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
-// ioutil.Discard. Any error from LogOutout is fatal.
+// io.Discard. Any error from LogOutout is fatal.
 func SetOutput(t testing.T) {
 	out, err := LogOutput(t)
 	if err != nil {
@@ -96,7 +95,7 @@ func SetOutput(t testing.T) {
 	}
 
 	if out == nil {
-		out = ioutil.Discard
+		out = io.Discard
 	}
 
 	log.SetOutput(out)

--- a/helper/resource/plugin.go
+++ b/helper/resource/plugin.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -191,7 +191,7 @@ func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *pl
 			Logger: hclog.New(&hclog.LoggerOptions{
 				Name:   "plugintest",
 				Level:  hclog.Trace,
-				Output: ioutil.Discard,
+				Output: io.Discard,
 			}),
 			NoLogOutputOverride: true,
 			UseTFLogSink:        t,
@@ -279,7 +279,7 @@ func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *pl
 			Logger: hclog.New(&hclog.LoggerOptions{
 				Name:   "plugintest",
 				Level:  hclog.Trace,
-				Output: ioutil.Discard,
+				Output: io.Discard,
 			}),
 			NoLogOutputOverride: true,
 			UseTFLogSink:        t,
@@ -364,7 +364,7 @@ func runProviderCommand(ctx context.Context, t testing.T, f func() error, wd *pl
 			Logger: hclog.New(&hclog.LoggerOptions{
 				Name:   "plugintest",
 				Level:  hclog.Trace,
-				Output: ioutil.Discard,
+				Output: io.Discard,
 			}),
 			NoLogOutputOverride: true,
 			UseTFLogSink:        t,

--- a/internal/plugintest/config.go
+++ b/internal/plugintest/config.go
@@ -3,7 +3,6 @@ package plugintest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -35,7 +34,7 @@ func DiscoverConfig(ctx context.Context, sourceDir string) (*Config, error) {
 	tfPath := os.Getenv(EnvTfAccTerraformPath)
 
 	tempDir := os.Getenv(EnvTfAccTempDir)
-	tfDir, err := ioutil.TempDir(tempDir, "plugintest-terraform")
+	tfDir, err := os.MkdirTemp(tempDir, "plugintest-terraform")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/internal/plugintest/helper.go
+++ b/internal/plugintest/helper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -70,7 +69,7 @@ func AutoInitHelper(ctx context.Context, sourceDir string) (*Helper, error) {
 // automatically clean those up.
 func InitHelper(ctx context.Context, config *Config) (*Helper, error) {
 	tempDir := os.Getenv(EnvTfAccTempDir)
-	baseDir, err := ioutil.TempDir(tempDir, "plugintest")
+	baseDir, err := os.MkdirTemp(tempDir, "plugintest")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory for test helper: %s", err)
 	}
@@ -105,7 +104,7 @@ func (h *Helper) Close() error {
 // program exits, the Close method on the helper itself will attempt to
 // delete it.
 func (h *Helper) NewWorkingDir(ctx context.Context, t TestControl) (*WorkingDir, error) {
-	dir, err := ioutil.TempDir(h.baseDir, "work")
+	dir, err := os.MkdirTemp(h.baseDir, "work")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugintest/working_dir.go
+++ b/internal/plugintest/working_dir.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -87,7 +87,7 @@ func (wd *WorkingDir) SetConfig(ctx context.Context, cfg string) error {
 	if err := os.Remove(rmFilename); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("unable to remove %q: %w", rmFilename, err)
 	}
-	err := ioutil.WriteFile(outFilename, bCfg, 0700)
+	err := os.WriteFile(outFilename, bCfg, 0700)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func (wd *WorkingDir) SavedPlanRawStdout(ctx context.Context) (string, error) {
 	var ret bytes.Buffer
 
 	wd.tf.SetStdout(&ret)
-	defer wd.tf.SetStdout(ioutil.Discard)
+	defer wd.tf.SetStdout(io.Discard)
 
 	logging.HelperResourceTrace(ctx, "Calling Terraform CLI show command")
 


### PR DESCRIPTION
Previously (locally for me):

```
internal/plugintest/config.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
internal/plugintest/helper.go:7:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
internal/plugintest/working_dir.go:8:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
helper/logging/logging.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
helper/resource/plugin.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
```