### PR TITLE
helper/validation: clarify IsCIDR() error message

### DIFF
--- a/helper/validation/network.go
+++ b/helper/validation/network.go
@@ -89,7 +89,7 @@ func IsCIDR(i interface{}, k string) (warnings []string, errors []error) {
 	}
 
 	if _, _, err := net.ParseCIDR(v); err != nil {
-		errors = append(errors, fmt.Errorf("expected %q to be a valid IPv4 Value, got %v: %v", k, i, err))
+		errors = append(errors, fmt.Errorf("expected %q to be a valid CIDR Value, got %v: %v", k, i, err))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
The old error was misleading for users, as IPv6 CIDR are valid