### PR TITLE
feat(terraform): add ability to suppress github etag while being noisy when no actual state has been changed

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -980,7 +980,8 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 				return fmt.Errorf("%s: DefaultFunc is for configurable attributes,"+
 					"there's nothing to configure on computed-only field", k)
 			}
-			if v.DiffSuppressFunc != nil {
+			// Allow this behavior for etag, which is a special case (being too noisy)
+			if v.DiffSuppressFunc != nil && k != "etag" {
 				return fmt.Errorf("%s: DiffSuppressFunc is for suppressing differences"+
 					" between config and state representation. "+
 					"There is no config for computed-only field, nothing to compare.", k)

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4797,6 +4797,28 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			true,
 		},
 
+		"Etag with DiffSuppressFunc": {
+			map[string]*Schema{
+				"etag": {
+					Type:             TypeString,
+					Computed:         true,
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool { return true },
+				},
+			},
+			false,
+		},
+
+		"Non Etag with DiffSuppressFunc": {
+			map[string]*Schema{
+				"non_etag": {
+					Type:             TypeString,
+					Computed:         true,
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *ResourceData) bool { return true },
+				},
+			},
+			true,
+		},
+
 		"DiffSuppressOnRefresh without DiffSuppressFunc": {
 			map[string]*Schema{
 				"string": {
@@ -5064,7 +5086,6 @@ func TestSchemaMap_InternalValidate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestSchemaMap_DiffSuppress(t *testing.T) {


### PR DESCRIPTION
Issues and PRs reference:
- https://github.com/integrations/terraform-provider-github/issues/796
- https://github.com/integrations/terraform-provider-github/issues/910
- https://github.com/hashicorp/terraform/issues/28803
- https://github.com/integrations/terraform-provider-github/pull/911
- https://github.com/integrations/terraform-provider-github/pull/909
- https://github.com/integrations/terraform-provider-github/pull/2296

The ETags are shown in diff on almost every plan, even after apply just before the next plan. After this change, ETag diff disappears. I've also added tests.