### PR TITLE
chore: Update golangci-lint linters and apply fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gofmt
     - gosimple
     - ineffassign
@@ -20,7 +20,7 @@ linters:
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused

--- a/helper/acctest/random_test.go
+++ b/helper/acctest/random_test.go
@@ -91,8 +91,6 @@ func TestRandSSHKeyPair(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/plugin_test.go
+++ b/helper/resource/plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/plugintest"
@@ -78,8 +79,6 @@ func TestProtoV5ProviderFactoriesMerge(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -153,8 +152,6 @@ func TestProtoV6ProviderFactoriesMerge(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -228,8 +225,6 @@ func TestSdkProviderFactoriesMerge(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/testcase_providers_test.go
+++ b/helper/resource/testcase_providers_test.go
@@ -226,8 +226,6 @@ provider "test" {}
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/testcase_validate_test.go
+++ b/helper/resource/testcase_validate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -68,8 +69,6 @@ func TestTestCaseHasProviders(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -148,8 +147,6 @@ func TestTestCaseValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -1401,8 +1401,6 @@ func TestTestCheckResourceAttr(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1834,8 +1832,6 @@ func TestTestCheckResourceAttrWith(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2065,8 +2061,6 @@ func TestTestCheckNoResourceAttr(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2495,8 +2489,6 @@ func TestTestCheckResourceAttrSet(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/teststep_providers_test.go
+++ b/helper/resource/teststep_providers_test.go
@@ -115,8 +115,6 @@ resource "test_test" "test" {}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -747,8 +745,6 @@ resource "test_test" "test" {}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -962,8 +958,6 @@ provider "test" {}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/resource/teststep_validate_test.go
+++ b/helper/resource/teststep_validate_test.go
@@ -61,8 +61,6 @@ func TestTestStepHasProviders(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,8 +191,6 @@ func TestTestStepValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -3268,8 +3268,6 @@ func TestGRPCProviderServerConfigureProvider(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3389,8 +3387,6 @@ func TestGRPCProviderServerGetMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3470,8 +3466,6 @@ func TestGRPCProviderServerMoveResourceState(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3953,8 +3947,6 @@ func TestGRPCProviderServerValidateResourceTypeConfig(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -4838,8 +4830,6 @@ func TestReadResource(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := testCase.server.ReadResource(context.Background(), testCase.req)
@@ -5560,8 +5550,6 @@ func TestPlanResourceChange(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -5871,8 +5859,6 @@ func TestApplyResourceChange(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6014,8 +6000,6 @@ func TestApplyResourceChange_ResourceFuncs(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6148,7 +6132,6 @@ func TestApplyResourceChange_bigint(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.Description, func(t *testing.T) {
 			server := NewGRPCProviderServer(&Provider{
 				ResourcesMap: map[string]*Resource{
@@ -6376,8 +6359,6 @@ func TestApplyResourceChange_ResourceFuncs_writeOnly(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -6710,8 +6691,6 @@ func TestImportResourceState(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := testCase.server.ImportResourceState(context.Background(), testCase.req)
@@ -7366,8 +7345,6 @@ func TestReadDataSource(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := testCase.server.ReadDataSource(context.Background(), testCase.req)
@@ -8138,7 +8115,6 @@ func TestStopContext_grpc(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.Description, func(t *testing.T) {
 			server := NewGRPCProviderServer(&Provider{
 				ResourcesMap: map[string]*Resource{
@@ -8253,7 +8229,6 @@ func TestStopContext_stop(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.Description, func(t *testing.T) {
 			server := NewGRPCProviderServer(&Provider{
 				ResourcesMap: map[string]*Resource{
@@ -8371,7 +8346,6 @@ func TestStopContext_stopReset(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.Description, func(t *testing.T) {
 			server := NewGRPCProviderServer(&Provider{
 				ResourcesMap: map[string]*Resource{

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -2498,6 +2498,7 @@ func TestProvider_InternalValidate(t *testing.T) {
 
 func TestProviderUserAgentAppendViaEnvVar(t *testing.T) {
 	if oldenv, isSet := os.LookupEnv(uaEnvVar); isSet {
+		//nolint:usetesting
 		defer os.Setenv(uaEnvVar, oldenv)
 	} else {
 		defer os.Unsetenv(uaEnvVar)

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -1633,7 +1633,6 @@ func TestProviderConfigure(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2246,8 +2245,6 @@ func TestProviderImportState(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/structure/suppress_json_diff_test.go
+++ b/helper/structure/suppress_json_diff_test.go
@@ -40,8 +40,6 @@ func TestSuppressJsonDiff(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/helper/validation/meta_test.go
+++ b/helper/validation/meta_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-cty/cty"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -240,8 +241,6 @@ func TestToDiagFunc(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/configs/hcl2shim/flatmap_test.go
+++ b/internal/configs/hcl2shim/flatmap_test.go
@@ -243,8 +243,6 @@ func TestFlatmapValueFromHCL2(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.Value.GoString(), func(t *testing.T) {
 			t.Parallel()
 
@@ -312,8 +310,6 @@ func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/plugin/convert/diagnostics.go
+++ b/internal/plugin/convert/diagnostics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/internal/logging"
 )
@@ -136,7 +137,7 @@ func AttributePathToPath(ap *tftypes.AttributePath) cty.Path {
 
 // PathToAttributePath takes a cty.Path and converts it to a proto-encoded path.
 func PathToAttributePath(p cty.Path) *tftypes.AttributePath {
-	if p == nil || len(p) < 1 {
+	if len(p) < 1 {
 		return nil
 	}
 	ap := tftypes.NewAttributePath()


### PR DESCRIPTION
Update golangci config and resolve `copyloopvar`