### PR TITLE
[wip] Prevent useless strings creations during applyCollectionDiff

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -747,11 +747,14 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 	}
 
 	currentKey := prefix + name
+	currentKeyDot := currentKey + "."
+	currentKeyDotPct := currentKeyDot + "%"
+	currentKeyDotSharp := currentKeyDot + "#"
 
 	// check the index first for special handling
 	for k, diff := range d.Attributes {
 		// check the index value, which can be set, and 0
-		if k == currentKey+".#" || k == currentKey+".%" || k == currentKey {
+		if k == currentKeyDotSharp || k == currentKeyDotPct || k == currentKey {
 			if diff.NewRemoved {
 				return result, nil
 			}
@@ -773,7 +776,7 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 	noDiff := true
 	keys := map[string]bool{}
 	for k := range d.Attributes {
-		if !strings.HasPrefix(k, currentKey+".") {
+		if !strings.HasPrefix(k, currentKeyDot) {
 			continue
 		}
 		noDiff = false
@@ -782,7 +785,7 @@ func (d *InstanceDiff) applyCollectionDiff(path []string, attrs map[string]strin
 
 	noAttrs := true
 	for k := range attrs {
-		if !strings.HasPrefix(k, currentKey+".") {
+		if !strings.HasPrefix(k, currentKeyDot) {
 			continue
 		}
 		noAttrs = false


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/16737377/228652073-d9c036a8-cfc3-4d76-924e-c9f84825bbdc.png)

following this change my terraform plan goes from  120s to 100s.

this is more a fyi as this pr is made against v1.17.2 (as used on my provider) but the main branch seems to use the same logic.
