### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240906-171344.yaml
+++ b/.changes/unreleased/NOTES-20240906-171344.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'all: This Go module has been updated to Go 1.22 per the [Go support policy](https://go.dev/doc/devel/release#policy).
+  It is recommended to review the [Go 1.22 release notes](https://go.dev/doc/go1.22)
+  before upgrading. Any consumers building on earlier Go versions may experience errors.'
+time: 2024-09-06T17:13:44.643765-04:00
+custom:
+  Issue: "1373"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22', '1.21' ]
+        go-version: [ '1.23', '1.22' ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When running provider tests, Terraform 0.12.26 or later is needed for version 2.
 
 This project follows the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by the project.
 
-Currently, that means Go **1.21** or later must be used when including this project as a dependency.
+Currently, that means Go **1.22** or later must be used when including this project as a dependency.
 
 ## Getting Started
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/hashicorp/terraform-plugin-sdk/v2
 
-go 1.21
+go 1.22.0
 
-toolchain go1.21.6
+toolchain go1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require github.com/hashicorp/copywrite v0.19.0
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.0 to allow for all patch versions in 1.22. Toolchain is using the latest 1.22.7