### PR TITLE
all: Initial MoveResourceState implementation

### DIFF
--- a/.changes/unreleased/NOTES-20240129-084840.yaml
+++ b/.changes/unreleased/NOTES-20240129-084840.yaml
@@ -5,4 +5,4 @@ body: 'helper/schema: While this Go module will not receive support for moving
   terraform-plugin-framework or terraform-plugin-mux in the future.'
 time: 2024-01-29T08:48:40.990566-05:00
 custom:
-  Issue: "9999"
+  Issue: "1307"

--- a/.changes/unreleased/NOTES-20240129-084840.yaml
+++ b/.changes/unreleased/NOTES-20240129-084840.yaml
@@ -1,0 +1,8 @@
+kind: NOTES
+body: 'helper/schema: While this Go module will not receive support for moving
+  resource state across resource types, the provider server is updated to handle
+  the new operation, which will be required to prevent errors when updating
+  terraform-plugin-framework or terraform-plugin-mux in the future.'
+time: 2024-01-29T08:48:40.990566-05:00
+custom:
+  Issue: "9999"


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-go/pull/351
Reference: https://developer.hashicorp.com/terraform/plugin/framework/migrating

The next versions of the plugin protocol (5.5/6.5) include support for moving resource state across resource types. The terraform-plugin-sdk Go module will not be receiving this feature, however this Go module must be updated to handle the new RPC with errors.

Provider developers can implement move resource state in their terraform-plugin-sdk based providers by following the framework migration documentation to introduce terraform-plugin-mux and migrating the resource type to terraform-plugin-framework.