### PR TITLE
add writeOnly in updateFuncSet check

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -1216,7 +1216,7 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 		if !r.updateFuncSet() {
 			nonForceNewAttrs := make([]string, 0)
 			for k, v := range schema {
-				if !v.ForceNew && !v.Computed {
+				if !v.ForceNew && !v.Computed && !v.WriteOnly {
 					nonForceNewAttrs = append(nonForceNewAttrs, k)
 				}
 			}


### PR DESCRIPTION
This addresses the bug that I was running into when attempting to use write-only attributes on a no update function resource.

I get a passing `TestProvider` now after applying the changes and integrating the plugin-sdk that's set on my machine.

![image](https://github.com/user-attachments/assets/ee754b42-219d-49f1-9d55-62f0954a8c5a)


Fixes https://github.com/hashicorp/terraform-plugin-sdk/issues/1471