### PR TITLE
Prevent destroy resource

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -388,6 +388,10 @@ type TestCase struct {
 	// are tested alongside real resources
 	PreventPostDestroyRefresh bool
 
+	// PreventPostDestroy can be set to true for cases where resources
+	// are tested alongside real resources
+	PreventPostDestroy bool
+
 	// CheckDestroy is called after the resource is finally destroyed
 	// to allow the tester to test that the resource is truly gone.
 	CheckDestroy TestCheckFunc

--- a/helper/resource/testing_new.go
+++ b/helper/resource/testing_new.go
@@ -18,6 +18,10 @@ import (
 func runPostTestDestroy(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, providers *providerFactories, statePreDestroy *terraform.State) error {
 	t.Helper()
 
+	if c.PreventPostDestroy {
+		return nil
+	}
+
 	err := runProviderCommand(ctx, t, func() error {
 		return wd.Destroy(ctx)
 	}, wd, providers)


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-plugin-testing/issues/85

Added `PreventPostDestroy` flag, which can be set to `true` when we testing against real resource and want to keep it.