### PR TITLE
Fix read data failure for TypeList defined in TypeSet

### DIFF
--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -42,6 +42,11 @@ func (r *ConfigFieldReader) readField(
 		// the address with the real list index. i.e. set.50 might actually
 		// map to set.12 in the config, since it is in list order in the
 		// config, not indexed by set value.
+		
+		updatedAddress := make([]string, len(address))
+		copy(updatedAddress, address)
+		address = updatedAddress
+
 		for i, v := range schemaList {
 			// Sets are the only thing that cause this issue.
 			if v.Type != TypeSet {


### PR DESCRIPTION
### Scenario

If a schema has a set property which contains a list property as follows, [GetOkExists](https://github.com/hashicorp/terraform-plugin-sdk/blob/6b60c91fdd316c50bf4f4de675e29fbc85f62f0d/helper/schema/resource_diff.go#LL410C24-L410C35) may failed to read values of `prop_list`.

```
"prop_set": {
			Type:     pluginsdk.TypeSet,
			Elem: &pluginsdk.Resource{
				Schema: map[string]*pluginsdk.Schema{
					...

					"prop_list": {
						Type:     pluginsdk.TypeList,
						Elem: &pluginsdk.Schema{
							Type: pluginsdk.TypeString,
						},
					},
				},
			},
		},
```

### Reason

[This line](https://github.com/hashicorp/terraform-plugin-sdk/blob/6b60c91fdd316c50bf4f4de675e29fbc85f62f0d/helper/schema/field_reader.go#L180) of `readListField` will finally run [this code](https://github.com/hashicorp/terraform-plugin-sdk/blob/6b60c91fdd316c50bf4f4de675e29fbc85f62f0d/helper/schema/field_reader_config.go#L78) to change the `address` from  `prop_set.xxxxx.prop_list.0` to `prop_set.0.prop_list.0`. Since the `address` is changed, `readListField` cannot [read](https://github.com/hashicorp/terraform-plugin-sdk/blob/6b60c91fdd316c50bf4f4de675e29fbc85f62f0d/helper/schema/field_reader.go#L203) values in array in subsequent code.

### Solution
Add a deep copy in `func (r *ConfigFieldReader) readField` when changing the address.