### PR TITLE
github: Use Dependabot to keep Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,7 @@ updates:
     directory: "/tools"
     schedule:
       interval: "daily"
-  # Dependabot only updates hashicorp GHAs, external GHAs are managed by internal tooling (tsccr)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-name: "hashicorp/*"


### PR DESCRIPTION

Now that TSCCR has gone away, Security's recommendation is that we go back to using Dependabot to keep all GitHub Actions updated.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>