### PR TITLE
update terraform-plugin-go to v0.27.0-alpha.1 and add changie entry

### DIFF
--- a/.changes/unreleased/NOTES-20250319-150717.yaml
+++ b/.changes/unreleased/NOTES-20250319-150717.yaml
@@ -1,0 +1,8 @@
+kind: NOTES
+body: This alpha pre-release contains an initial implementation for managed resource identity, which can used with Terraform v1.12.0-alpha20250312,
+    to store and read identity data during plan and apply workflows. A managed resource identity can be used by definning an identity schema in the
+    `resource.Identity` field. Once the identity schema is defined, you can read and store identity data in the new IdentityData struct that is available
+    via the new `Identity()` method on ResourceData and ResourceDiff structs.
+time: 2025-03-19T15:07:17.690255+01:00
+custom:
+    Issue: "1444"

--- a/.changes/unreleased/NOTES-20250319-150717.yaml
+++ b/.changes/unreleased/NOTES-20250319-150717.yaml
@@ -1,6 +1,6 @@
 kind: NOTES
 body: This alpha pre-release contains an initial implementation for managed resource identity, which can used with Terraform v1.12.0-alpha20250312,
-    to store and read identity data during plan and apply workflows. A managed resource identity can be used by definning an identity schema in the
+    to store and read identity data during plan and apply workflows. A managed resource identity can be used by defining an identity schema in the
     `resource.Identity` field. Once the identity schema is defined, you can read and store identity data in the new IdentityData struct that is available
     via the new `Identity()` method on ResourceData and ResourceDiff structs.
 time: 2025-03-19T15:07:17.690255+01:00

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform-exec v0.22.0
 	github.com/hashicorp/terraform-json v0.24.0
-	github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127
+	github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/go-testing-interface v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/hashicorp/terraform-json v0.24.0 h1:rUiyF+x1kYawXeRth6fKFm/MdfBS6+lW4
 github.com/hashicorp/terraform-json v0.24.0/go.mod h1:Nfj5ubo9xbu9uiAoZVBsNOjvNKB66Oyrvtit74kC7ow=
 github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127 h1:V7RFaz+LWQY/S8tiWLuVFQMigEoZOpCF2vv7FW83vVw=
 github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250313132633-b799d5c93127/go.mod h1:MfDwS/KnIy2QzCwdRtuqIjZ23gpYa9Vm+Z8cFpx8qtU=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1 h1:/IZFNUEafGnJGXRe2iNQQ+vtzEw/5qiD+gOxkFrNbi4=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1/go.mod h1:Tf2HngbyKvovAlGXgBOVGm3EDvbNaN/StUaTXwrej4o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.4 h1:JXu/zHB2Ymg/TGVCRu10XqNa4Sh2bWcqCNyKWjnCPJA=


### PR DESCRIPTION
~depends on #1444~

* Updates `terraform-plugin-go` to the latest alpha release (instead of it pointing to a commit on main)
* Adds a changie entry for the changelog for the anticipated alpha release