### PR TITLE
helper/schema: Remove Default mention from Schema type Optional field Go documentation

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -88,10 +88,6 @@ type Schema struct {
 	// Optional indicates whether the practitioner can choose to not enter
 	// a value in the configuration for this attribute. Optional cannot be used
 	// with Required.
-	//
-	// If also using Default or DefaultFunc, Computed should also be enabled,
-	// otherwise Terraform can output warning logs or "inconsistent result
-	// after apply" errors.
 	Optional bool
 
 	// Computed indicates whether the provider may return its own value for


### PR DESCRIPTION
Closes #1185

While the intention of the Go documentation matches Terraform's expectations, other parts of the SDK explicitly validate against the schema definition it was recommending. This documentation change is safer than trying to reconcile all the potential behavior changes should this particular validation be removed and a developer attempts to set `Computed`.