### PR TITLE
helper/logging: Adjust unit test regex flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,3 +25,7 @@ linters:
     - unparam
     - unused
     - vet
+
+run:
+  # Prevent false positive timeouts in CI
+  timeout: 5m

--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -201,7 +201,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 func TestNewLoggingHTTPTransport_LogMasking(t *testing.T) {
 	ctx, loggerOutput := setupRootLogger()
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "tf_http_op_type")
-	ctx = tflog.MaskAllFieldValuesRegexes(ctx, regexp.MustCompile(`<html>.*</html>`))
+	ctx = tflog.MaskAllFieldValuesRegexes(ctx, regexp.MustCompile(`(?s)<html>.*</html>`))
 	ctx = tflog.MaskMessageStrings(ctx, "Request", "Response")
 
 	transport := logging.NewLoggingHTTPTransport(http.DefaultTransport)


### PR DESCRIPTION
Originally found in #1223 - The unit test `TestNewLoggingHTTPTransport_LogMasking` started failing in a recent dependabot PR: https://github.com/hashicorp/terraform-plugin-sdk/actions/runs/5473296958/jobs/10006381743?pr=1223

The test failing is using a `GET https://www.terraform.io` request to test the masking for the logger on the response body, using a regex `<html>.*</html>` for the mask. I believe the site must have changed recently and introduced some `\n` characters, because `.` in RE2 regex does not match `\n` characters by default: https://github.com/google/re2/blob/a57a1d6462a1613e5e2cfd6fb1ce26d36706a9af/doc/syntax.txt#L68

Adjusting the test's regex to include that flag should fix it -> `(?s)<html>.*</html>`

## Notes
- Added timeout for lint