### PR TITLE
Add comments for UDR migration

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,8 @@
 # Terraform Documentation
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin SDK.
 
 The files in this directory are intended to be used in conjunction with

--- a/website/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/website/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -3,6 +3,9 @@ page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best
 description: 'Recommendations for deprecations, removals, and renames.'
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Deprecations, Removals, and Renames
 
 Terraform is trusted for managing many facets of infrastructure across many organizations. Part of that trust is due to consistent versioning guidelines and setting expectations for various levels of upgrades. Ensuring backwards compatibility for all patch and minor releases, potentially in concert with any upcoming major changes, is recommended and supported by the Terraform development framework. This allows operators to iteratively update their Terraform configurations rather than require massive refactoring.

--- a/website/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/website/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -6,6 +6,9 @@ description: |-
   infrastructure has changed.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Detecting Drift
 
 One of the core challenges of infrastructure as code is keeping an up-to-date

--- a/website/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/website/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 <Highlight>
 
 This best practices section only contains guidance for plugins built with [Terraform Plugin SDK](/terraform/plugin/sdkv2). More generic best practices that apply to both SDK and [Terraform Plugin Framework](/terraform/plugin/framework) can be found in the [Plugin Development Best Practices](/terraform/plugin/best-practices) section.

--- a/website/docs/plugin/sdkv2/debugging.mdx
+++ b/website/docs/plugin/sdkv2/debugging.mdx
@@ -3,6 +3,9 @@ page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Debugging SDKv2 Providers
 
 This page contains implementation details for inspecting runtime information of a Terraform provider developed with SDKv2 via a debugger tool. Review the top level [Debugging](/terraform/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.

--- a/website/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/website/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -5,6 +5,9 @@ description: |-
   codebases.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform 0.12 Compatibility for Providers
 
 Terraform 0.12 introduced a new type system for the Terraform language, and

--- a/website/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/website/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -3,6 +3,9 @@ page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Plugin SDK
 
 As of September 2019, Terraform provider developers importing the Go module `github.com/hashicorp/terraform`, known as Terraform Core, should switch to `github.com/hashicorp/terraform-plugin-sdk`, the Terraform Plugin SDK, instead.

--- a/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/website/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -3,6 +3,9 @@ page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Plugin SDK v2 Upgrade Guide
 
 Version 2.0.0 of the Terraform Plugin SDK is a major release and includes some

--- a/website/docs/plugin/sdkv2/index.mdx
+++ b/website/docs/plugin/sdkv2/index.mdx
@@ -3,6 +3,9 @@ page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Plugin SDKv2
 
 Terraform Plugin SDKv2 is a way to maintain Terraform Plugins on [protocol version 5](/terraform/plugin/terraform-plugin-protocol#protocol-version-5).

--- a/website/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/website/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -4,6 +4,9 @@ description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # HTTP Transport
 
 Terraform's public interface has included `helper/logging` [`NewTransport()`](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/logging/transport.go) since `v0.9.5`. This helper is an implementation of the Golang standard library [`http.RoundTripper`](https://pkg.go.dev/net/http#RoundTripper) that lets you add logging at the `DEBUG` level to your provider's HTTP transactions.

--- a/website/docs/plugin/sdkv2/logging/index.mdx
+++ b/website/docs/plugin/sdkv2/logging/index.mdx
@@ -4,6 +4,9 @@ description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Logging
 
 Terraform Plugin SDKv2 integrates with the structured logging framework [terraform-plugin-log](/terraform/plugin/log). High-quality logs are critical to quickly [debugging your provider](/terraform/plugin/debugging).

--- a/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/website/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -3,6 +3,9 @@ page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - Customizing Differences
 
 Terraform tracks the state of provisioned resources in its state file, and compares the user-passed configuration against that state. When Terraform detects a discrepancy, it presents the user with the differences between the configuration and the state.

--- a/website/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/website/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -3,6 +3,9 @@ page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - Data Consistency Errors
 
 Resources written with `terraform-plugin-sdk` are by default allowed to perform unexpected data handling operations from Terraform's perspective. Terraform versions 0.12 and later have stricter [data consistency rules](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md) than the design and implementation of this SDK, which predated those rules.

--- a/website/docs/plugin/sdkv2/resources/import.mdx
+++ b/website/docs/plugin/sdkv2/resources/import.mdx
@@ -3,6 +3,9 @@ page_title: Resources - Import
 description: Implementing resource import support.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - Import
 
 Adding import support for Terraform resources will allow existing infrastructure to be managed within Terraform. This type of enhancement generally requires a small to moderate amount of code changes.

--- a/website/docs/plugin/sdkv2/resources/index.mdx
+++ b/website/docs/plugin/sdkv2/resources/index.mdx
@@ -5,6 +5,9 @@ description: >-
   resource APIs.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources
 
 A key component to Terraform Provider development is defining the creation, read, update, and deletion functionality of a resource to map those API operations into the Terraform lifecycle. While the [Call APIs with Terraform Providers tutorial](/terraform/tutorials/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Schemas documentation](/terraform/plugin/sdkv2/schemas) cover the basic aspects of developing Terraform resources, this section covers more advanced features of resource development.

--- a/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/website/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -3,6 +3,9 @@ page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - Retries and Customizable Timeouts
 
 The reality of cloud infrastructure is that it typically takes time to perform operations such as booting operating systems, discovering services, and replicating state across network edges. As the provider developer you should take known delays in resource APIs into account in the CRUD functions of the resource. Terraform supports configurable timeouts to assist in these situations.

--- a/website/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/website/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -3,6 +3,9 @@ page_title: Resources - State Migration
 description: Migrating state values within resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - State Migration
 
 Resources define the data types and API interactions required to create, update, and destroy infrastructure with a cloud vendor while the [Terraform state](/terraform/language/state) stores mapping and metadata information for those remote objects. There are several reasons why a resource implementation needs to change: backend APIs Terraform interacts with will change overtime, or the current implementation might be incorrect or unmaintainable. Some of these changes may not be backward compatible and a migration is needed for resources provisioned in the wild with old schema configurations.

--- a/website/docs/plugin/sdkv2/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/sdkv2/resources/write-only-arguments.mdx
@@ -3,6 +3,9 @@ page_title: Resources - Write-only Arguments
 description: Implementing write-only arguments within resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Resources - Write-only Arguments
 
 ~> **NOTE:** Write-only arguments are only supported in Terraform `v1.11` or higher

--- a/website/docs/plugin/sdkv2/schemas/index.mdx
+++ b/website/docs/plugin/sdkv2/schemas/index.mdx
@@ -5,6 +5,9 @@ description: |-
   in SDKv2.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Schemas
 
 Terraform Plugins are expressed using schemas to define attributes and their

--- a/website/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -5,6 +5,9 @@ description: |-
   you can use to define element behaviors in SDKv2.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Schema Behaviors
 
 Schema fields that can have an effect at plan or apply time are collectively

--- a/website/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -5,6 +5,9 @@ description: |-
   to extend Terraform's core offering.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Terraform Schemas Methods
 
 _NOTE_ should distinguish between `schema.Provider`, `schema.Resource`,

--- a/website/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/website/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -6,6 +6,9 @@ description: |-
   element.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Schema Attributes and Types
 
 Almost every Terraform Plugin offers user configurable parameters, examples such

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -5,6 +5,9 @@ description: |-
   imitate applying one or more configuration files.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests
 
 <Highlight>

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -5,6 +5,9 @@ description: >-
   testing framework. Sweepers clean up leftover infrastructure.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Sweepers
 
 <Highlight>

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -5,6 +5,9 @@ description: |-
   creates a set of resources then verifies the new infrastructure.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests: TestCases
 
 <Highlight>

--- a/website/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/website/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -5,6 +5,9 @@ description: |-
   file to a given state.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Acceptance Tests: TestSteps
 
 <Highlight>

--- a/website/docs/plugin/sdkv2/testing/index.mdx
+++ b/website/docs/plugin/sdkv2/testing/index.mdx
@@ -5,6 +5,9 @@ description: |-
   plugins.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Testing Terraform Plugins
 
 <Highlight>

--- a/website/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/website/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -5,4 +5,7 @@ description: |-
   to extend Terraform's core offering.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Testing API

--- a/website/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/website/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -5,4 +5,7 @@ description: |-
   to extend Terraform's core offering.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Testing Patterns

--- a/website/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/website/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -5,6 +5,9 @@ description: |-
   flatten API responses into data structures that Terraform stores as state.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Unit Testing
 
 <Highlight>


### PR DESCRIPTION
### Description

We are migrating the terraform-plugin-* documentation to a unified HashiCorp product documentation repository. As a result of this migration, the unified repo (web-unified-docs) will be the source of truth.

This PR adds a noticed to all existing MDX files in the original location so folks know where to contribute. We plan on deprecating and removing the files in /website.

This PR will be merged after docs have been migrated