### PR TITLE
website: Add highlight callout for migrating to terraform-plugin-testing

### DIFF
--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -7,6 +7,12 @@ description: |-
 
 # Acceptance Tests
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 In order to deliver on our promise to be safe and predictable, we need to be
 able to easily and routinely verify that Terraform Plugins produce the expected
 outcome. The most common usage of an acceptance test is in Terraform Providers,

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -7,6 +7,12 @@ description: >-
 
 # Sweepers
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 Acceptance tests in Terraform provision and verify real infrastructure using [Terraform's testing framework](/terraform/plugin/sdkv2/testing/acceptance-tests). Ideally all infrastructure created is then destroyed within the lifecycle of a test, however the reality is that there are several situations that can arise where resources created during a test are “leaked”. Leaked test resources are resources created by Terraform during a test, but Terraform either failed to destroy them as part of the test, or the test falsely reported all resources were destroyed after completing the test. Common causes are intermittent errors or failures in vendor APIs, or developer error in the resource code or test.
 
 To address the possibility of leaked resources, Terraform provides a mechanism called sweepers to cleanup leftover infrastructure. We will add a file to our folder structure that will invoke the sweeper helper.

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -7,6 +7,12 @@ description: |-
 
 # Acceptance Tests: TestCases
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 Acceptance tests are expressed in terms of **Test Cases**, each using one or
 more Terraform configurations designed to create a set of resources under test,
 and then verify the actual infrastructure created. Terraform’s `resource`

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -7,6 +7,12 @@ description: |-
 
 # Acceptance Tests: TestSteps
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 `TestStep`s represent the application of an actual Terraform configuration file
 to a given state. Each step requires a configuration as input and provides
 developers several means of validating the behavior of the specific resource

--- a/website/docs/plugin/sdkv2/testing/index.mdx
+++ b/website/docs/plugin/sdkv2/testing/index.mdx
@@ -7,6 +7,12 @@ description: |-
 
 # Testing Terraform Plugins
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 Here we cover information needed to write successful tests for Terraform
 Plugins. Tests are a vital part of the Terraform ecosystem, verifying we can
 deliver on our mission to safely and predictably create, change, and improve

--- a/website/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/website/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -7,6 +7,12 @@ description: |-
 
 # Unit Testing
 
+<Highlight>
+
+Terraform Provider testing has migrated to a new [terraform-plugin-testing](/terraform/plugin/testing) Go module. New features will only be implemented in the new module. Review the [migration documentation](/terraform/plugin/testing/migrating) to learn how to switch existing testing code.
+
+</Highlight>
+
 Testing plugin code in small, isolated units is distinct from Acceptance Tests,
 and does not require network connections. Unit tests are commonly used for
 testing helper methods that expand or flatten API responses into data structures


### PR DESCRIPTION
Reference: https://discuss.hashicorp.com/t/announcing-the-terraform-plugin-testing-module/49914

This renders as an informational callout at the top of each of the existing SDKv2 testing pages to encourage migrating to the new testing module.

![Screenshot 2023-02-14 at 4 43 06 PM](https://user-images.githubusercontent.com/189114/218869858-511eb36b-883d-4418-aff9-d778fad95adc.png)
