### PR TITLE
helper/acctest: Further document RandTLSCert characteristics

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -81,6 +81,16 @@ func RandSSHKeyPair(comment string) (string, string, error) {
 
 // RandTLSCert generates a self-signed TLS certificate with a newly created
 // private key, and returns both the cert and the private key PEM encoded.
+//
+// The private key uses RSA algorithm, 1024 bits, and has no passphrase.
+//
+// The certificate expires in 24 hours, has a random serial number, and is
+// set for Encipherment, Digital Signature, and Server Auth key usage.
+// Only the organization name of the subject is configurable.
+//
+// Testing with different or stricter security requirements should
+// use the standard library [crypto] and [golang.org/x/crypto] packages
+// directly.
 func RandTLSCert(orgName string) (string, string, error) {
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(int64(RandInt())),


### PR DESCRIPTION
Closes #621

Similar to `RandSSHKeyPair`, whose cryptographic characteristics were recently more documented, the `RandTLSCert` helper was created with limited customization capabilities. Security requirements are constantly evolving and it is untenable for this Go module to maintain all possible permutations required for cryptographic logic needed across the entire provider ecosystem without constant maintenance or inevitably needing to introduce breaking changes to the exported Go APIs. Future major versions of this code would likely remove helpers like these for that reason, but any decision in that regard would happen at a later date. For now, this documentation will encourage developers to create their own functionality using the Go language standard library `crypto` package if their needs differ from the current implementation.