### PR TITLE
helper/schema: Ensure (ResourceData).GetRawConfig() is populated in provider Configure functions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20231102-063650.yaml
+++ b/.changes/unreleased/BUG FIXES-20231102-063650.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'helper/schema: Ensured `(ResourceData).GetRawConfig()` data is populated for
+  `Provider.ConfigureFunc` and `Provider.ConfigureContextFunc`'
+time: 2023-11-02T06:36:50.137259-04:00
+custom:
+  Issue: "1270"

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -582,6 +582,18 @@ func (s *GRPCProviderServer) ConfigureProvider(ctx context.Context, req *tfproto
 	}
 
 	config := terraform.NewResourceConfigShimmed(configVal, schemaBlock)
+
+	// CtyValue is the raw protocol configuration data from newer APIs.
+	//
+	// This field was only added as a targeted fix for passing raw protocol data
+	// through the existing (helper/schema.Provider).Configure() exported method
+	// and is only populated in that situation. The data could theoretically be
+	// set in the NewResourceConfigShimmed() function, however the consequences
+	// of doing this were not investigated at the time the fix was introduced.
+	//
+	// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1270
+	config.CtyValue = configVal
+
 	// TODO: remove global stop context hack
 	// This attaches a global stop synchro'd context onto the provider.Configure
 	// request scoped context. This provides a substitute for the removed provider.StopContext()

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -279,6 +279,19 @@ func (p *Provider) Configure(ctx context.Context, c *terraform.ResourceConfig) d
 		return diag.FromErr(err)
 	}
 
+	// Set the RawConfig directly on this diff so (ResourceData).GetRawConfig()
+	// is populated in provider defined Configure functions.
+	//
+	// This could theoretically be added in (schemaMap).Diff() itself, such as
+	// checking (s == nil && c != nil) early, however this is introduced as a
+	// targeted change for now to prevent unintended consequences without
+	// lengthy investigation into that potential solution.
+	//
+	// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1270
+	if c != nil && diff != nil {
+		diff.RawConfig = c.CtyValue
+	}
+
 	data, err := sm.Data(nil, diff)
 	if err != nil {
 		return diag.FromErr(err)

--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -40,6 +40,21 @@ type ResourceConfig struct {
 	ComputedKeys []string
 	Raw          map[string]interface{}
 	Config       map[string]interface{}
+
+	// CtyValue is the raw protocol configuration data from newer APIs.
+	//
+	// This field was only added as a targeted fix for passing raw protocol data
+	// through the existing (helper/schema.Provider).Configure() exported method
+	// and is only populated in that situation. The data could theoretically be
+	// set in the NewResourceConfigShimmed() function, however the consequences
+	// of doing this were not investigated at the time the fix was introduced.
+	//
+	// This field is ignored in the Equal() method to prevent a breaking
+	// behavior change since the entirety of the terraform package and this type
+	// are unintentionally exported in v2.
+	//
+	// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1270
+	CtyValue cty.Value
 }
 
 // NewResourceConfigRaw constructs a ResourceConfig whose content is exactly
@@ -169,6 +184,10 @@ func (c *ResourceConfig) DeepCopy() *ResourceConfig {
 }
 
 // Equal checks the equality of two resource configs.
+//
+// This method intentionally ignores the CtyValue field as a major version
+// compatibility concern, as this exported field was later added to the type.
+// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1270
 func (c *ResourceConfig) Equal(c2 *ResourceConfig) bool {
 	// If either are nil, then they're only equal if they're both nil
 	if c == nil || c2 == nil {

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -265,6 +265,38 @@ func TestResourceConfigEqual_computedKeyOrder(t *testing.T) {
 	}
 }
 
+func TestResourceConfigEqual_CtyValue(t *testing.T) {
+	t.Parallel()
+
+	value := cty.ObjectVal(map[string]cty.Value{
+		"test": cty.UnknownVal(cty.String),
+	})
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"test": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	}
+
+	rc := NewResourceConfigShimmed(value, schema)
+	rc2 := NewResourceConfigShimmed(value, schema)
+
+	// Regardless of whether NewResourceConfigShimmed() was updated to set the
+	// CtyValue field, ensure that they differ manually as a major version
+	// compatibility check.
+	rc.CtyValue = value
+	rc2.CtyValue = cty.Value{}
+
+	// At least in v2, these should intentionally be equal even though the
+	// CtyValue fields differ.
+	// Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/1270
+	if !rc.Equal(rc2) {
+		t.Fatal("should be equal")
+	}
+}
+
 func TestUnknownCheckWalker(t *testing.T) {
 	cases := []struct {
 		Name   string


### PR DESCRIPTION
Closes #1270

This change is intended to be as targeted as possible to prevent other unintended changes. In other RPCs, the protocol configuration data is able to be set upfront via `terraform.InstanceState`, however for provider configuration it is still using the legacy `terraform.ResourceConfig` value which previously did not have the same data field. This adds the data field while trying to be pragmatic about potentially breaking compatibility with the unfortunately exported APIs in this SDK.

New test failures prior to updating logic:

```
--- FAIL: TestProviderConfigure (0.00s)
    --- FAIL: TestProviderConfigure/ConfigureContextFunc-GetRawConfig (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/provider_test.go:338: Unexpected diagnostics (-wanted +got):   diag.Diagnostics(
            - 	nil,
            + 	{{Summary: "unexpected GetRawConfig difference: expected: {{{{} map[test:{{{"...}},
              )
    --- FAIL: TestProviderConfigure/ConfigureFunc-GetRawConfig (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/provider_test.go:338: Unexpected diagnostics (-wanted +got):   diag.Diagnostics(
            - 	nil,
            + 	{{Summary: "unexpected GetRawConfig difference: expected: {{{{} map[test:{{{"...}},
              )

--- FAIL: TestGRPCProviderServerConfigureProvider (0.00s)
    --- FAIL: TestGRPCProviderServerConfigureProvider/ConfigureContextFunc-GetRawConfig (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/grpc_provider_test.go:343: unexpected difference:   &tfprotov5.ConfigureProviderResponse{
            - 	Diagnostics: []*tfprotov5.Diagnostic{
            - 		&{
            - 			Severity: s"ERROR",
            - 			Summary:  "unexpected difference: expected: {{{{} map[test:{{{} %!s(cty.pri"...,
            - 		},
            - 	},
            + 	Diagnostics: nil,
              }
    --- FAIL: TestGRPCProviderServerConfigureProvider/ConfigureFunc-GetRawConfig (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-sdk/helper/schema/grpc_provider_test.go:343: unexpected difference:   &tfprotov5.ConfigureProviderResponse{
            - 	Diagnostics: []*tfprotov5.Diagnostic{
            - 		&{
            - 			Severity: s"ERROR",
            - 			Summary:  "unexpected difference: expected: {{{{} map[test:{{{} %!s(cty.pri"...,
            - 		},
            - 	},
            + 	Diagnostics: nil,
              }
```