### PR TITLE
Fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ We welcome issues of all kinds including feature requests, bug reports or docume
 
 ### Bug Reports
 
- - [ ] **Test against latest release**: Make sure you test against the latest avaiable version of both Terraform and SDK.
+ - [ ] **Test against latest release**: Make sure you test against the latest available version of both Terraform and SDK.
 It is possible we already fixed the bug you're experiencing.
 
  - [ ] **Search for duplicates**: It's helpful to keep bug reports consolidated to one thread, so do a quick search on existing bug reports to check if anybody else has reported the same thing. You can scope searches by the label `bug` to help narrow things down.
@@ -116,7 +116,7 @@ In the case of `terraform-plugin-sdk`, the repo's close relationship to the `ter
 
 #### Exceptions
 
-We belive that one should "leave the campsite cleaner than you found it", so you are welcome to clean up cosmetic issues in the neighbourhood when submitting a patch that makes functional changes or fixes.
+We believe that one should "leave the campsite cleaner than you found it", so you are welcome to clean up cosmetic issues in the neighbourhood when submitting a patch that makes functional changes or fixes.
 
 ### Dependency Updates
 
@@ -140,7 +140,7 @@ changie new
 ```
 and choose a `kind` of change corresponding to the Terraform Plugin [changelog categories](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#categorization)
 
-Fill out the body field following the entry format. Changie will then prompt for a Github issue or pull request number.
+Fill out the body field following the entry format. Changie will then prompt for a GitHub issue or pull request number.
 
 Repeat this process for any additional changes. The `.yaml` files created in the `.changes/unreleased` folder
 should be pushed the repository along with any code changes.
@@ -181,7 +181,7 @@ tfsdk: Prevented potential panic in `Example()` function
 
 ###### Enhancements
 
-A new enhancement entry should use the `ENHANCEMENTS` kind and have a prefix indicating the sub-package it corresponds to, a colon, then followed by a brief summary. Use a `all` prefix for enchancements that apply to all sub-packages.
+A new enhancement entry should use the `ENHANCEMENTS` kind and have a prefix indicating the sub-package it corresponds to, a colon, then followed by a brief summary. Use a `all` prefix for enhancements that apply to all sub-packages.
 
 ``````markdown
 attr: Added `Great` interface for doing great things
@@ -262,7 +262,7 @@ To test the `ci-go/terraform-provider-corner` job, a valid GitHub Personal Acces
 
 ### Go Unit Tests
 
-Go code unit testing is perfomed via Go's built-in testing functionality.
+Go code unit testing is performed via Go's built-in testing functionality.
 
 To run the Go unit testing locally:
 
@@ -343,7 +343,7 @@ Before running a release:
 
 - **`meta/meta.go`**: The versions must be appropriately updated.
 
-To cut a release, go to the repository in Github and click on the `Actions` tab.
+To cut a release, go to the repository in GitHub and click on the `Actions` tab.
 
 Select the `Release` workflow on the left-hand menu.
 

--- a/helper/logging/logging.go
+++ b/helper/logging/logging.go
@@ -90,7 +90,7 @@ func LogOutput(t testing.T) (logOutput io.Writer, err error) {
 
 // SetOutput checks for a log destination with LogOutput, and calls
 // log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
-// io.Discard. Any error from LogOutout is fatal.
+// io.Discard. Any error from LogOutput is fatal.
 func SetOutput(t testing.T) {
 	out, err := LogOutput(t)
 	if err != nil {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -28,7 +28,7 @@ import (
 )
 
 // flagSweep is a flag available when running tests on the command line. It
-// contains a comma seperated list of regions to for the sweeper functions to
+// contains a comma separated list of regions to for the sweeper functions to
 // run in.  This flag bypasses the normal Test path and instead runs functions designed to
 // clean up any leaked resources a testing environment could have created. It is
 // a best effort attempt, and relies on Provider authors to implement "Sweeper"
@@ -49,7 +49,7 @@ import (
 
 var flagSweep = flag.String("sweep", "", "List of Regions to run available Sweepers")
 var flagSweepAllowFailures = flag.Bool("sweep-allow-failures", false, "Enable to allow Sweeper Tests to continue after failures")
-var flagSweepRun = flag.String("sweep-run", "", "Comma seperated list of Sweeper Tests to run")
+var flagSweepRun = flag.String("sweep-run", "", "Comma separated list of Sweeper Tests to run")
 var sweeperFuncs map[string]*Sweeper
 
 // SweeperFunc is a signature for a function that acts as a sweeper. It
@@ -103,7 +103,7 @@ func AddTestSweepers(name string, s *Sweeper) {
 // Sweeper flags added to the "go test" command:
 //
 //	-sweep: Comma-separated list of locations/regions to run available sweepers.
-//	-sweep-allow-failues: Enable to allow other sweepers to run after failures.
+//	-sweep-allow-failures: Enable to allow other sweepers to run after failures.
 //	-sweep-run: Comma-separated list of resource type sweepers to run. Defaults
 //	        to all sweepers.
 //
@@ -183,7 +183,7 @@ func runSweepers(regions []string, sweepers map[string]*Sweeper, allowFailures b
 	return sweeperRunList, nil
 }
 
-// filterSweepers takes a comma seperated string listing the names of sweepers
+// filterSweepers takes a comma separated string listing the names of sweepers
 // to be ran, and returns a filtered set from the list of all of sweepers to
 // run based on the names given.
 func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {
@@ -230,7 +230,7 @@ func filterSweeperWithDependencies(name string, source map[string]*Sweeper) map[
 	return result
 }
 
-// runSweeperWithRegion recieves a sweeper and a region, and recursively calls
+// runSweeperWithRegion receives a sweeper and a region, and recursively calls
 // itself with that region for every dependency found for that sweeper. If there
 // are no dependencies, invoke the contained sweeper fun with the region, and
 // add the success/fail status to the sweeperRunList.
@@ -812,7 +812,7 @@ func testResource(c TestStep, state *terraform.State) (*terraform.ResourceState,
 // into smaller pieces more easily.
 //
 // ComposeTestCheckFunc returns immediately on the first TestCheckFunc error.
-// To aggregrate all errors, use ComposeAggregateTestCheckFunc instead.
+// To aggregate all errors, use ComposeAggregateTestCheckFunc instead.
 func ComposeTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {
 		for i, f := range fs {
@@ -831,7 +831,7 @@ func ComposeTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 // As a user testing their provider, this lets you decompose your checks
 // into smaller pieces more easily.
 //
-// Unlike ComposeTestCheckFunc, ComposeAggergateTestCheckFunc runs _all_ of the
+// Unlike ComposeTestCheckFunc, ComposeAggregateTestCheckFunc runs _all_ of the
 // TestCheckFuncs and aggregates failures.
 func ComposeAggregateTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/helper/resource/testing_sets.go
+++ b/helper/resource/testing_sets.go
@@ -20,7 +20,7 @@ const (
 // TestCheckTypeSetElemNestedAttrs ensures a subset map of values is stored in
 // state for the given name and key combination of attributes nested under a
 // list or set block. Use this TestCheckFunc in preference over non-set
-// variants to simplify testing code and ensure compatibility with indicies,
+// variants to simplify testing code and ensure compatibility with indices,
 // which can easily change with schema changes. State value checking is only
 // recommended for testing Computed attributes and attribute defaults.
 //
@@ -92,7 +92,7 @@ func TestCheckTypeSetElemNestedAttrs(name, attr string, values map[string]string
 // regular expressions, is stored in state for the given name and key
 // combination of attributes nested under a list or set block. Use this
 // TestCheckFunc in preference over non-set variants to simplify testing code
-// and ensure compatibility with indicies, which can easily change with schema
+// and ensure compatibility with indices, which can easily change with schema
 // changes. State value checking is only recommended for testing Computed
 // attributes and attribute defaults.
 //
@@ -171,7 +171,7 @@ func TestMatchTypeSetElemNestedAttrs(name, attr string, values map[string]*regex
 // TestCheckTypeSetElemAttr ensures a specific value is stored in state for the
 // given name and key combination under a list or set. Use this TestCheckFunc
 // in preference over non-set variants to simplify testing code and ensure
-// compatibility with indicies, which can easily change with schema changes.
+// compatibility with indices, which can easily change with schema changes.
 // State value checking is only recommended for testing Computed attributes and
 // attribute defaults.
 //

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -337,7 +337,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter: "none",
 		},
 		{
-			Name: "with nested depenencies and top level filter",
+			Name: "with nested dependencies and top level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",
@@ -362,7 +362,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "matching_level1",
 		},
 		{
-			Name: "with nested depenencies and middle level filter",
+			Name: "with nested dependencies and middle level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",
@@ -387,7 +387,7 @@ func TestFilterSweepers(t *testing.T) {
 			Filter:           "matching_level2",
 		},
 		{
-			Name: "with nested depenencies and bottom level filter",
+			Name: "with nested dependencies and bottom level filter",
 			Sweepers: map[string]*Sweeper{
 				"not_matching": {
 					Name: "not_matching",
@@ -809,7 +809,7 @@ func TestRunSweepers(t *testing.T) {
 			ExpectError:     true,
 		},
 		{
-			Name: "failing top and dep allow failues",
+			Name: "failing top and dep allow failures",
 			Sweepers: map[string]*Sweeper{
 				"aws_top": {
 					Name:         "aws_top",

--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -123,7 +123,7 @@ func (m schemaMap) CoreConfigSchema() *configschema.Block {
 // whose elem is a whole resource.
 func (s *Schema) coreConfigSchemaAttribute() *configschema.Attribute {
 	// The Schema.DefaultFunc capability adds some extra weirdness here since
-	// it can be combined with "Required: true" to create a sitution where
+	// it can be combined with "Required: true" to create a situation where
 	// required-ness is conditional. Terraform Core doesn't share this concept,
 	// so we must sniff for this possibility here and conditionally turn
 	// off the "Required" flag if it looks like the DefaultFunc is going

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -269,7 +269,7 @@ func (r *ConfigFieldReader) readSet(
 		return FieldReadResult{Value: set}, nil
 	}
 
-	// If the list is computed, the set is necessarilly computed
+	// If the list is computed, the set is necessarily computed
 	if raw.Computed {
 		return FieldReadResult{
 			Value:    set,

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -501,7 +501,7 @@ func (s *GRPCProviderServer) upgradeJSONState(ctx context.Context, version int, 
 // Remove any attributes no longer present in the schema, so that the json can
 // be correctly decoded.
 func (s *GRPCProviderServer) removeAttributes(ctx context.Context, v interface{}, ty cty.Type) {
-	// we're only concerned with finding maps that corespond to object
+	// we're only concerned with finding maps that correspond to object
 	// attributes
 	switch v := v.(type) {
 	case []interface{}:
@@ -1593,7 +1593,7 @@ func stripSchema(s *Schema) *Schema {
 }
 
 // Zero values and empty containers may be interchanged by the apply process.
-// When there is a discrepency between src and dst value being null or empty,
+// When there is a discrepancy between src and dst value being null or empty,
 // prefer the src value. This takes a little more liberty with set types, since
 // we can't correlate modified set values. In the case of sets, if the src set
 // was wholly known we assume the value was correctly applied and copy that

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -189,7 +189,7 @@ type Resource struct {
 	// This implementation is optional. If omitted, all Schema must enable
 	// the ForceNew field and any practitioner changes that would have
 	// caused and update will instead destroy and recreate the infrastructure
-	// compontent.
+	// component.
 	//
 	// The *ResourceData parameter contains the plan and state data for this
 	// managed resource instance. The available data in the Get* methods is the
@@ -321,7 +321,7 @@ type Resource struct {
 	// This implementation is optional. If omitted, all Schema must enable
 	// the ForceNew field and any practitioner changes that would have
 	// caused and update will instead destroy and recreate the infrastructure
-	// compontent.
+	// component.
 	//
 	// The Context parameter stores SDK information, such as loggers and
 	// timeout deadlines. It also is wired to receive any cancellation from
@@ -460,7 +460,7 @@ type Resource struct {
 	// This implementation is optional. If omitted, all Schema must enable
 	// the ForceNew field and any practitioner changes that would have
 	// caused and update will instead destroy and recreate the infrastructure
-	// compontent.
+	// component.
 	//
 	// The Context parameter stores SDK information, such as loggers. It also
 	// is wired to receive any cancellation from Terraform such as a system or
@@ -664,7 +664,7 @@ type ResourceBehavior struct {
 // to change or break without warning. It is not protected by version compatibility guarantees.
 type ProviderDeferredBehavior struct {
 	// When EnablePlanModification is true, the SDK will execute provider-defined logic
-	// during plan (CustomizeDiff, Default, DiffSupressFunc, etc.) if ConfigureProvider
+	// during plan (CustomizeDiff, Default, DiffSuppressFunc, etc.) if ConfigureProvider
 	// returns a deferred response. The SDK will then automatically return a deferred response
 	// along with the modified plan.
 	EnablePlanModification bool
@@ -748,7 +748,7 @@ type StateUpgrader struct {
 
 	// Upgrade takes the JSON encoded state and the provider meta value, and
 	// upgrades the state one single schema version. The provided state is
-	// deocded into the default json types using a map[string]interface{}. It
+	// decoded into the default json types using a map[string]interface{}. It
 	// is up to the StateUpgradeFunc to ensure that the returned value can be
 	// encoded using the new schema.
 	Upgrade StateUpgradeFunc
@@ -873,7 +873,7 @@ func (r *Resource) Apply(
 		data.providerMeta = s.ProviderMeta
 	}
 
-	// Instance Diff shoould have the timeout info, need to copy it over to the
+	// Instance Diff should have the timeout info, need to copy it over to the
 	// ResourceData meta
 	rt := ResourceTimeout{}
 	if _, ok := d.Meta[TimeoutKey]; ok {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -82,7 +82,7 @@ func (d *ResourceData) GetChange(key string) (interface{}, interface{}) {
 // GetOk returns the data for the given key and whether or not the key
 // has been set to a non-zero value at some point.
 //
-// The first result will not necessarilly be nil if the value doesn't exist.
+// The first result will not necessarily be nil if the value doesn't exist.
 // The second result should be checked to determine this information.
 func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	r := d.getRaw(key, getSourceSet)

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1037,7 +1037,7 @@ func TestResourceDataGetOk(t *testing.T) {
 			Ok:    false,
 		},
 
-		// Further illustrates and clarifiies the GetOk semantics from #933, and
+		// Further illustrates and clarifies the GetOk semantics from #933, and
 		// highlights the limitation that zero-value config is currently
 		// indistinguishable from unset config.
 		{

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -132,7 +132,7 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 					timeout = t.Default
 				}
 
-				// If the resource has not delcared this in the definition, then error
+				// If the resource has not declared this in the definition, then error
 				// with an unsupported message
 				if timeout == nil {
 					return unsupportedTimeoutKeyError(timeKey)

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -145,7 +145,7 @@ type Schema struct {
 	//
 	// The key benefit of activating this flag is that the result of Read or
 	// ReadContext will be cleaned of normalization-only changes in the same
-	// way as the planning result would normaly be, which therefore prevents
+	// way as the planning result would normally be, which therefore prevents
 	// churn for downstream expressions deriving from this attribute and
 	// prevents incorrect "Values changed outside of Terraform" messages
 	// when the remote API returns values which have the same meaning as the
@@ -1099,7 +1099,7 @@ func isValidFieldName(name string) bool {
 }
 
 // resourceDiffer is an interface that is used by the private diff functions.
-// This helps facilitate diff logic for both ResourceData and ResoureDiff with
+// This helps facilitate diff logic for both ResourceData and ResourceDiff with
 // minimal divergence in code.
 type resourceDiffer interface {
 	diffChange(string) (interface{}, interface{}, bool, bool, bool)
@@ -1119,24 +1119,24 @@ func (m schemaMap) diff(
 	d resourceDiffer,
 	all bool) error {
 
-	unsupressedDiff := new(terraform.InstanceDiff)
-	unsupressedDiff.Attributes = make(map[string]*terraform.ResourceAttrDiff)
+	unsuppressedDiff := new(terraform.InstanceDiff)
+	unsuppressedDiff.Attributes = make(map[string]*terraform.ResourceAttrDiff)
 
 	var err error
 	switch schema.Type {
 	case TypeBool, TypeInt, TypeFloat, TypeString:
-		err = m.diffString(k, schema, unsupressedDiff, d, all)
+		err = m.diffString(k, schema, unsuppressedDiff, d, all)
 	case TypeList:
-		err = m.diffList(ctx, k, schema, unsupressedDiff, d, all)
+		err = m.diffList(ctx, k, schema, unsuppressedDiff, d, all)
 	case TypeMap:
-		err = m.diffMap(k, schema, unsupressedDiff, d, all)
+		err = m.diffMap(k, schema, unsuppressedDiff, d, all)
 	case TypeSet:
-		err = m.diffSet(ctx, k, schema, unsupressedDiff, d, all)
+		err = m.diffSet(ctx, k, schema, unsuppressedDiff, d, all)
 	default:
 		err = fmt.Errorf("%s: unknown type %#v", k, schema.Type)
 	}
 
-	for attrK, attrV := range unsupressedDiff.Attributes {
+	for attrK, attrV := range unsuppressedDiff.Attributes {
 		switch rd := d.(type) {
 		case *ResourceData:
 			if schema.DiffSuppressFunc != nil && attrV != nil &&

--- a/helper/schema/set.go
+++ b/helper/schema/set.go
@@ -219,7 +219,7 @@ func (s *Set) add(item interface{}, computed bool) string {
 
 func (s *Set) hash(item interface{}) string {
 	code := s.F(item)
-	// Always return a nonnegative hashcode.
+	// Always return a non-negative hashcode.
 	if code < 0 {
 		code = -code
 	}

--- a/helper/schema/shims_test.go
+++ b/helper/schema/shims_test.go
@@ -73,7 +73,7 @@ func testApplyDiff(t *testing.T,
 		}
 	}
 
-	// Resource.Meta will be hanlded separately, so it's OK that we lose the
+	// Resource.Meta will be handled separately, so it's OK that we lose the
 	// timeout values here.
 	expectedState, err := StateValueFromInstanceState(expected, testSchema.Block.ImpliedType())
 	if err != nil {

--- a/helper/structure/normalize_json_test.go
+++ b/helper/structure/normalize_json_test.go
@@ -70,7 +70,7 @@ func TestNormalizeJsonString_valid(t *testing.T) {
 
 func TestNormalizeJsonString_invalid(t *testing.T) {
 	// Well formatted but not valid,
-	// missing closing squre bracket.
+	// missing closing square bracket.
 	invalidJson := `{
    "abc": {
       "def": 123,

--- a/helper/validation/uuid_test.go
+++ b/helper/validation/uuid_test.go
@@ -24,7 +24,7 @@ func TestValidationIsUUID(t *testing.T) {
 			Value: "00000000-0000-123-0000-000000000000",
 			Error: true,
 		},
-		"ValidUuidWithOutDashs": {
+		"ValidUuidWithoutDashes": {
 			Value: "12345678123412341234123456789012",
 			Error: true,
 		},

--- a/internal/addrs/instance_key.go
+++ b/internal/addrs/instance_key.go
@@ -20,7 +20,7 @@ type instanceKey interface {
 	String() string
 }
 
-// NoKey represents the absense of an instanceKey, for the single instance
+// NoKey represents the absence of an instanceKey, for the single instance
 // of a configuration object that does not use "count" or "for_each" at all.
 var NoKey instanceKey
 

--- a/internal/configs/configschema/coerce_value.go
+++ b/internal/configs/configschema/coerce_value.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CoerceValue attempts to force the given value to conform to the type
-// implied by the receiever.
+// implied by the receiver.
 //
 // This is useful in situations where a configuration must be derived from
 // an already-decoded value. It is always better to decode directly from

--- a/internal/configs/configschema/coerce_value_test.go
+++ b/internal/configs/configschema/coerce_value_test.go
@@ -549,7 +549,7 @@ func TestCoerceValue(t *testing.T) {
 
 			if gotErrObj == nil {
 				if test.WantErr != "" {
-					t.Fatalf("coersion succeeded; want error: %q", test.WantErr)
+					t.Fatalf("coercion succeeded; want error: %q", test.WantErr)
 				}
 			} else {
 				gotErr := tfdiags.FormatError(gotErrObj)

--- a/internal/configs/configschema/empty_value.go
+++ b/internal/configs/configschema/empty_value.go
@@ -7,12 +7,12 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 )
 
-// EmptyValue returns the "empty value" for the recieving block, which for
+// EmptyValue returns the "empty value" for the receiving block, which for
 // a block type is a non-null object where all of the attribute values are
 // the empty values of the block's attributes and nested block types.
 //
 // In other words, it returns the value that would be returned if an empty
-// block were decoded against the recieving schema, assuming that no required
+// block were decoded against the receiving schema, assuming that no required
 // attribute or block constraints were honored.
 func (b *Block) EmptyValue() cty.Value {
 	vals := make(map[string]cty.Value)

--- a/internal/configs/configschema/schema.go
+++ b/internal/configs/configschema/schema.go
@@ -125,7 +125,7 @@ const (
 	NestingSingle
 
 	// NestingGroup is similar to NestingSingle in that it calls for only a
-	// single instance of a given block type with no labels, but it additonally
+	// single instance of a given block type with no labels, but it additionally
 	// guarantees that its result will never be null, even if the block is
 	// absent, and instead the nested attributes and blocks will be treated
 	// as absent in that case. (Any required attributes or blocks within the

--- a/internal/configs/hcl2shim/values_equiv.go
+++ b/internal/configs/hcl2shim/values_equiv.go
@@ -187,8 +187,8 @@ func valuesSDKEquivalentMappings(a, b cty.Value) bool {
 // precision in the round-trip.
 //
 // This does _not_ attempt to allow for an epsilon difference that may be
-// caused by accumulated innacuracy in a float calculation, under the
-// expectation that providers generally do not actually do compuations on
+// caused by accumulated inaccuracy in a float calculation, under the
+// expectation that providers generally do not actually do computations on
 // floats and instead just pass string representations of them on verbatim
 // to remote APIs. A remote API _itself_ may introduce inaccuracy, but that's
 // a problem for the provider itself to deal with, based on its knowledge of

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -10,7 +10,7 @@ const (
 	// usage, this environment variable is handled by terraform-plugin-go.
 	//
 	// Terraform CLI's logging must be explicitly turned on before this
-	// environment varable can be used to reduce the SDK logging levels. It
+	// environment variable can be used to reduce the SDK logging levels. It
 	// cannot be used to show only SDK logging unless all other logging levels
 	// are turned off.
 	EnvTfLogSdk = "TF_LOG_SDK"

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -183,7 +183,7 @@ func (d *InstanceDiff) applyBlockDiff(path []string, attrs map[string]string, sc
 
 		// check each set candidate to see if it was removed.
 		// we need to do this, because when entire sets are removed, they may
-		// have the wrong key, and ony show diffs going to ""
+		// have the wrong key, and only show diffs going to ""
 		if block.Nesting == configschema.NestingSet {
 			for k := range candidateKeys {
 				indexPrefix := strings.Join(append(path, n, k), ".") + "."
@@ -359,7 +359,7 @@ func (d *InstanceDiff) applySingleAttrDiff(path []string, attrs map[string]strin
 		return result, nil
 	}
 
-	// check for missmatched diff values
+	// check for mismatched diff values
 	if exists &&
 		old != diff.Old &&
 		old != hcl2shim.UnknownVariableValue &&
@@ -892,7 +892,7 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 				continue
 			}
 
-			// If the last diff was a computed value then the absense of
+			// If the last diff was a computed value then the absence of
 			// that value is allowed since it may mean the value ended up
 			// being the same.
 			if diffOld.NewComputed {

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -613,7 +613,7 @@ func TestInstanceDiffSame(t *testing.T) {
 			"",
 		},
 
-		// Innner computed set should allow outer change in key
+		// Inner computed set should allow outer change in key
 		{
 			&InstanceDiff{
 				Attributes: map[string]*ResourceAttrDiff{
@@ -660,7 +660,7 @@ func TestInstanceDiffSame(t *testing.T) {
 			"",
 		},
 
-		// Innner computed list should allow outer change in key
+		// Inner computed list should allow outer change in key
 		{
 			&InstanceDiff{
 				Attributes: map[string]*ResourceAttrDiff{

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -46,7 +46,7 @@ var rootModulePath = []string{"root"}
 // normalizeModulePath takes a raw module path and returns a path that
 // has the rootModulePath prepended to it. If I could go back in time I
 // would've never had a rootModulePath (empty path would be root). We can
-// still fix this but thats a big refactor that my branch doesn't make sense
+// still fix this but that's a big refactor that my branch doesn't make sense
 // for. Instead, this function normalizes paths.
 func normalizeModulePath(p []string) addrs.ModuleInstance {
 	// FIXME: Remove this once everyone is using addrs.ModuleInstance.
@@ -799,7 +799,7 @@ func (s *OutputState) Equal(other *OutputState) bool {
 // module.
 type ModuleState struct {
 	// Path is the import path from the root module. Modules imports are
-	// always disjoint, so the path represents amodule tree
+	// always disjoint, so the path represents a module tree
 	Path []string `json:"path"`
 
 	// Locals are kept only transiently in-memory, because we can always

--- a/terraform/state_filter.go
+++ b/terraform/state_filter.go
@@ -263,7 +263,7 @@ func (s stateFilterResultSlice) Less(i, j int) bool {
 		return addrA.Index < addrB.Index
 	}
 
-	// If the addresses are different it is just lexographic sorting
+	// If the addresses are different it is just lexicographic sorting
 	if a.Address != b.Address {
 		return a.Address < b.Address
 	}

--- a/website/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/website/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -9,7 +9,7 @@ As of September 2019, Terraform provider developers importing the Go module `git
 
 ## Why a separate module?
 
-While the `helper/*` and other packages in Terraform Core has served us well, in order for provider development to evolve, the SDK needed to break out into its own repository. Terraform Core's versioning has been oriented towards practitioners. With the "unofficial" SDK existing in the core repository, the SDK becomes tied to Core releases and cannot follow semantic versioning. The new standalone SDK [github.com/hashicorp/terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk) follows sematic versioning starting with v1.0.0.
+While the `helper/*` and other packages in Terraform Core has served us well, in order for provider development to evolve, the SDK needed to break out into its own repository. Terraform Core's versioning has been oriented towards practitioners. With the "unofficial" SDK existing in the core repository, the SDK becomes tied to Core releases and cannot follow semantic versioning. The new standalone SDK [github.com/hashicorp/terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk) follows semantic versioning starting with v1.0.0.
 
 We will use the term "legacy Terraform plugin SDK" when referring to the version of Terraform Core imported and used by providers.
 

--- a/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -595,7 +595,7 @@ deprecated aliases have been removed:
 
 ## Removal of `helper/schema.Schema.PromoteSingle`
 
-The `PromotSingle` property of `*helper/schema.Schema` is a discouraged pattern
+The `PromoteSingle` property of `*helper/schema.Schema` is a discouraged pattern
 and no longer valid after Terraform 0.12, and has been removed.
 
 ## Removal of `helper/schema.ResourceData.UnsafeSetFieldRaw`

--- a/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -76,7 +76,7 @@ If a CRUD function timeout is exceeded, the SDK will automatically return a `con
 The retry helper takes a timeout and a retry function.
 
 - The **timeout** value specifies the maximum time Terraform will invoke the retry function. You can retrieve the timeout from the `*schema.ResourceData` struct by passing the timeout key (`schema.TimeoutCreate`) to the `Timeout` method.
-- The **retry function**, which is available by importing `github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry`, returns either a `retry.NonRetryableError` for unexpected errors/states or a `retry.RetryableError` for expected errrors/states. If the function returns a `retry.RetryableError`, it will re-run the function.
+- The **retry function**, which is available by importing `github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry`, returns either a `retry.NonRetryableError` for unexpected errors/states or a `retry.RetryableError` for expected errors/states. If the function returns a `retry.RetryableError`, it will re-run the function.
 
 In the context of a `CREATE` function, once the backend responds with the desired state, invoke the `READ` function. If `READ` errors, return that error wrapped with `retry.NonRetryableError`. Otherwise, return `nil` (no error) from the retry function.
 

--- a/website/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/website/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -13,7 +13,7 @@ The mechanism that is used for state migrations changed between v0.11 and v0.12 
 
 ~> **Note:** This method of state migration does not work if the provider has a dependency on the Terraform v0.11 SDK. See the [Terraform v0.11 SDK State Migrations](#terraform-v0-11-sdk-state-migrations) section for details on using `MigrateState` instead.
 
-For this task provider developers should use a resource's `SchemaVersion` and `StateUpgraders` fields. Resources typically do not have these fields configured unless state migrations have been perfomed in the past.
+For this task provider developers should use a resource's `SchemaVersion` and `StateUpgraders` fields. Resources typically do not have these fields configured unless state migrations have been performed in the past.
 
 When Terraform encounters a newer resource `SchemaVersion` during planning, it will automatically migrate the state through each `StateUpgrader` function until it matches the current `SchemaVersion`.
 

--- a/website/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -29,7 +29,7 @@ func resourceExampleResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validatName,
+				ValidateFunc: validateName,
 			},
 			// ... //
 		},


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

Use the following command to get a quick summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* unsupressed
* compontent
* depenencies
* indicies
* seperated
* innner
* absense
* failues
* necessarilly
* perfomed
* recieving