### PR TITLE
error if there's no identity schema (or an empty one) defined when it should be

### DIFF
--- a/helper/schema/core_schema.go
+++ b/helper/schema/core_schema.go
@@ -374,21 +374,26 @@ func (r *Resource) coreConfigSchema() *configschema.Block {
 	return schemaMap(r.SchemaMap()).CoreConfigSchema()
 }
 
-func (r *Resource) CoreIdentitySchema() *configschema.Block {
-	block := r.coreIdentitySchema()
+func (r *Resource) CoreIdentitySchema() (*configschema.Block, error) {
+	block, err := r.coreIdentitySchema()
 
-	if block.Attributes == nil {
-		// TODO: we should error instead and callers should handle the error appropriately
-		// and error would hint at an invalid provider implementation
-		block.Attributes = map[string]*configschema.Attribute{}
+	if err != nil {
+		return nil, err
 	}
 
-	return block
+	if block.Attributes == nil {
+		return nil, fmt.Errorf("identity schema must have at least one attribute")
+	}
+
+	return block, nil
 }
 
-func (r *Resource) coreIdentitySchema() *configschema.Block {
+func (r *Resource) coreIdentitySchema() (*configschema.Block, error) {
+	if r.Identity == nil || r.Identity.Schema == nil {
+		return nil, fmt.Errorf("resource does not have an identity schema")
+	}
 	// while there is schemaMapWithIdentity, we don't need to use it here
 	// as we're only interested in the existing CoreConfigSchema() method
 	// to convert our schema
-	return schemaMap(r.Identity.Schema).CoreConfigSchema()
+	return schemaMap(r.Identity.Schema).CoreConfigSchema(), nil
 }

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -3515,7 +3515,13 @@ func TestUpgradeResourceIdentity_jsonState(t *testing.T) {
 		t.Fatal("error")
 	}
 
-	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, r.CoreIdentitySchema().ImpliedType())
+	idschema, err := r.CoreIdentitySchema()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, idschema.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3593,7 +3599,12 @@ func TestUpgradeResourceIdentity_removedAttr(t *testing.T) {
 		t.Fatal("error")
 	}
 
-	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, r.CoreIdentitySchema().ImpliedType())
+	idschema, err := r.CoreIdentitySchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, idschema.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3652,7 +3663,12 @@ func TestUpgradeResourceIdentity_jsonStateBigInt(t *testing.T) {
 		t.Fatal("error")
 	}
 
-	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, r.CoreIdentitySchema().ImpliedType())
+	idschema, err := r.CoreIdentitySchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := msgpack.Unmarshal(resp.UpgradedIdentity.IdentityData.MsgPack, idschema.ImpliedType())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -3421,6 +3421,47 @@ func TestGRPCProviderServerGetResourceIdentitySchemas(t *testing.T) {
 				},
 			},
 		},
+		"no identity schema": {
+			Provider: &Provider{
+				ResourcesMap: map[string]*Resource{
+					"test_resource1": {
+						Identity: &ResourceIdentity{
+							Version: 1,
+						},
+					},
+				},
+			},
+			Expected: &tfprotov5.GetResourceIdentitySchemasResponse{
+				IdentitySchemas: map[string]*tfprotov5.ResourceIdentitySchema{},
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "getting identity schema failed for resource 'test_resource1': resource does not have an identity schema",
+					},
+				},
+			},
+		},
+		"empty identity schema": {
+			Provider: &Provider{
+				ResourcesMap: map[string]*Resource{
+					"test_resource1": {
+						Identity: &ResourceIdentity{
+							Version: 1,
+							Schema:  map[string]*Schema{},
+						},
+					},
+				},
+			},
+			Expected: &tfprotov5.GetResourceIdentitySchemasResponse{
+				IdentitySchemas: map[string]*tfprotov5.ResourceIdentitySchema{},
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "getting identity schema failed for resource 'test_resource1': identity schema must have at least one attribute",
+					},
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
Return error diagnostics if there's no identity schema (or an empty one) defined when it should be.

Includes tests for this (`GetResourceIdentitySchemas`, `ReadResource`, `PlanResourceChange`, `ApplyResourceChange`)

Oh, and also adds an identity test for `ApplyResourceChange` that didn't exist yet.