### PR TITLE
helper/schema: guard GenerateResourceConfig against unknown types and nil State

### DIFF
--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -1791,8 +1791,37 @@ func (s *GRPCProviderServer) GenerateResourceConfig(ctx context.Context, req *tf
 
 	resp := &tfprotov5.GenerateResourceConfigResponse{}
 
-	schemaBlock := s.getResourceSchemaBlock(req.TypeName)
-	res := s.provider.ResourcesMap[req.TypeName]
+	// req.TypeName may refer to a list/query resource type that this
+	// SDK's managed ResourcesMap does not know about (Terraform can
+	// route `terraform query` `list "foo" {}` calls here through mux).
+	// The schema-block lookup would then deref a nil Resource, and
+	// msgpack.Unmarshal below would nil-deref if req.State is nil.
+	// Surface a diagnostic instead of panicking (#1575).
+	res, ok := s.provider.ResourcesMap[req.TypeName]
+	if !ok || res == nil {
+		resp.Diagnostics = []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unknown Resource Type",
+				Detail: fmt.Sprintf("GenerateResourceConfig was called for resource type %q, which is not registered as a managed resource with this SDK-based provider. "+
+					"This typically means Terraform is routing a list/query request to the managed-resource schema path.", req.TypeName),
+			},
+		}
+		return resp, nil
+	}
+	schemaBlock := res.CoreConfigSchema()
+
+	if req.State == nil {
+		resp.Diagnostics = []*tfprotov5.Diagnostic{
+			{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Unexpected Generate Config Request",
+				Detail: "An unexpected error was encountered when generating resource configuration. The request did not include a state payload.\n\n" +
+					"This is always a problem with Terraform or terraform-plugin-sdk. Please report this to the provider developer.",
+			},
+		}
+		return resp, nil
+	}
 
 	stateVal, err := msgpack.Unmarshal(req.State.MsgPack, schemaBlock.ImpliedType())
 	if err != nil {

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -11354,6 +11354,62 @@ func TestGenerateResourceConfig(t *testing.T) {
 		expected    *tfprotov5.GenerateResourceConfigResponse
 		ExpectError string
 	}{
+		"unknown-resource-type": {
+			// Regression for #1575: Terraform can route list/query
+			// requests (e.g. `list "aws_s3_bucket"`) through this
+			// entry point for a name that is not in ResourcesMap.
+			// Previously that nil-deref'd inside getResourceSchemaBlock
+			// and crashed the provider.
+			server: NewGRPCProviderServer(&Provider{
+				ResourcesMap: map[string]*Resource{},
+			}),
+			req: &tfprotov5.GenerateResourceConfigRequest{
+				TypeName: "not_registered",
+			},
+			expected: &tfprotov5.GenerateResourceConfigResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Unknown Resource Type",
+						Detail: `GenerateResourceConfig was called for resource type "not_registered", ` +
+							`which is not registered as a managed resource with this SDK-based provider. ` +
+							`This typically means Terraform is routing a list/query request to the managed-resource schema path.`,
+					},
+				},
+			},
+		},
+		"nil-state": {
+			// Regression for #1575: if req.State is nil, the original
+			// msgpack.Unmarshal(req.State.MsgPack, ...) nil-deref'd.
+			server: NewGRPCProviderServer(&Provider{
+				ResourcesMap: map[string]*Resource{
+					"test": {
+						SchemaVersion: 1,
+						Schema: map[string]*Schema{
+							"id": {
+								Type:     TypeString,
+								Computed: true,
+								Optional: true,
+							},
+						},
+					},
+				},
+			}),
+			req: &tfprotov5.GenerateResourceConfigRequest{
+				TypeName: "test",
+				// State: nil
+			},
+			expected: &tfprotov5.GenerateResourceConfigResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Unexpected Generate Config Request",
+						Detail: "An unexpected error was encountered when generating resource configuration. The request did not include a state payload.\n\n" +
+							"This is always a problem with Terraform or terraform-plugin-sdk. Please report this to the provider developer.",
+					},
+				},
+			},
+		},
 		"null-state": {
 			server: NewGRPCProviderServer(&Provider{
 				ResourcesMap: map[string]*Resource{


### PR DESCRIPTION
## Summary

Fixes #1575.

Two nil derefs collided when Terraform routed a list/query request (e.g. `list "aws_s3_bucket"` in a `.tfquery.hcl`) through the managed-resource `GRPCProviderServer` path:

- `getResourceSchemaBlock(req.TypeName)` dereferenced a nil `*Resource` when `req.TypeName` was not in `provider.ResourcesMap` (the SDK's list/query story is handled via the plugin-framework + mux, but Terraform still occasionally routes to this entry point).
- `msgpack.Unmarshal(req.State.MsgPack, ...)` dereferenced nil when `req.State` itself was nil.

Both surfaced as `panic: runtime error: invalid memory address or nil pointer dereference` at `grpc_provider.go:1796`, taking down the provider plugin.

## Fix

Surface a diagnostic in each case instead of panicking:

- Unknown resource type → `Unknown Resource Type` error that explicitly names the type and points at the usual list/query routing cause.
- Missing state payload → reuse the existing `Unexpected Generate Config Request` phrasing, adjusted to mention the absent payload rather than the absent value.

## Tests

Adds two regression cases to `TestGenerateResourceConfig`:

- `unknown-resource-type`, `TypeName: "not_registered"` with an empty `ResourcesMap`; pre-fix nil-deref, post-fix returns `Unknown Resource Type` diagnostic.
- `nil-state`, nil `State`; pre-fix nil-deref, post-fix returns `Unexpected Generate Config Request`.

Both pass; the existing `null-state`, `simple-resource`, and `schema-behaviors` cases remain green.