### PR TITLE
changelog: Fix entry quoting issues

### DIFF
--- a/.changes/unreleased/NOTES-20231011-094644.yaml
+++ b/.changes/unreleased/NOTES-20231011-094644.yaml
@@ -1,7 +1,7 @@
 kind: NOTES
 body: 'meta: The `SDKVersion` variable, `SDKPrerelease` variable, and `SDKVersionString()`
-  function have been deprecated. Use the Go standard library `runtime/debug' package
-  build information instead.
+  function have been deprecated. Use the Go standard library `runtime/debug` package
+  build information instead.'
 time: 2023-10-11T09:46:44.606126-04:00
 custom:
   Issue: "1257"


### PR DESCRIPTION
Previously:

```
Error: unmarshaling change file '.changes/unreleased/NOTES-20231011-094644.yaml': yaml: line 2: did not find expected key
```

Created separate internal issue to catch this during PRs.
