### PR TITLE
all: Initial ephemeral resource implementation

### DIFF
--- a/.changes/unreleased/NOTES-20241030-173604.yaml
+++ b/.changes/unreleased/NOTES-20241030-173604.yaml
@@ -1,0 +1,8 @@
+kind: NOTES
+body: 'helper/schema: While this Go module will not receive support for ephemeral
+  resource types, the provider server is updated to handle the new operations, which
+  will be required to prevent errors when updating `terraform-plugin-framework` or
+  `terraform-plugin-mux` in the future.'
+time: 2024-10-30T17:36:04.538418-04:00
+custom:
+  Issue: "1390"

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -84,6 +84,7 @@ func (s *GRPCProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.Get
 
 	resp := &tfprotov5.GetMetadataResponse{
 		DataSources:        make([]tfprotov5.DataSourceMetadata, 0, len(s.provider.DataSourcesMap)),
+		EphemeralResources: make([]tfprotov5.EphemeralResourceMetadata, 0),
 		Functions:          make([]tfprotov5.FunctionMetadata, 0),
 		Resources:          make([]tfprotov5.ResourceMetadata, 0, len(s.provider.ResourcesMap)),
 		ServerCapabilities: s.serverCapabilities(),
@@ -110,10 +111,11 @@ func (s *GRPCProviderServer) GetProviderSchema(ctx context.Context, req *tfproto
 	logging.HelperSchemaTrace(ctx, "Getting provider schema")
 
 	resp := &tfprotov5.GetProviderSchemaResponse{
-		DataSourceSchemas:  make(map[string]*tfprotov5.Schema, len(s.provider.DataSourcesMap)),
-		Functions:          make(map[string]*tfprotov5.Function, 0),
-		ResourceSchemas:    make(map[string]*tfprotov5.Schema, len(s.provider.ResourcesMap)),
-		ServerCapabilities: s.serverCapabilities(),
+		DataSourceSchemas:        make(map[string]*tfprotov5.Schema, len(s.provider.DataSourcesMap)),
+		EphemeralResourceSchemas: make(map[string]*tfprotov5.Schema, 0),
+		Functions:                make(map[string]*tfprotov5.Function, 0),
+		ResourceSchemas:          make(map[string]*tfprotov5.Schema, len(s.provider.ResourcesMap)),
+		ServerCapabilities:       s.serverCapabilities(),
 	}
 
 	resp.Provider = &tfprotov5.Schema{
@@ -1477,6 +1479,78 @@ func (s *GRPCProviderServer) GetFunctions(ctx context.Context, req *tfprotov5.Ge
 
 	resp := &tfprotov5.GetFunctionsResponse{
 		Functions: make(map[string]*tfprotov5.Function, 0),
+	}
+
+	return resp, nil
+}
+
+func (s *GRPCProviderServer) ValidateEphemeralResourceConfig(ctx context.Context, req *tfprotov5.ValidateEphemeralResourceConfigRequest) (*tfprotov5.ValidateEphemeralResourceConfigResponse, error) {
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Returning error for ephemeral resource validate")
+
+	resp := &tfprotov5.ValidateEphemeralResourceConfigResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unknown Ephemeral Resource Type",
+				Detail:   fmt.Sprintf("The %q ephemeral resource type is not supported by this provider.", req.TypeName),
+			},
+		},
+	}
+
+	return resp, nil
+}
+
+func (s *GRPCProviderServer) OpenEphemeralResource(ctx context.Context, req *tfprotov5.OpenEphemeralResourceRequest) (*tfprotov5.OpenEphemeralResourceResponse, error) {
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Returning error for ephemeral resource open")
+
+	resp := &tfprotov5.OpenEphemeralResourceResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unknown Ephemeral Resource Type",
+				Detail:   fmt.Sprintf("The %q ephemeral resource type is not supported by this provider.", req.TypeName),
+			},
+		},
+	}
+
+	return resp, nil
+}
+
+func (s *GRPCProviderServer) RenewEphemeralResource(ctx context.Context, req *tfprotov5.RenewEphemeralResourceRequest) (*tfprotov5.RenewEphemeralResourceResponse, error) {
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Returning error for ephemeral resource renew")
+
+	resp := &tfprotov5.RenewEphemeralResourceResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unknown Ephemeral Resource Type",
+				Detail:   fmt.Sprintf("The %q ephemeral resource type is not supported by this provider.", req.TypeName),
+			},
+		},
+	}
+
+	return resp, nil
+}
+
+func (s *GRPCProviderServer) CloseEphemeralResource(ctx context.Context, req *tfprotov5.CloseEphemeralResourceRequest) (*tfprotov5.CloseEphemeralResourceResponse, error) {
+	ctx = logging.InitContext(ctx)
+
+	logging.HelperSchemaTrace(ctx, "Returning error for ephemeral resource close")
+
+	resp := &tfprotov5.CloseEphemeralResourceResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unknown Ephemeral Resource Type",
+				Detail:   fmt.Sprintf("The %q ephemeral resource type is not supported by this provider.", req.TypeName),
+			},
+		},
 	}
 
 	return resp, nil

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -3319,8 +3319,9 @@ func TestGRPCProviderServerGetMetadata(t *testing.T) {
 						TypeName: "test_datasource2",
 					},
 				},
-				Functions: []tfprotov5.FunctionMetadata{},
-				Resources: []tfprotov5.ResourceMetadata{},
+				Functions:          []tfprotov5.FunctionMetadata{},
+				EphemeralResources: []tfprotov5.EphemeralResourceMetadata{},
+				Resources:          []tfprotov5.ResourceMetadata{},
 				ServerCapabilities: &tfprotov5.ServerCapabilities{
 					GetProviderSchemaOptional: true,
 				},
@@ -3346,7 +3347,8 @@ func TestGRPCProviderServerGetMetadata(t *testing.T) {
 						TypeName: "test_datasource2",
 					},
 				},
-				Functions: []tfprotov5.FunctionMetadata{},
+				Functions:          []tfprotov5.FunctionMetadata{},
+				EphemeralResources: []tfprotov5.EphemeralResourceMetadata{},
 				Resources: []tfprotov5.ResourceMetadata{
 					{
 						TypeName: "test_resource1",
@@ -3368,8 +3370,9 @@ func TestGRPCProviderServerGetMetadata(t *testing.T) {
 				},
 			},
 			Expected: &tfprotov5.GetMetadataResponse{
-				DataSources: []tfprotov5.DataSourceMetadata{},
-				Functions:   []tfprotov5.FunctionMetadata{},
+				DataSources:        []tfprotov5.DataSourceMetadata{},
+				Functions:          []tfprotov5.FunctionMetadata{},
+				EphemeralResources: []tfprotov5.EphemeralResourceMetadata{},
 				Resources: []tfprotov5.ResourceMetadata{
 					{
 						TypeName: "test_resource1",


### PR DESCRIPTION
Refs:
- https://github.com/hashicorp/terraform-plugin-go/pull/441
- https://developer.hashicorp.com/terraform/plugin/framework/migrating
- https://developer.hashicorp.com/terraform/plugin/mux

The upcoming versions of the plugin protocol (5.7/6.7) include support for ephemeral resource types. The `terraform-plugin-sdk` Go module will not be receiving this feature, however this Go module must be updated to handle the new RPCs with errors.

Provider developers can still implement ephemeral resource types in their `terraform-plugin-sdk` based providers by following the [framework migration documentation](https://developer.hashicorp.com/terraform/plugin/framework/migrating) to introduce `terraform-plugin-mux`, which then will enable `terraform-plugin-framework` based ephemeral resource implementations.