### PR TITLE
helper/validation: `StringInSlice`: Single quote slice elements

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20230829-141309.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230829-141309.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'helper/validation: Added quoting in `StringInSlice` error diagnostic output to
+  prevent confusion with values that contain spaces'
+time: 2023-08-29T14:13:09.735543+02:00
+custom:
+  Issue: "464"

--- a/helper/validation/strings.go
+++ b/helper/validation/strings.go
@@ -146,7 +146,7 @@ func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
 			}
 		}
 
-		errors = append(errors, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		errors = append(errors, fmt.Errorf("expected %s to be one of %q, got %s", k, valid, v))
 		return warnings, errors
 	}
 }

--- a/helper/validation/strings_test.go
+++ b/helper/validation/strings_test.go
@@ -293,12 +293,12 @@ func TestValidationStringInSlice(t *testing.T) {
 		{
 			val:         "VALIDVALUE",
 			f:           StringInSlice([]string{"ValidValue", "AnotherValidValue"}, false),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[ValidValue AnotherValidValue\], got VALIDVALUE`),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \["ValidValue" "AnotherValidValue"\], got VALIDVALUE`),
 		},
 		{
 			val:         "InvalidValue",
 			f:           StringInSlice([]string{"ValidValue", "AnotherValidValue"}, false),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[ValidValue AnotherValidValue\], got InvalidValue`),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \["ValidValue" "AnotherValidValue"\], got InvalidValue`),
 		},
 		{
 			val:         1,


### PR DESCRIPTION
The validation function's error is ambiguous when dealing with slices containing spaces. For example:
```
expected role_name to be one of [Apache Spark Administrator Synapse Credential User Synapse Administrator]
```

By changing the format verb, the error becomes more user friendly:
```
expected role_name to be one of ["Apache Spark Administrator" "Synapse Credential User" "Synapse Administrator"]
```

This fixes #464