### PR TITLE
helper/schema: Remove timeouts during ImportResourceState

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230213-150146.yaml
+++ b/.changes/unreleased/BUG FIXES-20230213-150146.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/schema: Prevented unexpected difference for timeouts on first plan after
+  import'
+time: 2023-02-13T15:01:46.441029-05:00
+custom:
+  Issue: "1146"

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -1110,6 +1110,22 @@ func (s *GRPCProviderServer) ImportResourceState(ctx context.Context, req *tfpro
 		// Normalize the value and fill in any missing blocks.
 		newStateVal = objchange.NormalizeObjectFromLegacySDK(newStateVal, schemaBlock)
 
+		// Ensure any timeouts block is null in the imported state. There is no
+		// configuration to read from during import, so it is never valid to
+		// return a known value for the block.
+		//
+		// This is done without modifying HCL2ValueFromFlatmap or
+		// NormalizeObjectFromLegacySDK to prevent other unexpected changes.
+		//
+		// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1145
+		newStateType := newStateVal.Type()
+
+		if newStateVal != cty.NilVal && !newStateVal.IsNull() && newStateType.IsObjectType() && newStateType.HasAttribute(TimeoutsConfigKey) {
+			newStateValueMap := newStateVal.AsValueMap()
+			newStateValueMap[TimeoutsConfigKey] = cty.NullVal(newStateType.AttributeType(TimeoutsConfigKey))
+			newStateVal = cty.ObjectVal(newStateValueMap)
+		}
+
 		newStateMP, err := msgpack.Marshal(newStateVal, schemaBlock.ImpliedType())
 		if err != nil {
 			resp.Diagnostics = convert.AppendProtoDiag(ctx, resp.Diagnostics, err)


### PR DESCRIPTION
Closes #1145
Reference: https://github.com/hashicorp/terraform/pull/32463

Terraform 1.3.8 and later now correctly handles null values for single nested blocks. This means Terraform will now report differences between a null block and known block with null values. This SDK only supported single nested blocks via its timeouts functionality.

This change is a very targeted removal of any potential `timeouts` block values in a resource state from the `ImportResourceState` RPC. Since configuration is not available during that RPC, it is never valid to return any data beyond null for that block. This will prevent unexpected differences on the first plan after import, where Terraform will report the block removal for configurations which do not contain the block.

New unit test failure prior to code updates:

```
--- FAIL: TestImportResourceState_Timeouts_Removed (0.00s)
    /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/grpc_provider_test.go:1159: unexpected difference:   cty.Value(
        - 	{
        - 		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{...}}},
        - 		v:  map[string]any{"id": string("test"), "string_attribute": nil, "timeouts": nil},
        - 	},
        + 	{
        + 		ty: cty.Type{typeImpl: cty.typeObject{AttrTypes: map[string]cty.Type{...}}},
        + 		v: map[string]any{
        + 			"id":               string("test"),
        + 			"string_attribute": nil,
        + 			"timeouts":         map[string]any{"create": nil, "read": nil},
        + 		},
        + 	},
          )
```