### PR TITLE
support importing by resource identity

### DIFF
--- a/helper/logging/logging_http_transport_test.go
+++ b/helper/logging/logging_http_transport_test.go
@@ -31,7 +31,7 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 	reqBody := `An example
 		multiline
 		request body`
-	req, _ := http.NewRequest("GET", "https://www.terraform.io", bytes.NewBufferString(reqBody))
+	req, _ := http.NewRequest("GET", "https://developer.hashicorp.com/terraform", bytes.NewBufferString(reqBody))
 	res, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -40,7 +40,7 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 
 	entries, err := tflogtest.MultilineJSONDecode(loggerOutput)
 	if err != nil {
-		t.Fatalf("log outtput parsing failed: %v", err)
+		t.Fatalf("log output parsing failed: %v", err)
 	}
 
 	if len(entries) != 2 {
@@ -67,12 +67,12 @@ func TestNewLoggingHTTPTransport(t *testing.T) {
 		"@module":             "provider",
 		"tf_http_op_type":     "request",
 		"tf_http_req_method":  "GET",
-		"tf_http_req_uri":     "/",
+		"tf_http_req_uri":     "/terraform",
 		"tf_http_req_version": "HTTP/1.1",
 		"tf_http_req_body":    "An example multiline request body",
 		"tf_http_trans_id":    transId,
 		"Accept-Encoding":     "gzip",
-		"Host":                "www.terraform.io",
+		"Host":                "developer.hashicorp.com",
 		"User-Agent":          "Go-http-client/1.1",
 		"Content-Length":      "37",
 	}); diff != "" {
@@ -122,7 +122,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 	reqBody := `An example
 		multiline
 		request body`
-	req, _ := http.NewRequest("GET", "https://www.terraform.io", bytes.NewBufferString(reqBody))
+	req, _ := http.NewRequest("GET", "https://developer.hashicorp.com/terraform", bytes.NewBufferString(reqBody))
 	res, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -158,12 +158,12 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 		"@module":             "provider.test-subsystem",
 		"tf_http_op_type":     "request",
 		"tf_http_req_method":  "GET",
-		"tf_http_req_uri":     "/",
+		"tf_http_req_uri":     "/terraform",
 		"tf_http_req_version": "HTTP/1.1",
 		"tf_http_req_body":    "An example multiline request body",
 		"tf_http_trans_id":    transId,
 		"Accept-Encoding":     "gzip",
-		"Host":                "www.terraform.io",
+		"Host":                "developer.hashicorp.com",
 		"User-Agent":          "Go-http-client/1.1",
 		"Content-Length":      "37",
 	}); diff != "" {
@@ -201,7 +201,7 @@ func TestNewSubsystemLoggingHTTPTransport(t *testing.T) {
 func TestNewLoggingHTTPTransport_LogMasking(t *testing.T) {
 	ctx, loggerOutput := setupRootLogger()
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "tf_http_op_type")
-	ctx = tflog.MaskAllFieldValuesRegexes(ctx, regexp.MustCompile(`(?s)<html>.*</html>`))
+	ctx = tflog.MaskAllFieldValuesRegexes(ctx, regexp.MustCompile(`(?s)<html.*>.*</html>`))
 	ctx = tflog.MaskMessageStrings(ctx, "Request", "Response")
 
 	transport := logging.NewLoggingHTTPTransport(http.DefaultTransport)
@@ -210,7 +210,7 @@ func TestNewLoggingHTTPTransport_LogMasking(t *testing.T) {
 		Timeout:   10 * time.Second,
 	}
 
-	req, _ := http.NewRequest("GET", "https://www.terraform.io", nil)
+	req, _ := http.NewRequest("GET", "https://developer.hashicorp.com/terraform", nil)
 	res, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
@@ -266,7 +266,7 @@ func TestNewLoggingHTTPTransport_LogOmitting(t *testing.T) {
 		Timeout:   10 * time.Second,
 	}
 
-	req, _ := http.NewRequest("GET", "https://www.terraform.io", nil)
+	req, _ := http.NewRequest("GET", "https://developer.hashicorp.com/terraform", nil)
 	res, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -476,6 +476,14 @@ func (p *Provider) ImportState(
 	ctx context.Context,
 	info *terraform.InstanceInfo,
 	id string) ([]*terraform.InstanceState, error) {
+	return p.ImportStateWithIdentity(ctx, info, id, nil)
+}
+
+func (p *Provider) ImportStateWithIdentity(
+	ctx context.Context,
+	info *terraform.InstanceInfo,
+	id string,
+	identity map[string]string) ([]*terraform.InstanceState, error) {
 	// Find the resource
 	r, ok := p.ResourcesMap[info.Type]
 	if !ok {
@@ -491,6 +499,16 @@ func (p *Provider) ImportState(
 	data := r.Data(nil)
 	data.SetId(id)
 	data.SetType(info.Type)
+
+	if data.identitySchema != nil {
+		identityData, err := data.Identity()
+		if err != nil {
+			return nil, err // this should not happen, as we checked above
+		}
+		identityData.raw = identity // is this too hacky / unexpected?
+	} else if identity != nil {
+		return nil, fmt.Errorf("resource %s doesn't support identity import", info.Type)
+	}
 
 	// Call the import function
 	results := []*ResourceData{data}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -1398,7 +1398,7 @@ func isReservedResourceFieldName(name string) bool {
 //
 // This function is useful for unit tests and ResourceImporter functions.
 func (r *Resource) Data(s *terraform.InstanceState) *ResourceData {
-	result, err := schemaMap(r.SchemaMap()).Data(s, nil)
+	result, err := schemaMapWithIdentity{r.SchemaMap(), r.Identity.SchemaMap()}.Data(s, nil)
 	if err != nil {
 		// At the time of writing, this isn't possible (Data never returns
 		// non-nil errors). We panic to find this in the future if we have to.

--- a/helper/schema/resource_importer.go
+++ b/helper/schema/resource_importer.go
@@ -77,7 +77,9 @@ func ImportStatePassthrough(d *ResourceData, m interface{}) ([]*ResourceData, er
 // ImportStatePassthroughContext is an implementation of StateContextFunc that can be
 // used to simply pass the ID directly through. This should be used only
 // in the case that an ID-only refresh is possible.
-// TODO: this does not work with identity, since we also need to be able to set the id at the same time and that can't happen automatically, since the id probably is a combination of the identity attributes (this could work if there's only one attribute though, but practitioners should be able to write their own function that handles this then)
+// Please note that this implementation does not work when using resource identity as
+// an Id still has to be set and the identity might contain multiple fields
+// that are not the same as the ID.
 func ImportStatePassthroughContext(ctx context.Context, d *ResourceData, m interface{}) ([]*ResourceData, error) {
 	return []*ResourceData{d}, nil
 }

--- a/helper/schema/resource_importer.go
+++ b/helper/schema/resource_importer.go
@@ -77,6 +77,7 @@ func ImportStatePassthrough(d *ResourceData, m interface{}) ([]*ResourceData, er
 // ImportStatePassthroughContext is an implementation of StateContextFunc that can be
 // used to simply pass the ID directly through. This should be used only
 // in the case that an ID-only refresh is possible.
+// TODO: this does not work with identity, since we also need to be able to set the id at the same time and that can't happen automatically, since the id probably is a combination of the identity attributes (this could work if there's only one attribute though, but practitioners should be able to write their own function that handles this then)
 func ImportStatePassthroughContext(ctx context.Context, d *ResourceData, m interface{}) ([]*ResourceData, error) {
 	return []*ResourceData{d}, nil
 }


### PR DESCRIPTION
This PR adds a new `ImportStateWithIdentity` method to `Provider` which is used in the `ImportResourceState` RPC handler to optionally pass a resource identity instead of a string id. Both still exist side-by-side and will for backwards compatibility.

Resources can now retrieve and set values in an identity like this to support import by identity:
```golang
Importer: &schema.ResourceImporter{
	StateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
		if rd.Id() != "" {
			return []*schema.ResourceData{rd}, nil // just return the resource data, since the string id is used
		}

		identity, err := rd.Identity()
		if err != nil {
			return nil, err
		}

		emailRaw, ok := identity.GetOk("email")
		if !ok {
			return nil, fmt.Errorf("error getting email from identity: %w", err)
		}

		email, ok := emailRaw.(string)
		if !ok {
			return nil, fmt.Errorf("error converting email to string")
		}

		if email == "" {
			return nil, fmt.Errorf("email cannot be empty")
		}

		err = rd.Set("email", email)
		rd.SetId(email) // TODO: document that this is still required with resource identity
		if err != nil {
			return nil, fmt.Errorf("error setting email: %w", err)
		}

		return []*schema.ResourceData{rd}, nil
	},
},
```