### PR TITLE
TFECO-9157: Add tests for `identity_data.go` and switch to multiple field reader

### DIFF
--- a/helper/schema/identity_data_test.go
+++ b/helper/schema/identity_data_test.go
@@ -235,7 +235,7 @@ func TestIdentityDataGet(t *testing.T) {
 		},
 
 		{
-			Name: "float zero: empty state, empty diff", // todo: this should return nothing, right?
+			Name: "float zero: empty state, empty diff",
 			IdentitySchema: map[string]*Schema{
 				"ratio": {
 					Type:              TypeFloat,
@@ -323,791 +323,373 @@ func TestIdentityDataGet(t *testing.T) {
 	}
 }
 
-// func TestIdentityDataGetOk(t *testing.T) {
-// 	cases := []struct {
-// 		IdentitySchema map[string]*Schema
-// 		State          *terraform.InstanceState
-// 		Diff           *terraform.InstanceDiff
-// 		Key            string
-// 		Value          interface{}
-// 		Ok             bool
-// 	}{
-// 		/*
-// 		 * Primitives
-// 		 */
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: &terraform.InstanceDiff{
-// 				Attributes: map[string]*terraform.ResourceAttrDiff{
-// 					"region": {
-// 						Old: "",
-// 						New: "",
-// 					},
-// 				},
-// 			},
-
-// 			Key:   "region",
-// 			Value: "",
-// 			Ok:    false,
-// 		},
-
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: &terraform.InstanceDiff{
-// 				Attributes: map[string]*terraform.ResourceAttrDiff{
-// 					"region": {
-// 						Old:         "",
-// 						New:         "",
-// 						NewComputed: true,
-// 					},
-// 				},
-// 			},
-
-// 			Key:   "region",
-// 			Value: "",
-// 			Ok:    false,
-// 		},
-
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: "",
-// 			Ok:    false,
-// 		},
-
-// 		/*
-// 		 * Lists
-// 		 */
-
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeList,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports",
-// 			Value: []interface{}{},
-// 			Ok:    false,
-// 		},
-
-// 		/*
-// 		 * Map
-// 		 */
-
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeMap,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports",
-// 			Value: map[string]interface{}{},
-// 			Ok:    false,
-// 		},
-
-// 		/*
-// 		 * Set
-// 		 */
-
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set:  func(a interface{}) int { return a.(int) },
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports",
-// 			Value: []interface{}{},
-// 			Ok:    false,
-// 		},
-
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set:  func(a interface{}) int { return a.(int) },
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports.0",
-// 			Value: 0,
-// 			Ok:    false,
-// 		},
-
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set:  func(a interface{}) int { return a.(int) },
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: &terraform.InstanceDiff{
-// 				Attributes: map[string]*terraform.ResourceAttrDiff{
-// 					"ports.#": {
-// 						Old: "0",
-// 						New: "0",
-// 					},
-// 				},
-// 			},
-
-// 			Key:   "ports",
-// 			Value: []interface{}{},
-// 			Ok:    false,
-// 		},
-
-// 		// Further illustrates and clarifies the GetOk semantics from #933, and
-// 		// highlights the limitation that zero-value config is currently
-// 		// indistinguishable from unset config.
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"from_port": {
-// 					Type: TypeInt,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: &terraform.InstanceDiff{
-// 				Attributes: map[string]*terraform.ResourceAttrDiff{
-// 					"from_port": {
-// 						Old: "",
-// 						New: "0",
-// 					},
-// 				},
-// 			},
-
-// 			Key:   "from_port",
-// 			Value: 0,
-// 			Ok:    false,
-// 		},
-// 	}
-
-// 	for i, tc := range cases {
-// 		schema := map[string]*Schema{}
-// 		d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
-// 		if err != nil {
-// 			t.Fatalf("err: %s", err)
-// 		}
-
-// 		v, ok := d.GetOk(tc.Key)
-// 		if s, ok := v.(*Set); ok {
-// 			v = s.List()
-// 		}
-
-// 		if !reflect.DeepEqual(v, tc.Value) {
-// 			t.Fatalf("Bad: %d\n\n%#v", i, v)
-// 		}
-// 		if ok != tc.Ok {
-// 			t.Fatalf("%d: expected ok: %t, got: %t", i, tc.Ok, ok)
-// 		}
-// 	}
-// }
-
-// func TestIdentityDataSet(t *testing.T) {
-// 	var testNilPtr *string
-
-// 	cases := []struct {
-// 		IdentitySchema map[string]*Schema
-// 		State          *terraform.InstanceState
-// 		Diff           *terraform.InstanceDiff
-// 		Key            string
-// 		Value          interface{}
-// 		Err            bool
-// 		GetKey         string
-// 		GetValue       interface{}
-
-// 		// GetPreProcess can be set to munge the return value before being
-// 		// compared to GetValue
-// 		GetPreProcess func(interface{}) interface{}
-// 	}{
-// 		// #0: Basic good
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: "foo",
-
-// 			GetKey:   "region",
-// 			GetValue: "foo",
-// 		},
-
-// 		// #1: Basic int
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"port": {
-// 					Type: TypeInt,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "port",
-// 			Value: 80,
-
-// 			GetKey:   "port",
-// 			GetValue: 80,
-// 		},
-
-// 		// #2: Basic bool
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"vpc": {
-// 					Type: TypeBool,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "vpc",
-// 			Value: true,
-
-// 			GetKey:   "vpc",
-// 			GetValue: true,
-// 		},
-
-// 		// #3
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"vpc": {
-// 					Type: TypeBool,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "vpc",
-// 			Value: false,
-
-// 			GetKey:   "vpc",
-// 			GetValue: false,
-// 		},
-
-// 		// #4: Invalid type
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: 80,
-// 			Err:   true,
-
-// 			GetKey:   "region",
-// 			GetValue: "",
-// 		},
-
-// 		// #5: List of primitives, set list
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeList,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports",
-// 			Value: []int{1, 2, 5},
-
-// 			GetKey:   "ports",
-// 			GetValue: []interface{}{1, 2, 5},
-// 		},
-
-// 		// #6: List of primitives, set list with error
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeList,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ports",
-// 			Value: []interface{}{1, "NOPE", 5},
-// 			Err:   true,
-
-// 			GetKey:   "ports",
-// 			GetValue: []interface{}{},
-// 		},
-
-// 		// #7: Set a list of maps
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"config_vars": {
-// 					Type: TypeList,
-
-// 					Elem: &Schema{
-// 						Type: TypeMap,
-// 					},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key: "config_vars",
-// 			Value: []interface{}{
-// 				map[string]interface{}{
-// 					"foo": "bar",
-// 				},
-// 				map[string]interface{}{
-// 					"bar": "baz",
-// 				},
-// 			},
-// 			Err: false,
-
-// 			GetKey: "config_vars",
-// 			GetValue: []interface{}{
-// 				map[string]interface{}{
-// 					"foo": "bar",
-// 				},
-// 				map[string]interface{}{
-// 					"bar": "baz",
-// 				},
-// 			},
-// 		},
-
-// 		// #8: Set, with list
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set: func(a interface{}) int {
-// 						return a.(int)
-// 					},
-// 				},
-// 			},
-
-// 			State: &terraform.InstanceState{
-// 				Attributes: map[string]string{
-// 					"ports.#": "3",
-// 					"ports.0": "100",
-// 					"ports.1": "80",
-// 					"ports.2": "80",
-// 				},
-// 			},
-
-// 			Key:   "ports",
-// 			Value: []interface{}{100, 125, 125},
-
-// 			GetKey:   "ports",
-// 			GetValue: []interface{}{100, 125},
-// 		},
-
-// 		// #9: Set, with Set
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set: func(a interface{}) int {
-// 						return a.(int)
-// 					},
-// 				},
-// 			},
-
-// 			State: &terraform.InstanceState{
-// 				Attributes: map[string]string{
-// 					"ports.#":   "3",
-// 					"ports.100": "100",
-// 					"ports.80":  "80",
-// 					"ports.81":  "81",
-// 				},
-// 			},
-
-// 			Key: "ports",
-// 			Value: &Set{
-// 				m: map[string]interface{}{
-// 					"1": 1,
-// 					"2": 2,
-// 				},
-// 			},
-
-// 			GetKey:   "ports",
-// 			GetValue: []interface{}{1, 2},
-// 		},
-
-// 		// #10: Set single item
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeInt},
-// 					Set: func(a interface{}) int {
-// 						return a.(int)
-// 					},
-// 				},
-// 			},
-
-// 			State: &terraform.InstanceState{
-// 				Attributes: map[string]string{
-// 					"ports.#":   "2",
-// 					"ports.100": "100",
-// 					"ports.80":  "80",
-// 				},
-// 			},
-
-// 			Key:   "ports.100",
-// 			Value: 256,
-// 			Err:   true,
-
-// 			GetKey:   "ports",
-// 			GetValue: []interface{}{100, 80},
-// 		},
-
-// 		// #11: Set with nested set
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeSet,
-// 					Elem: &Resource{
-// 						Schema: map[string]*Schema{
-// 							"port": {
-// 								Type: TypeInt,
-// 							},
-
-// 							"set": {
-// 								Type: TypeSet,
-// 								Elem: &Schema{Type: TypeInt},
-// 								Set: func(a interface{}) int {
-// 									return a.(int)
-// 								},
-// 							},
-// 						},
-// 					},
-// 					Set: func(a interface{}) int {
-// 						return a.(map[string]interface{})["port"].(int)
-// 					},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Key: "ports",
-// 			Value: []interface{}{
-// 				map[string]interface{}{
-// 					"port": 80,
-// 				},
-// 			},
-
-// 			GetKey: "ports",
-// 			GetValue: []interface{}{
-// 				map[string]interface{}{
-// 					"port": 80,
-// 					"set":  []interface{}{},
-// 				},
-// 			},
-
-// 			GetPreProcess: func(v interface{}) interface{} {
-// 				if v == nil {
-// 					return v
-// 				}
-// 				s, ok := v.([]interface{})
-// 				if !ok {
-// 					return v
-// 				}
-// 				for _, v := range s {
-// 					m, ok := v.(map[string]interface{})
-// 					if !ok {
-// 						continue
-// 					}
-// 					if m["set"] == nil {
-// 						continue
-// 					}
-// 					if s, ok := m["set"].(*Set); ok {
-// 						m["set"] = s.List()
-// 					}
-// 				}
-
-// 				return v
-// 			},
-// 		},
-
-// 		// #12: List of floats, set list
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ratios": {
-// 					Type: TypeList,
-
-// 					Elem: &Schema{Type: TypeFloat},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ratios",
-// 			Value: []float64{1.0, 2.2, 5.5},
-
-// 			GetKey:   "ratios",
-// 			GetValue: []interface{}{1.0, 2.2, 5.5},
-// 		},
-
-// 		// #12: Set of floats, set list
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ratios": {
-// 					Type: TypeSet,
-
-// 					Elem: &Schema{Type: TypeFloat},
-// 					Set: func(a interface{}) int {
-// 						return int(math.Float64bits(a.(float64)))
-// 					},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "ratios",
-// 			Value: []float64{1.0, 2.2, 5.5},
-
-// 			GetKey:   "ratios",
-// 			GetValue: []interface{}{1.0, 2.2, 5.5},
-// 		},
-
-// 		// #13: Basic pointer
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: testPtrTo("foo"),
-
-// 			GetKey:   "region",
-// 			GetValue: "foo",
-// 		},
-
-// 		// #14: Basic nil value
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: testPtrTo(nil),
-
-// 			GetKey:   "region",
-// 			GetValue: "",
-// 		},
-
-// 		// #15: Basic nil pointer
-// 		{
-// 			IdentitySchema: map[string]*Schema{
-// 				"region": {
-// 					Type:              TypeString,
-// 					RequiredForImport: true,
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Diff: nil,
-
-// 			Key:   "region",
-// 			Value: testNilPtr,
-
-// 			GetKey:   "region",
-// 			GetValue: "",
-// 		},
-
-// 		// #16: Set in a list
-// 		{
-// 			Schema: map[string]*Schema{
-// 				"ports": {
-// 					Type: TypeList,
-// 					Elem: &Resource{
-// 						Schema: map[string]*Schema{
-// 							"set": {
-// 								Type: TypeSet,
-// 								Elem: &Schema{Type: TypeInt},
-// 								Set: func(a interface{}) int {
-// 									return a.(int)
-// 								},
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-
-// 			State: nil,
-
-// 			Key: "ports",
-// 			Value: []interface{}{
-// 				map[string]interface{}{
-// 					"set": []interface{}{
-// 						1,
-// 					},
-// 				},
-// 			},
-
-// 			GetKey: "ports",
-// 			GetValue: []interface{}{
-// 				map[string]interface{}{
-// 					"set": []interface{}{
-// 						1,
-// 					},
-// 				},
-// 			},
-// 			GetPreProcess: func(v interface{}) interface{} {
-// 				if v == nil {
-// 					return v
-// 				}
-// 				s, ok := v.([]interface{})
-// 				if !ok {
-// 					return v
-// 				}
-// 				for _, v := range s {
-// 					m, ok := v.(map[string]interface{})
-// 					if !ok {
-// 						continue
-// 					}
-// 					if m["set"] == nil {
-// 						continue
-// 					}
-// 					if s, ok := m["set"].(*Set); ok {
-// 						m["set"] = s.List()
-// 					}
-// 				}
-
-// 				return v
-// 			},
-// 		},
-// 	}
-
-// 	for i, tc := range cases {
-// 		schema := map[string]*Schema{}
-
-// 		d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
-// 		if err != nil {
-// 			t.Fatalf("err: %s", err)
-// 		}
-
-// 		err = d.Set(tc.Key, tc.Value)
-// 		if err != nil != tc.Err {
-// 			t.Fatalf("%d err: %s", i, err)
-// 		}
-
-// 		v := d.Get(tc.GetKey)
-// 		if s, ok := v.(*Set); ok {
-// 			v = s.List()
-// 		}
-
-// 		if tc.GetPreProcess != nil {
-// 			v = tc.GetPreProcess(v)
-// 		}
-
-// 		if !reflect.DeepEqual(v, tc.GetValue) {
-// 			t.Fatalf("Get Bad: %d\n\n%#v", i, v)
-// 		}
-// 	}
-// }
+func TestIdentityDataGetOk(t *testing.T) {
+	cases := []struct {
+		IdentitySchema map[string]*Schema
+		State          *terraform.InstanceState
+		Diff           *terraform.InstanceDiff
+		Key            string
+		Value          interface{}
+		Ok             bool
+	}{
+		/*
+		 * Primitives
+		 */
+		{
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: &terraform.InstanceDiff{
+				Identity: map[string]string{
+					"region": "",
+				},
+			},
+
+			Key:   "region",
+			Value: "",
+			Ok:    false,
+		},
+
+		{
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: "",
+			Ok:    false,
+		},
+
+		/*
+		 * Lists
+		 */
+
+		{
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type:              TypeList,
+					Elem:              &Schema{Type: TypeInt},
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "ports",
+			Value: []interface{}{},
+			Ok:    false,
+		},
+	}
+
+	for i, tc := range cases {
+		schema := map[string]*Schema{}
+		d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		identity, err := d.Identity()
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v, ok := identity.GetOk(tc.Key)
+		if s, ok := v.(*Set); ok {
+			v = s.List()
+		}
+
+		if !reflect.DeepEqual(v, tc.Value) {
+			t.Fatalf("Bad: %d\n\n%#v", i, v)
+		}
+		if ok != tc.Ok {
+			t.Fatalf("%d: expected ok: %t, got: %t", i, tc.Ok, ok)
+		}
+	}
+}
+
+func TestIdentityDataSet(t *testing.T) {
+	var testNilPtr *string
+
+	cases := []struct {
+		Name           string
+		IdentitySchema map[string]*Schema
+		State          *terraform.InstanceState
+		Diff           *terraform.InstanceDiff
+		Key            string
+		Value          interface{}
+		Err            bool
+		GetKey         string
+		GetValue       interface{}
+	}{
+		{
+			Name: "basic good",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: "foo",
+
+			GetKey:   "region",
+			GetValue: "foo",
+		},
+
+		{
+			Name: "basic int",
+			IdentitySchema: map[string]*Schema{
+				"port": {
+					Type: TypeInt,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "port",
+			Value: 80,
+
+			GetKey:   "port",
+			GetValue: 80,
+		},
+
+		{
+			Name: "basic bool",
+			IdentitySchema: map[string]*Schema{
+				"vpc": {
+					Type: TypeBool,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "vpc",
+			Value: true,
+
+			GetKey:   "vpc",
+			GetValue: true,
+		},
+
+		{
+			Name: "basic bool false",
+			IdentitySchema: map[string]*Schema{
+				"vpc": {
+					Type: TypeBool,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "vpc",
+			Value: false,
+
+			GetKey:   "vpc",
+			GetValue: false,
+		},
+
+		{
+			Name: "invalid type",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: 80,
+			Err:   true,
+
+			GetKey:   "region",
+			GetValue: "",
+		},
+
+		{
+			Name: "list of primitives - set list",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type: TypeList,
+
+					Elem: &Schema{Type: TypeInt},
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "ports",
+			Value: []int{1, 2, 5},
+
+			GetKey:   "ports",
+			GetValue: []interface{}{1, 2, 5},
+		},
+
+		{
+			Name: "list of primitives - set list with error",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type: TypeList,
+
+					Elem: &Schema{Type: TypeInt},
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "ports",
+			Value: []interface{}{1, "NOPE", 5},
+			Err:   true,
+
+			GetKey:   "ports",
+			GetValue: []interface{}{},
+		},
+
+		{
+			Name: "list of floats - set list",
+			IdentitySchema: map[string]*Schema{
+				"ratios": {
+					Type: TypeList,
+
+					Elem: &Schema{Type: TypeFloat},
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "ratios",
+			Value: []float64{1.0, 2.2, 5.5},
+
+			GetKey:   "ratios",
+			GetValue: []interface{}{1.0, 2.2, 5.5},
+		},
+
+		{
+			Name: "basic pointer",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: testPtrTo("foo"),
+
+			GetKey:   "region",
+			GetValue: "foo",
+		},
+
+		{
+			Name: "basic nil value",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: testPtrTo(nil),
+
+			GetKey:   "region",
+			GetValue: "",
+		},
+
+		{
+			Name: "basic nil pointer",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key:   "region",
+			Value: testNilPtr,
+
+			GetKey:   "region",
+			GetValue: "",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+
+			schema := map[string]*Schema{}
+
+			d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			identity, err := d.Identity()
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			err = identity.Set(tc.Key, tc.Value)
+			if err != nil != tc.Err {
+				t.Fatalf("%d err: %s", i, err)
+			}
+
+			// we retrieve a new identity to ensure memoization is working
+			identity, err = d.Identity()
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			v := identity.Get(tc.GetKey)
+
+			if !reflect.DeepEqual(v, tc.GetValue) {
+				t.Fatalf("Get Bad: %d\n\n%#v", i, v)
+			}
+		})
+	}
+}

--- a/helper/schema/identity_data_test.go
+++ b/helper/schema/identity_data_test.go
@@ -11,16 +11,14 @@ import (
 )
 
 func TestIdentityDataGet(t *testing.T) {
-	cases := []struct {
-		Name           string
+	cases := map[string]struct {
 		IdentitySchema map[string]*Schema
 		State          *terraform.InstanceState
 		Diff           *terraform.InstanceDiff
 		Key            string
 		Value          interface{}
 	}{
-		{
-			Name: "no state, empty diff",
+		"no state, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -36,8 +34,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: "",
 		},
 
-		{
-			Name: "no state, diff with identity",
+		"no state, diff with identity": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -57,8 +54,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: "foo",
 		},
 
-		{
-			Name: "state with identity, no diff",
+		"state with identity, no diff": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -79,8 +75,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: "bar",
 		},
 
-		{
-			Name: "state with identity, empty diff",
+		"state with identity, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -100,8 +95,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: "foo", // This is different than for resource data – which would be empty
 		},
 
-		{
-			Name: "int type: state with identity, no diff",
+		"int type: state with identity, no diff": {
 			IdentitySchema: map[string]*Schema{
 				"port": {
 					Type:              TypeInt,
@@ -122,8 +116,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 80,
 		},
 
-		{
-			Name: "int list type: state with identity, empty diff",
+		"int list type: state with identity, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type:              TypeList,
@@ -146,8 +139,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 2,
 		},
 
-		{
-			Name: "int list type length: state with identity, empty diff",
+		"int list type length: state with identity, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type: TypeList,
@@ -169,8 +161,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 3,
 		},
 
-		{
-			Name: "int list type length: empty state, empty diff",
+		"int list type length: empty state, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type:              TypeList,
@@ -186,8 +177,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 0,
 		},
 
-		{
-			Name: "int list type all: state with identity, empty diff",
+		"int list type all: state with identity, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type:              TypeList,
@@ -210,8 +200,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: []interface{}{1, 2, 5},
 		},
 
-		{
-			Name: "full object: empty state, diff with identity",
+		"full object: empty state, diff with identity": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -234,8 +223,7 @@ func TestIdentityDataGet(t *testing.T) {
 			},
 		},
 
-		{
-			Name: "float zero: empty state, empty diff",
+		"float zero: empty state, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ratio": {
 					Type:              TypeFloat,
@@ -252,8 +240,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 0.0,
 		},
 
-		{
-			Name: "float: state with identity, empty diff",
+		"float: state with identity, empty diff": {
 			IdentitySchema: map[string]*Schema{
 				"ratio": {
 					Type:              TypeFloat,
@@ -274,8 +261,7 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: 0.5,
 		},
 
-		{
-			Name: "float: state with identity, diff with identity",
+		"float: state with identity, diff with identity": {
 			IdentitySchema: map[string]*Schema{
 				"ratio": {
 					Type:              TypeFloat,
@@ -301,8 +287,8 @@ func TestIdentityDataGet(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			schema := map[string]*Schema{}
 			d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
 			if err != nil {
@@ -317,7 +303,7 @@ func TestIdentityDataGet(t *testing.T) {
 			v := identity.Get(tc.Key)
 
 			if !reflect.DeepEqual(v, tc.Value) {
-				t.Fatalf("Bad: %d\n\n%#v\n\nExpected: %#v", i, v, tc.Value)
+				t.Fatalf("Bad: %s\n\n%#v\n\nExpected: %#v", name, v, tc.Value)
 			}
 		})
 	}
@@ -425,8 +411,7 @@ func TestIdentityDataGetOk(t *testing.T) {
 func TestIdentityDataSet(t *testing.T) {
 	var testNilPtr *string
 
-	cases := []struct {
-		Name           string
+	cases := map[string]struct {
 		IdentitySchema map[string]*Schema
 		State          *terraform.InstanceState
 		Diff           *terraform.InstanceDiff
@@ -436,8 +421,7 @@ func TestIdentityDataSet(t *testing.T) {
 		GetKey         string
 		GetValue       interface{}
 	}{
-		{
-			Name: "basic good",
+		"basic string": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -456,8 +440,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: "foo",
 		},
 
-		{
-			Name: "basic int",
+		"basic int": {
 			IdentitySchema: map[string]*Schema{
 				"port": {
 					Type: TypeInt,
@@ -475,8 +458,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: 80,
 		},
 
-		{
-			Name: "basic bool",
+		"basic bool": {
 			IdentitySchema: map[string]*Schema{
 				"vpc": {
 					Type: TypeBool,
@@ -494,8 +476,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: true,
 		},
 
-		{
-			Name: "basic bool false",
+		"basic bool false": {
 			IdentitySchema: map[string]*Schema{
 				"vpc": {
 					Type: TypeBool,
@@ -513,8 +494,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: false,
 		},
 
-		{
-			Name: "invalid type",
+		"invalid type": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -534,8 +514,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: "",
 		},
 
-		{
-			Name: "list of primitives - set list",
+		"list of primitives - set list": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type: TypeList,
@@ -555,8 +534,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: []interface{}{1, 2, 5},
 		},
 
-		{
-			Name: "list of primitives - set list with error",
+		"list of primitives - set list with error": {
 			IdentitySchema: map[string]*Schema{
 				"ports": {
 					Type: TypeList,
@@ -577,8 +555,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: []interface{}{},
 		},
 
-		{
-			Name: "list of floats - set list",
+		"list of floats - set list": {
 			IdentitySchema: map[string]*Schema{
 				"ratios": {
 					Type: TypeList,
@@ -598,8 +575,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: []interface{}{1.0, 2.2, 5.5},
 		},
 
-		{
-			Name: "basic pointer",
+		"basic pointer": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -618,8 +594,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: "foo",
 		},
 
-		{
-			Name: "basic nil value",
+		"basic nil value": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -638,8 +613,7 @@ func TestIdentityDataSet(t *testing.T) {
 			GetValue: "",
 		},
 
-		{
-			Name: "basic nil pointer",
+		"basic nil pointer": {
 			IdentitySchema: map[string]*Schema{
 				"region": {
 					Type:              TypeString,
@@ -659,8 +633,8 @@ func TestIdentityDataSet(t *testing.T) {
 		},
 	}
 
-	for i, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 
 			schema := map[string]*Schema{}
 
@@ -676,7 +650,7 @@ func TestIdentityDataSet(t *testing.T) {
 
 			err = identity.Set(tc.Key, tc.Value)
 			if err != nil != tc.Err {
-				t.Fatalf("%d err: %s", i, err)
+				t.Fatalf("%s err: %s", name, err)
 			}
 
 			// we retrieve a new identity to ensure memoization is working
@@ -688,7 +662,7 @@ func TestIdentityDataSet(t *testing.T) {
 			v := identity.Get(tc.GetKey)
 
 			if !reflect.DeepEqual(v, tc.GetValue) {
-				t.Fatalf("Get Bad: %d\n\n%#v", i, v)
+				t.Fatalf("Get Bad: %s\n\n%#v", name, v)
 			}
 		})
 	}

--- a/helper/schema/identity_data_test.go
+++ b/helper/schema/identity_data_test.go
@@ -57,8 +57,6 @@ func TestIdentityDataGet(t *testing.T) {
 			Value: "foo",
 		},
 
-		// TODO: these numbers are off since i removed some cases -> remove them
-		// #3
 		{
 			Name: "state with identity, no diff",
 			IdentitySchema: map[string]*Schema{
@@ -99,10 +97,9 @@ func TestIdentityDataGet(t *testing.T) {
 			Diff: &terraform.InstanceDiff{},
 
 			Key:   "region",
-			Value: "",
+			Value: "foo", // This is different than for resource data – which would be empty
 		},
 
-		// #5
 		{
 			Name: "int type: state with identity, no diff",
 			IdentitySchema: map[string]*Schema{
@@ -113,7 +110,7 @@ func TestIdentityDataGet(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
-				Attributes: map[string]string{
+				Identity: map[string]string{
 					"port": "80",
 				},
 			},
@@ -136,7 +133,7 @@ func TestIdentityDataGet(t *testing.T) {
 			},
 
 			State: &terraform.InstanceState{
-				Attributes: map[string]string{
+				Identity: map[string]string{
 					"ports.#": "3",
 					"ports.0": "1",
 					"ports.1": "2",

--- a/helper/schema/identity_data_test.go
+++ b/helper/schema/identity_data_test.go
@@ -1,0 +1,1116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestIdentityDataGet(t *testing.T) {
+	cases := []struct {
+		Name           string
+		IdentitySchema map[string]*Schema
+		State          *terraform.InstanceState
+		Diff           *terraform.InstanceDiff
+		Key            string
+		Value          interface{}
+	}{
+		{
+			Name: "no state, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: &terraform.InstanceDiff{},
+
+			Key:   "region",
+			Value: "",
+		},
+
+		{
+			Name: "no state, diff with identity",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: &terraform.InstanceDiff{
+				Identity: map[string]string{
+					"region": "foo",
+				},
+			},
+
+			Key:   "region",
+			Value: "foo",
+		},
+
+		// TODO: these numbers are off since i removed some cases -> remove them
+		// #3
+		{
+			Name: "state with identity, no diff",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"region": "bar",
+				},
+			},
+
+			Diff: nil,
+
+			Key: "region",
+
+			Value: "bar",
+		},
+
+		{
+			Name: "state with identity, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"region": "foo",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{},
+
+			Key:   "region",
+			Value: "",
+		},
+
+		// #5
+		{
+			Name: "int type: state with identity, no diff",
+			IdentitySchema: map[string]*Schema{
+				"port": {
+					Type:              TypeInt,
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"port": "80",
+				},
+			},
+
+			Diff: nil,
+
+			Key: "port",
+
+			Value: 80,
+		},
+
+		{
+			Name: "int list type: state with identity, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type:              TypeList,
+					Elem:              &Schema{Type: TypeInt},
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"ports.#": "3",
+					"ports.0": "1",
+					"ports.1": "2",
+					"ports.2": "5",
+				},
+			},
+
+			Key: "ports.1",
+
+			Value: 2,
+		},
+
+		{
+			Name: "int list type length: state with identity, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type: TypeList,
+					Elem: &Schema{Type: TypeInt},
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"ports.#": "3",
+					"ports.0": "1",
+					"ports.1": "2",
+					"ports.2": "5",
+				},
+			},
+
+			Key: "ports.#",
+
+			Value: 3,
+		},
+
+		{
+			Name: "int list type length: empty state, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type:              TypeList,
+					Elem:              &Schema{Type: TypeInt},
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Key: "ports.#",
+
+			Value: 0,
+		},
+
+		{
+			Name: "int list type all: state with identity, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"ports": {
+					Type:              TypeList,
+					Elem:              &Schema{Type: TypeInt},
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"ports.#": "3",
+					"ports.0": "1",
+					"ports.1": "2",
+					"ports.2": "5",
+				},
+			},
+
+			Key: "ports",
+
+			Value: []interface{}{1, 2, 5},
+		},
+
+		{
+			Name: "full object: empty state, diff with identity",
+			IdentitySchema: map[string]*Schema{
+				"region": {
+					Type:              TypeString,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: &terraform.InstanceDiff{
+				Identity: map[string]string{
+					"region": "foo",
+				},
+			},
+
+			Key: "",
+
+			Value: map[string]interface{}{
+				"region": "foo",
+			},
+		},
+
+		{
+			Name: "float zero: empty state, empty diff", // todo: this should return nothing, right?
+			IdentitySchema: map[string]*Schema{
+				"ratio": {
+					Type:              TypeFloat,
+					RequiredForImport: true,
+				},
+			},
+
+			State: nil,
+
+			Diff: nil,
+
+			Key: "ratio",
+
+			Value: 0.0,
+		},
+
+		{
+			Name: "float: state with identity, empty diff",
+			IdentitySchema: map[string]*Schema{
+				"ratio": {
+					Type:              TypeFloat,
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"ratio": "0.5",
+				},
+			},
+
+			Diff: nil,
+
+			Key: "ratio",
+
+			Value: 0.5,
+		},
+
+		{
+			Name: "float: state with identity, diff with identity",
+			IdentitySchema: map[string]*Schema{
+				"ratio": {
+					Type:              TypeFloat,
+					RequiredForImport: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Identity: map[string]string{
+					"ratio": "-0.5",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Identity: map[string]string{
+					"ratio": "33.0",
+				},
+			},
+
+			Key: "ratio",
+
+			Value: 33.0,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			schema := map[string]*Schema{}
+			d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			identity, err := d.Identity()
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			v := identity.Get(tc.Key)
+
+			if !reflect.DeepEqual(v, tc.Value) {
+				t.Fatalf("Bad: %d\n\n%#v\n\nExpected: %#v", i, v, tc.Value)
+			}
+		})
+	}
+}
+
+// func TestIdentityDataGetOk(t *testing.T) {
+// 	cases := []struct {
+// 		IdentitySchema map[string]*Schema
+// 		State          *terraform.InstanceState
+// 		Diff           *terraform.InstanceDiff
+// 		Key            string
+// 		Value          interface{}
+// 		Ok             bool
+// 	}{
+// 		/*
+// 		 * Primitives
+// 		 */
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: &terraform.InstanceDiff{
+// 				Attributes: map[string]*terraform.ResourceAttrDiff{
+// 					"region": {
+// 						Old: "",
+// 						New: "",
+// 					},
+// 				},
+// 			},
+
+// 			Key:   "region",
+// 			Value: "",
+// 			Ok:    false,
+// 		},
+
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: &terraform.InstanceDiff{
+// 				Attributes: map[string]*terraform.ResourceAttrDiff{
+// 					"region": {
+// 						Old:         "",
+// 						New:         "",
+// 						NewComputed: true,
+// 					},
+// 				},
+// 			},
+
+// 			Key:   "region",
+// 			Value: "",
+// 			Ok:    false,
+// 		},
+
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: "",
+// 			Ok:    false,
+// 		},
+
+// 		/*
+// 		 * Lists
+// 		 */
+
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeList,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports",
+// 			Value: []interface{}{},
+// 			Ok:    false,
+// 		},
+
+// 		/*
+// 		 * Map
+// 		 */
+
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeMap,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports",
+// 			Value: map[string]interface{}{},
+// 			Ok:    false,
+// 		},
+
+// 		/*
+// 		 * Set
+// 		 */
+
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set:  func(a interface{}) int { return a.(int) },
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports",
+// 			Value: []interface{}{},
+// 			Ok:    false,
+// 		},
+
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set:  func(a interface{}) int { return a.(int) },
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports.0",
+// 			Value: 0,
+// 			Ok:    false,
+// 		},
+
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set:  func(a interface{}) int { return a.(int) },
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: &terraform.InstanceDiff{
+// 				Attributes: map[string]*terraform.ResourceAttrDiff{
+// 					"ports.#": {
+// 						Old: "0",
+// 						New: "0",
+// 					},
+// 				},
+// 			},
+
+// 			Key:   "ports",
+// 			Value: []interface{}{},
+// 			Ok:    false,
+// 		},
+
+// 		// Further illustrates and clarifies the GetOk semantics from #933, and
+// 		// highlights the limitation that zero-value config is currently
+// 		// indistinguishable from unset config.
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"from_port": {
+// 					Type: TypeInt,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: &terraform.InstanceDiff{
+// 				Attributes: map[string]*terraform.ResourceAttrDiff{
+// 					"from_port": {
+// 						Old: "",
+// 						New: "0",
+// 					},
+// 				},
+// 			},
+
+// 			Key:   "from_port",
+// 			Value: 0,
+// 			Ok:    false,
+// 		},
+// 	}
+
+// 	for i, tc := range cases {
+// 		schema := map[string]*Schema{}
+// 		d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
+// 		if err != nil {
+// 			t.Fatalf("err: %s", err)
+// 		}
+
+// 		v, ok := d.GetOk(tc.Key)
+// 		if s, ok := v.(*Set); ok {
+// 			v = s.List()
+// 		}
+
+// 		if !reflect.DeepEqual(v, tc.Value) {
+// 			t.Fatalf("Bad: %d\n\n%#v", i, v)
+// 		}
+// 		if ok != tc.Ok {
+// 			t.Fatalf("%d: expected ok: %t, got: %t", i, tc.Ok, ok)
+// 		}
+// 	}
+// }
+
+// func TestIdentityDataSet(t *testing.T) {
+// 	var testNilPtr *string
+
+// 	cases := []struct {
+// 		IdentitySchema map[string]*Schema
+// 		State          *terraform.InstanceState
+// 		Diff           *terraform.InstanceDiff
+// 		Key            string
+// 		Value          interface{}
+// 		Err            bool
+// 		GetKey         string
+// 		GetValue       interface{}
+
+// 		// GetPreProcess can be set to munge the return value before being
+// 		// compared to GetValue
+// 		GetPreProcess func(interface{}) interface{}
+// 	}{
+// 		// #0: Basic good
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: "foo",
+
+// 			GetKey:   "region",
+// 			GetValue: "foo",
+// 		},
+
+// 		// #1: Basic int
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"port": {
+// 					Type: TypeInt,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "port",
+// 			Value: 80,
+
+// 			GetKey:   "port",
+// 			GetValue: 80,
+// 		},
+
+// 		// #2: Basic bool
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"vpc": {
+// 					Type: TypeBool,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "vpc",
+// 			Value: true,
+
+// 			GetKey:   "vpc",
+// 			GetValue: true,
+// 		},
+
+// 		// #3
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"vpc": {
+// 					Type: TypeBool,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "vpc",
+// 			Value: false,
+
+// 			GetKey:   "vpc",
+// 			GetValue: false,
+// 		},
+
+// 		// #4: Invalid type
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: 80,
+// 			Err:   true,
+
+// 			GetKey:   "region",
+// 			GetValue: "",
+// 		},
+
+// 		// #5: List of primitives, set list
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeList,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports",
+// 			Value: []int{1, 2, 5},
+
+// 			GetKey:   "ports",
+// 			GetValue: []interface{}{1, 2, 5},
+// 		},
+
+// 		// #6: List of primitives, set list with error
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeList,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ports",
+// 			Value: []interface{}{1, "NOPE", 5},
+// 			Err:   true,
+
+// 			GetKey:   "ports",
+// 			GetValue: []interface{}{},
+// 		},
+
+// 		// #7: Set a list of maps
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"config_vars": {
+// 					Type: TypeList,
+
+// 					Elem: &Schema{
+// 						Type: TypeMap,
+// 					},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key: "config_vars",
+// 			Value: []interface{}{
+// 				map[string]interface{}{
+// 					"foo": "bar",
+// 				},
+// 				map[string]interface{}{
+// 					"bar": "baz",
+// 				},
+// 			},
+// 			Err: false,
+
+// 			GetKey: "config_vars",
+// 			GetValue: []interface{}{
+// 				map[string]interface{}{
+// 					"foo": "bar",
+// 				},
+// 				map[string]interface{}{
+// 					"bar": "baz",
+// 				},
+// 			},
+// 		},
+
+// 		// #8: Set, with list
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set: func(a interface{}) int {
+// 						return a.(int)
+// 					},
+// 				},
+// 			},
+
+// 			State: &terraform.InstanceState{
+// 				Attributes: map[string]string{
+// 					"ports.#": "3",
+// 					"ports.0": "100",
+// 					"ports.1": "80",
+// 					"ports.2": "80",
+// 				},
+// 			},
+
+// 			Key:   "ports",
+// 			Value: []interface{}{100, 125, 125},
+
+// 			GetKey:   "ports",
+// 			GetValue: []interface{}{100, 125},
+// 		},
+
+// 		// #9: Set, with Set
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set: func(a interface{}) int {
+// 						return a.(int)
+// 					},
+// 				},
+// 			},
+
+// 			State: &terraform.InstanceState{
+// 				Attributes: map[string]string{
+// 					"ports.#":   "3",
+// 					"ports.100": "100",
+// 					"ports.80":  "80",
+// 					"ports.81":  "81",
+// 				},
+// 			},
+
+// 			Key: "ports",
+// 			Value: &Set{
+// 				m: map[string]interface{}{
+// 					"1": 1,
+// 					"2": 2,
+// 				},
+// 			},
+
+// 			GetKey:   "ports",
+// 			GetValue: []interface{}{1, 2},
+// 		},
+
+// 		// #10: Set single item
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeInt},
+// 					Set: func(a interface{}) int {
+// 						return a.(int)
+// 					},
+// 				},
+// 			},
+
+// 			State: &terraform.InstanceState{
+// 				Attributes: map[string]string{
+// 					"ports.#":   "2",
+// 					"ports.100": "100",
+// 					"ports.80":  "80",
+// 				},
+// 			},
+
+// 			Key:   "ports.100",
+// 			Value: 256,
+// 			Err:   true,
+
+// 			GetKey:   "ports",
+// 			GetValue: []interface{}{100, 80},
+// 		},
+
+// 		// #11: Set with nested set
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeSet,
+// 					Elem: &Resource{
+// 						Schema: map[string]*Schema{
+// 							"port": {
+// 								Type: TypeInt,
+// 							},
+
+// 							"set": {
+// 								Type: TypeSet,
+// 								Elem: &Schema{Type: TypeInt},
+// 								Set: func(a interface{}) int {
+// 									return a.(int)
+// 								},
+// 							},
+// 						},
+// 					},
+// 					Set: func(a interface{}) int {
+// 						return a.(map[string]interface{})["port"].(int)
+// 					},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Key: "ports",
+// 			Value: []interface{}{
+// 				map[string]interface{}{
+// 					"port": 80,
+// 				},
+// 			},
+
+// 			GetKey: "ports",
+// 			GetValue: []interface{}{
+// 				map[string]interface{}{
+// 					"port": 80,
+// 					"set":  []interface{}{},
+// 				},
+// 			},
+
+// 			GetPreProcess: func(v interface{}) interface{} {
+// 				if v == nil {
+// 					return v
+// 				}
+// 				s, ok := v.([]interface{})
+// 				if !ok {
+// 					return v
+// 				}
+// 				for _, v := range s {
+// 					m, ok := v.(map[string]interface{})
+// 					if !ok {
+// 						continue
+// 					}
+// 					if m["set"] == nil {
+// 						continue
+// 					}
+// 					if s, ok := m["set"].(*Set); ok {
+// 						m["set"] = s.List()
+// 					}
+// 				}
+
+// 				return v
+// 			},
+// 		},
+
+// 		// #12: List of floats, set list
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ratios": {
+// 					Type: TypeList,
+
+// 					Elem: &Schema{Type: TypeFloat},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ratios",
+// 			Value: []float64{1.0, 2.2, 5.5},
+
+// 			GetKey:   "ratios",
+// 			GetValue: []interface{}{1.0, 2.2, 5.5},
+// 		},
+
+// 		// #12: Set of floats, set list
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ratios": {
+// 					Type: TypeSet,
+
+// 					Elem: &Schema{Type: TypeFloat},
+// 					Set: func(a interface{}) int {
+// 						return int(math.Float64bits(a.(float64)))
+// 					},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "ratios",
+// 			Value: []float64{1.0, 2.2, 5.5},
+
+// 			GetKey:   "ratios",
+// 			GetValue: []interface{}{1.0, 2.2, 5.5},
+// 		},
+
+// 		// #13: Basic pointer
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: testPtrTo("foo"),
+
+// 			GetKey:   "region",
+// 			GetValue: "foo",
+// 		},
+
+// 		// #14: Basic nil value
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: testPtrTo(nil),
+
+// 			GetKey:   "region",
+// 			GetValue: "",
+// 		},
+
+// 		// #15: Basic nil pointer
+// 		{
+// 			IdentitySchema: map[string]*Schema{
+// 				"region": {
+// 					Type:              TypeString,
+// 					RequiredForImport: true,
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Diff: nil,
+
+// 			Key:   "region",
+// 			Value: testNilPtr,
+
+// 			GetKey:   "region",
+// 			GetValue: "",
+// 		},
+
+// 		// #16: Set in a list
+// 		{
+// 			Schema: map[string]*Schema{
+// 				"ports": {
+// 					Type: TypeList,
+// 					Elem: &Resource{
+// 						Schema: map[string]*Schema{
+// 							"set": {
+// 								Type: TypeSet,
+// 								Elem: &Schema{Type: TypeInt},
+// 								Set: func(a interface{}) int {
+// 									return a.(int)
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+
+// 			State: nil,
+
+// 			Key: "ports",
+// 			Value: []interface{}{
+// 				map[string]interface{}{
+// 					"set": []interface{}{
+// 						1,
+// 					},
+// 				},
+// 			},
+
+// 			GetKey: "ports",
+// 			GetValue: []interface{}{
+// 				map[string]interface{}{
+// 					"set": []interface{}{
+// 						1,
+// 					},
+// 				},
+// 			},
+// 			GetPreProcess: func(v interface{}) interface{} {
+// 				if v == nil {
+// 					return v
+// 				}
+// 				s, ok := v.([]interface{})
+// 				if !ok {
+// 					return v
+// 				}
+// 				for _, v := range s {
+// 					m, ok := v.(map[string]interface{})
+// 					if !ok {
+// 						continue
+// 					}
+// 					if m["set"] == nil {
+// 						continue
+// 					}
+// 					if s, ok := m["set"].(*Set); ok {
+// 						m["set"] = s.List()
+// 					}
+// 				}
+
+// 				return v
+// 			},
+// 		},
+// 	}
+
+// 	for i, tc := range cases {
+// 		schema := map[string]*Schema{}
+
+// 		d, err := schemaMapWithIdentity{schema, tc.IdentitySchema}.Data(tc.State, tc.Diff)
+// 		if err != nil {
+// 			t.Fatalf("err: %s", err)
+// 		}
+
+// 		err = d.Set(tc.Key, tc.Value)
+// 		if err != nil != tc.Err {
+// 			t.Fatalf("%d err: %s", i, err)
+// 		}
+
+// 		v := d.Get(tc.GetKey)
+// 		if s, ok := v.(*Set); ok {
+// 			v = s.List()
+// 		}
+
+// 		if tc.GetPreProcess != nil {
+// 			v = tc.GetPreProcess(v)
+// 		}
+
+// 		if !reflect.DeepEqual(v, tc.GetValue) {
+// 			t.Fatalf("Get Bad: %d\n\n%#v", i, v)
+// 		}
+// 	}
+// }

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -750,6 +750,9 @@ func (d *ResourceData) Identity() (*IdentityData, error) {
 	if d.state != nil && d.state.Identity != nil {
 		identityData = d.state.Identity
 	}
+	if d.diff != nil && d.diff.Identity != nil {
+		identityData = d.diff.Identity
+	}
 
 	d.newIdentity = &IdentityData{
 		schema:       d.identitySchema,


### PR DESCRIPTION
This PR adds tests for `identity_data.go` inspired by existing tests for `resource_data.go`.

This uncovered a flaw in the current implementation, when it comes to non-string identity attributes which currently don't work.

To quote the relevant commit message on this:
>  Switch to using multiple field readers in IdentityData
>
> This resembles the behaviour in `ResourceData` more closely. Specifically,
this makes it possible to have number values in the source identity sent by
Terraform that are encoded as strings. Before this commit this failed as the
field writer does not allow to write strings for fields that are typed as
integers in the schema, which is what we did to initialize the result.