### PR TITLE
deps: Remove github.com/apparentlymart/go-dump and github.com/davecgh/go-spew

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.18
 
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=

--- a/helper/resource/testing_new_refresh_state.go
+++ b/helper/resource/testing_new_refresh_state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/mitchellh/go-testing-interface"
 
@@ -15,9 +14,6 @@ import (
 
 func testStepNewRefreshState(ctx context.Context, t testing.T, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories) error {
 	t.Helper()
-
-	spewConf := spew.NewDefaultConfig()
-	spewConf.SortKeys = true
 
 	var err error
 	// Explicitly ensure prior state exists before refresh.

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/hcl2shim"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -654,8 +654,8 @@ func TestSetNew(t *testing.T) {
 					t.Fatalf("bad: %s", err)
 				}
 			}
-			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
+			if diff := cmp.Diff(tc.Expected, tc.Diff); diff != "" {
+				t.Fatalf("unexpected difference: %s", diff)
 			}
 		})
 	}
@@ -681,8 +681,8 @@ func TestSetNewComputed(t *testing.T) {
 					t.Fatalf("bad: %s", err)
 				}
 			}
-			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
+			if diff := cmp.Diff(tc.Expected, tc.Diff); diff != "" {
+				t.Fatalf("unexpected difference: %s", diff)
 			}
 		})
 	}
@@ -950,8 +950,8 @@ func TestForceNew(t *testing.T) {
 					t.Fatalf("bad: %s", err)
 				}
 			}
-			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
+			if diff := cmp.Diff(tc.Expected, tc.Diff); diff != "" {
+				t.Fatalf("unexpected difference: %s", diff)
 			}
 		})
 	}
@@ -1199,8 +1199,8 @@ func TestClear(t *testing.T) {
 					t.Fatalf("bad: %s", err)
 				}
 			}
-			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
+			if diff := cmp.Diff(tc.Expected, tc.Diff); diff != "" {
+				t.Fatalf("unexpected difference: %s", diff)
 			}
 		})
 	}
@@ -1444,8 +1444,8 @@ func TestGetChangedKeysPrefix(t *testing.T) {
 
 			sort.Strings(keys)
 
-			if !reflect.DeepEqual(tc.ExpectedKeys, keys) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.ExpectedKeys), spew.Sdump(keys))
+			if diff := cmp.Diff(tc.ExpectedKeys, keys); diff != "" {
+				t.Fatalf("unexpected difference: %s", diff)
 			}
 		})
 	}

--- a/internal/configs/configschema/coerce_value_test.go
+++ b/internal/configs/configschema/coerce_value_test.go
@@ -3,7 +3,6 @@ package configschema
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/tfdiags"
@@ -566,7 +565,7 @@ func TestCoerceValue(t *testing.T) {
 			wantTy := test.Schema.ImpliedType()
 			gotTy := gotValue.Type()
 			if errs := gotTy.TestConformance(wantTy); len(errs) > 0 {
-				t.Errorf("empty value has incorrect type\ngot: %#v\nwant: %#v\nerrors: %s", gotTy, wantTy, spew.Sdump(errs))
+				t.Errorf("empty value has incorrect type\ngot: %#v\nwant: %#v\nerrors: %#v", gotTy, wantTy, errs)
 			}
 		})
 	}

--- a/internal/configs/configschema/empty_value_test.go
+++ b/internal/configs/configschema/empty_value_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-cty/cty"
 )
 
@@ -163,7 +161,7 @@ func TestBlockEmptyValue(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
 			got := test.Schema.EmptyValue()
 			if !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\nschema: %#v\ngot: %#v\nwant: %#v", test.Schema, got, test.Want)
 			}
 
 			// The empty value must always conform to the implied type of
@@ -171,7 +169,7 @@ func TestBlockEmptyValue(t *testing.T) {
 			wantTy := test.Schema.ImpliedType()
 			gotTy := got.Type()
 			if errs := gotTy.TestConformance(wantTy); len(errs) > 0 {
-				t.Errorf("empty value has incorrect type\ngot: %#v\nwant: %#v\nerrors: %s", gotTy, wantTy, spew.Sdump(errs))
+				t.Errorf("empty value has incorrect type\ngot: %#v\nwant: %#v\nerrors: %#v", gotTy, wantTy, errs)
 			}
 		})
 	}

--- a/internal/plans/objchange/normalize_obj_test.go
+++ b/internal/plans/objchange/normalize_obj_test.go
@@ -3,7 +3,6 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
 	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/configschema"
@@ -299,10 +298,7 @@ func TestNormalizeObjectFromLegacySDK(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := NormalizeObjectFromLegacySDK(test.Input, test.Schema)
 			if !got.RawEquals(test.Want) {
-				t.Errorf(
-					"wrong result\ngot:  %s\nwant: %s",
-					dump.Value(got), dump.Value(test.Want),
-				)
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
 			}
 		})
 	}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -6,8 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/configs/hcl2shim"
 )
@@ -108,8 +107,8 @@ func TestStateAddModule(t *testing.T) {
 			actual = append(actual, m.Path)
 		}
 
-		if !reflect.DeepEqual(actual, tc.Out) {
-			t.Fatalf("wrong result\ninput: %sgot:   %#v\nwant:  %#v", spew.Sdump(tc.In), actual, tc.Out)
+		if diff := cmp.Diff(tc.Out, actual); diff != "" {
+			t.Fatalf("unexpected difference: %s", diff)
 		}
 	}
 }


### PR DESCRIPTION
Removes some additional, mainly testing-related dependencies to further reduce maintenance and code migration burden of this Go module. The only external facing change is the output of ImportStateVerify and (very uncommon, not recommended) IDRefreshName differences, which feel slightly cleaner with the standard go-cmp output.

Prior:

```
--- FAIL: TestTest_TestStep_ImportStateVerify (0.83s)
    /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_new_import_state_test.go:87: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=11) "create_only": (string) (len=9) "testvalue"
        }
FAIL
FAIL	github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource	1.782s
```

Now:

```
--- FAIL: TestTest_TestStep_ImportStateVerify (0.56s)
    /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_new_import_state_test.go:87: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        - 	"create_only": "testvalue",
          }
FAIL
FAIL	github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource	1.501s
```

If we ever need better output of cty types, there is  github.com/zclconf/go-cty-debug available, which is go-cmp compatible.