### PR TITLE
fix: when parsing map length entries look for the key exactly equalling %

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240827-174424.yaml
+++ b/.changes/unreleased/BUG FIXES-20240827-174424.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/schema: Fixed an issue where all map keys starting with % where ignored, even if they didn''t correspond to the map length'
+time: 2024-08-27T17:44:24.436061-06:00
+custom:
+    Issue: "1369"

--- a/helper/schema/field_reader_diff.go
+++ b/helper/schema/field_reader_diff.go
@@ -112,7 +112,9 @@ func (r *DiffFieldReader) readMap(
 		if !strings.HasPrefix(k, prefix) {
 			continue
 		}
-		if strings.HasPrefix(k, prefix+"%") {
+
+		key := k[len(prefix):]
+		if key == "%" {
 			// Ignore the count field
 			continue
 		}

--- a/helper/schema/field_reader_diff_test.go
+++ b/helper/schema/field_reader_diff_test.go
@@ -131,6 +131,10 @@ func TestDiffFieldReader_MapHandling(t *testing.T) {
 					Old: "",
 					New: "qux",
 				},
+				"tags.%baz": {
+					Old: "",
+					New: "%qux",
+				},
 			},
 		},
 		Source: &MapFieldReader{
@@ -148,8 +152,9 @@ func TestDiffFieldReader_MapHandling(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"foo": "bar",
-		"baz": "qux",
+		"foo":  "bar",
+		"baz":  "qux",
+		"%baz": "%qux",
 	}
 
 	if !reflect.DeepEqual(expected, result.Value) {


### PR DESCRIPTION
fix: when parsing map length entries look for the key exactly equalling `%` rather than being prefixed with it, to allow for map keys names to start with %.

When working with a custom provider I ran into an issue where map entries starting with `%` were being dropped, and not being passed to the provider implementation. I noticed that there were different approaches to checking for the map length, e.g. in internalconfigs/hcl2shim/flatmap.go:

https://github.com/hashicorp/terraform-plugin-sdk/blob/651ff3354401b964d3d3a9cd3d396afad121128c/internal/configs/hcl2shim/flatmap.go#L284



