### PR TITLE
identity: Update change validation to ensure empty identities (all null attributes) are not validated

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250922-091942.yaml
+++ b/.changes/unreleased/BUG FIXES-20250922-091942.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'all: Prevent identity change validation from raising an error when prior identity is empty (all attributes are null)'
+time: 2025-09-22T09:19:42.075962-04:00
+custom:
+    Issue: "1527"


### PR DESCRIPTION
## Related Issue

Ref: https://github.com/hashicorp/terraform-provider-aws/issues/44182

## Description

There are some scenarios where an identity may be stored with all null values (a scenario that #1513 will prevent from occurring now), which should not be validated, since an identity with all null values is invalid.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
