### PR TITLE
Add callout for `PreferWriteOnlyAttribute` validator

### DIFF
--- a/helper/validation/write_only.go
+++ b/helper/validation/write_only.go
@@ -22,6 +22,10 @@ import (
 // For lists: cty.Index(cty.UnknownVal(cty.Number)),
 // For maps: cty.Index(cty.UnknownVal(cty.String)),
 // For sets: cty.Index(cty.UnknownVal(cty.Object(nil))),
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules
+// who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(oldAttribute cty.Path, writeOnlyAttribute cty.Path) schema.ValidateRawResourceConfigFunc {
 	return func(ctx context.Context, req schema.ValidateResourceConfigFuncRequest, resp *schema.ValidateResourceConfigFuncResponse) {
 		if !req.WriteOnlyAttributesAllowed {

--- a/website/docs/plugin/sdkv2/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/sdkv2/resources/write-only-arguments.mdx
@@ -203,6 +203,13 @@ if !woVal.IsNull() {
 
 ## PreferWriteOnlyAttribute Validator
 
+<Note>
+
+    This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+    has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
+
+</Note>
+
 `PreferWriteOnlyAttribute()` is a validator that takes a `cty.Path` to an existing configuration attribute (required/optional) and a `cty.Path` to a write-only argument.
 
 Use this validator when you have a write-only version of an existing attribute, and you want to encourage practitioners to use the write-only version whenever possible.


### PR DESCRIPTION
Adds a callout for `PreferWriteOnlyAttribute()` validator usage about the persistent nature of the warnings for practitioners.