### PR TITLE
Fix typo in diagnostic summary for identity change error message

### DIFF
--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -5790,7 +5790,7 @@ func TestReadResource(t *testing.T) {
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
-						Summary: (`Unexpected Identity Change: During the read operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.
+						Summary: (`Unexpected Identity Change: During the read operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.
 
 This is always a problem with the provider and should be reported to the provider developer.
 


### PR DESCRIPTION
- Corrected the word "then" to "than" in the error message displayed during the read operation in TestReadResource.

Related: https://github.com/hashicorp/terraform-plugin-framework/pull/1172
