### PR TITLE
deps: Remove github.com/hashicorp/go-multierror direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.5.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
@@ -35,6 +34,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/helper/customdiff/compose.go
+++ b/helper/customdiff/compose.go
@@ -5,8 +5,7 @@ package customdiff
 
 import (
 	"context"
-
-	"github.com/hashicorp/go-multierror"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -48,14 +47,14 @@ import (
 //	}
 func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-		var err error
+		var errs []error
 		for _, f := range funcs {
 			thisErr := f(ctx, d, meta)
 			if thisErr != nil {
-				err = multierror.Append(err, thisErr)
+				errs = append(errs, thisErr)
 			}
 		}
-		return err
+		return errors.Join(errs...)
 	}
 }
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/go-testing-interface"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -836,15 +835,15 @@ func ComposeTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 // TestCheckFuncs and aggregates failures.
 func ComposeAggregateTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
-		var result *multierror.Error
+		var result []error
 
 		for i, f := range fs {
 			if err := f(s); err != nil {
-				result = multierror.Append(result, fmt.Errorf("Check %d/%d error: %s", i+1, len(fs), err))
+				result = append(result, fmt.Errorf("Check %d/%d error: %w", i+1, len(fs), err))
 			}
 		}
 
-		return result.ErrorOrNil()
+		return errors.Join(result...)
 	}
 }
 

--- a/internal/diagutils/diagutils.go
+++ b/internal/diagutils/diagutils.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -28,7 +27,7 @@ func (diags ErrorDiags) Errors() []error {
 }
 
 func (diags ErrorDiags) Error() string {
-	return multierror.ListFormatFunc(diags.Errors())
+	return errors.Join(diags.Errors()...).Error()
 }
 
 type WarningDiags diag.Diagnostics

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/copystructure"
 
@@ -287,7 +287,7 @@ func (s *State) Validate() error {
 	s.Lock()
 	defer s.Unlock()
 
-	var result error
+	var result []error
 
 	// !!!! FOR DEVELOPERS !!!!
 	//
@@ -309,7 +309,7 @@ func (s *State) Validate() error {
 
 			key := strings.Join(ms.Path, ".")
 			if _, ok := found[key]; ok {
-				result = multierror.Append(result, fmt.Errorf(
+				result = append(result, fmt.Errorf(
 					strings.TrimSpace(stateValidateErrMultiModule), key))
 				continue
 			}
@@ -318,7 +318,7 @@ func (s *State) Validate() error {
 		}
 	}
 
-	return result
+	return errors.Join(result...)
 }
 
 // Remove removes the item in the state at the given address, returning


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/99

Similar to terraform-plugin-testing, now that this Go module is Go 1.20+, we can use native `errors.Join()` functionality for joining multiple errors.

To fully remove the dependency, will need to update some other dependencies as well, e.g.

```
# github.com/hashicorp/go-multierror
github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugintest
github.com/hashicorp/hc-install
github.com/hashicorp/go-multierror
```