### PR TITLE
meta: Fix version number, deprecate exported variables and function

### DIFF
--- a/.changes/unreleased/BUG FIXES-20231011-094550.yaml
+++ b/.changes/unreleased/BUG FIXES-20231011-094550.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'meta: Fixed version in `SDKVersion` variable and `SDKVersionString()` function'
+time: 2023-10-11T09:45:50.333603-04:00
+custom:
+  Issue: "1257"

--- a/.changes/unreleased/NOTES-20231011-094644.yaml
+++ b/.changes/unreleased/NOTES-20231011-094644.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'meta: The `SDKVersion` variable, `SDKPrerelease` variable, and `SDKVersionString()`
+  function have been deprecated. Use the Go standard library `runtime/debug' package
+  build information instead.
+time: 2023-10-11T09:46:44.606126-04:00
+custom:
+  Issue: "1257"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "version=$(echo "${{ inputs.versionNumber }}" | cut -c 2-)" >> "$GITHUB_OUTPUT"
 
   changelog:
-    needs: changelog-version
+    needs: [ changelog-version, meta-version ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,6 +51,27 @@ jobs:
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           git add .
           git commit -a -m "Update changelog"
+          git push "https://${{ env.CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+  meta-version:
+    needs: changelog-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          fetch-depth: 0
+          # Avoid persisting GITHUB_TOKEN credentials as they take priority over our service account PAT for `git push` operations
+          # More details: https://github.com/actions/checkout/blob/b4626ce19ce1106186ddf9bb20e706842f11a7c3/adrs/0153-checkout-v2.md#persist-credentials
+          persist-credentials: false
+      - name: Update meta package SDKVersion
+        run: sed -i "s/var SDKVersion =.*/var SDKVersion = \"${{ needs.changelog-version.outputs.version }}\"/" meta/meta.go
+      - name: Git push meta
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          git add meta/meta.go
+          git commit -m "Update meta package SDKVersion"
           git push "https://${{ env.CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
 
   release-tag:

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -14,11 +14,17 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var SDKVersion = "2.10.1"
+//
+// Deprecated: Use Go standard library [runtime/debug] package build information
+// instead.
+var SDKVersion = "2.30.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
+//
+// Deprecated: Use Go standard library [runtime/debug] package build information
+// instead.
 var SDKPrerelease = ""
 
 // SemVer is an instance of version.Version. This has the secondary
@@ -31,6 +37,9 @@ func init() {
 }
 
 // VersionString returns the complete version string, including prerelease
+//
+// Deprecated: Use Go standard library [runtime/debug] package build information
+// instead.
 func SDKVersionString() string {
 	if SDKPrerelease != "" {
 		return fmt.Sprintf("%s-%s", SDKVersion, SDKPrerelease)


### PR DESCRIPTION
Closes #1257

The release process is also updated to automatically overwrite the version variable as it did in the previous release process. While this should ensure this version information is correct going forward, consumers should instead prefer the Go standard library `runtime/debug` package build information, which is guaranteed to always be correct.