### PR TITLE
chore: Update CI to run corner tests on all v5 protocol Terraform versions

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -24,10 +24,11 @@ jobs:
       - uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
         with:
           version: latest
-  terraform-provider-corner:
+  terraform-provider-corner-tfprotov5:
     defaults:
       run:
         working-directory: terraform-provider-corner
+    name: terraform-provider-corner (tfprotov5 / Terraform ${{ matrix.terraform}})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,11 +39,19 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
       - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-sdk/v2=../
       - run: go mod tidy
-      - run: go test -v ./...
+      - run: go test -v ./internal/sdkv2provider
         env:
           TF_ACC: '1'
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform: ${{ fromJSON(vars.TF_VERSIONS_PROTOCOL_V5) }}
   test:
     name: test (Go v${{ matrix.go-version }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously, it was just using running a single test with the latest Terraform version that is installed on the machine.

We will have new functionality/new tests that need to run on newer Terraform versions after #1375 