### PR TITLE
fix: Correctly validate the length of a UTF8 string with `StringLenBetween` validator

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250217-181939.yaml
+++ b/.changes/unreleased/BUG FIXES-20250217-181939.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'tfsdk: Correctly validate the length of a UTF8 string with `StringLenBetween` validator'
+time: 2025-02-17T18:19:39.713656+11:00
+custom:
+    Issue: "1425"

--- a/helper/validation/meta_test.go
+++ b/helper/validation/meta_test.go
@@ -71,7 +71,7 @@ func TestValidationAll(t *testing.T) {
 		{
 			val: "你好世界",
 			f: All(
-				StringLenBetween(1,5),
+				StringLenBetween(1, 5),
 			),
 		},
 	})
@@ -101,6 +101,12 @@ func TestValidationAllDiag(t *testing.T) {
 				ToDiagFunc(StringMatch(regexp.MustCompile(`[a-zA-Z0-9]+`), "value must be alphanumeric")),
 			),
 			expectedDiagSummary: regexp.MustCompile("value must be alphanumeric"),
+		},
+		{
+			val: "你好世界",
+			f: AllDiag(
+				ToDiagFunc(StringLenBetween(1, 5)),
+			),
 		},
 	})
 }

--- a/helper/validation/meta_test.go
+++ b/helper/validation/meta_test.go
@@ -68,6 +68,12 @@ func TestValidationAll(t *testing.T) {
 			),
 			expectedErr: regexp.MustCompile("value must be alphanumeric"),
 		},
+		{
+			val: "你好世界",
+			f: All(
+				StringLenBetween(1,5),
+			),
+		},
 	})
 }
 

--- a/helper/validation/strings.go
+++ b/helper/validation/strings.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
@@ -79,7 +80,8 @@ func StringLenBetween(minVal, maxVal int) schema.SchemaValidateFunc {
 			return warnings, errors
 		}
 
-		if len(v) < minVal || len(v) > maxVal {
+		length := utf8.RuneCountInString(v)
+		if length < minVal || length > maxVal {
 			errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, minVal, maxVal, v))
 		}
 


### PR DESCRIPTION
Fixes #1425.