### PR TITLE
.github: Ensure new meta-version release job uses latest branch reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+          # Default input is the SHA that initially triggered the workflow. As we created a new commit in the previous job,
+          # to ensure we get the latest commit we use the ref for checkout: 'refs/heads/<branch_name>'
+          ref: ${{ github.ref }}
           # Avoid persisting GITHUB_TOKEN credentials as they take priority over our service account PAT for `git push` operations
           # More details: https://github.com/actions/checkout/blob/b4626ce19ce1106186ddf9bb20e706842f11a7c3/adrs/0153-checkout-v2.md#persist-credentials
           persist-credentials: false

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -17,7 +17,7 @@ import (
 //
 // Deprecated: Use Go standard library [runtime/debug] package build information
 // instead.
-var SDKVersion = "2.30.0"
+var SDKVersion = "2.29.0"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
The new meta-version job in the release process was not using the latest branch reference for checkout (similar to release-tag). This fixes the release workflow and resets the meta version to re-run release.

Previously:

```
To https://github.com/hashicorp/terraform-plugin-sdk.git
 ! [rejected]          main -> main (non-fast-forward)
error: failed to push some refs to 'https://github.com/hashicorp/terraform-plugin-sdk.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
```