### PR TITLE
.github/workflows: Fix label name in issue comment workflow

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           labels: |
             stale
-            waiting-reply
+            waiting-response


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/labels/waiting-response

The `stale` label is there should we ever want to use actions/stale (similar to other HashiCorp projects).