### PR TITLE
helper/schema: preserve no-op planning shortcut when only identity is carried over

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260423-110543.yaml
+++ b/.changes/unreleased/BUG FIXES-20260423-110543.yaml
@@ -1,5 +1,5 @@
 kind: BUG FIXES
-body: 'helper/schema: Fix `PlanResourceChange` skipping the no-op shortcut when a resource has `Identity` set, which caused legacy state shapes (e.g. an empty `timeouts {}` block) to be re-shaped via the flatmap path and produce spurious diffs.'
+body: 'helper/schema: Fixed a bug that caused spurious diffs in the plan when resource identity is set but didn''t change.'
 time: 2026-04-23T11:05:43.475731+02:00
 custom:
     Issue: "1582"

--- a/.changes/unreleased/BUG FIXES-20260423-110543.yaml
+++ b/.changes/unreleased/BUG FIXES-20260423-110543.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/schema: Fix `PlanResourceChange` skipping the no-op shortcut when a resource has `Identity` set, which caused legacy state shapes (e.g. an empty `timeouts {}` block) to be re-shaped via the flatmap path and produce spurious diffs.'
+time: 2026-04-23T11:05:43.475731+02:00
+custom:
+    Issue: "1582"

--- a/helper/schema/grpc_provider.go
+++ b/helper/schema/grpc_provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -1148,7 +1149,13 @@ func (s *GRPCProviderServer) PlanResourceChange(ctx context.Context, req *tfprot
 		}
 	}
 
-	if diff == nil || (len(diff.Attributes) == 0 && len(diff.Identity) == 0) {
+	// The diff carries identity over from the prior state unconditionally
+	// (see schemaMapWithIdentity.Diff), so a non-empty diff.Identity does not
+	// necessarily indicate an identity change. Treat the identity as unchanged
+	// when it matches what was supplied in the prior state.
+	identityUnchanged := diff == nil || maps.Equal(diff.Identity, priorState.Identity)
+
+	if diff == nil || (len(diff.Attributes) == 0 && identityUnchanged) {
 		// schema.Provider.Diff returns nil if it ends up making a diff with no
 		// changes, but our new interface wants us to return an actual change
 		// description that _shows_ there are no changes. This is always the

--- a/helper/schema/grpc_provider_test.go
+++ b/helper/schema/grpc_provider_test.go
@@ -8031,6 +8031,158 @@ Planned Identity: cty.ObjectVal(map[string]cty.Value{"identity":cty.StringVal("c
 				},
 			},
 		},
+		// Regression test: when a resource defines Identity and the prior
+		// state contains an empty `timeouts {}` block (a state shape that
+		// older provider versions could persist), the no-op planning
+		// shortcut must still trigger. Previously, because the diff
+		// unconditionally carries identity over from prior state,
+		// `len(diff.Identity) != 0` caused us to skip the shortcut and
+		// re-shape state via the legacy flatmap path, which dropped the
+		// empty timeouts block and produced a spurious `- timeouts {}`
+		// plan. See hashicorp/terraform-provider-google#27055.
+		"identity-noop-preserves-empty-timeouts-block": {
+			server: NewGRPCProviderServer(&Provider{
+				ResourcesMap: map[string]*Resource{
+					"test": {
+						SchemaVersion: 1,
+						Schema: map[string]*Schema{
+							"foo": {
+								Type:     TypeString,
+								Optional: true,
+							},
+						},
+						Identity: &ResourceIdentity{
+							Version: 1,
+							SchemaFunc: func() map[string]*Schema {
+								return map[string]*Schema{
+									"name": {
+										Type:              TypeString,
+										RequiredForImport: true,
+									},
+								}
+							},
+						},
+						Timeouts: &ResourceTimeout{
+							Create: DefaultTimeout(20 * time.Minute),
+						},
+					},
+				},
+			}),
+			req: &tfprotov5.PlanResourceChangeRequest{
+				TypeName: "test",
+				PriorState: &tfprotov5.DynamicValue{
+					MsgPack: mustMsgpackMarshal(
+						cty.Object(map[string]cty.Type{
+							"id":  cty.String,
+							"foo": cty.String,
+							"timeouts": cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							}),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"id":  cty.StringVal("existing"),
+							"foo": cty.StringVal("bar"),
+							// Empty `timeouts {}` block: a non-null object
+							// with all-null inner attributes, which is what
+							// state from older provider versions can look
+							// like for resources that never declared
+							// timeouts in config.
+							"timeouts": cty.ObjectVal(map[string]cty.Value{
+								"create": cty.NullVal(cty.String),
+							}),
+						}),
+					),
+				},
+				ProposedNewState: &tfprotov5.DynamicValue{
+					MsgPack: mustMsgpackMarshal(
+						cty.Object(map[string]cty.Type{
+							"id":  cty.String,
+							"foo": cty.String,
+							"timeouts": cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							}),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"id":  cty.StringVal("existing"),
+							"foo": cty.StringVal("bar"),
+							// Config has no timeouts block, so proposed
+							// new state has a null timeouts.
+							"timeouts": cty.NullVal(cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							})),
+						}),
+					),
+				},
+				Config: &tfprotov5.DynamicValue{
+					MsgPack: mustMsgpackMarshal(
+						cty.Object(map[string]cty.Type{
+							"id":  cty.String,
+							"foo": cty.String,
+							"timeouts": cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							}),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"id":  cty.NullVal(cty.String),
+							"foo": cty.StringVal("bar"),
+							"timeouts": cty.NullVal(cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							})),
+						}),
+					),
+				},
+				PriorIdentity: &tfprotov5.ResourceIdentityData{
+					IdentityData: &tfprotov5.DynamicValue{
+						MsgPack: mustMsgpackMarshal(
+							cty.Object(map[string]cty.Type{
+								"name": cty.String,
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"name": cty.StringVal("existing"),
+							}),
+						),
+					},
+				},
+				PriorPrivate: []byte(`{"_new_extra_shim":{}}`),
+			},
+			// Expect the planned state to equal the prior state exactly:
+			// the no-op shortcut should fire and the timeouts block must
+			// not be dropped.
+			expected: &tfprotov5.PlanResourceChangeResponse{
+				PlannedState: &tfprotov5.DynamicValue{
+					MsgPack: mustMsgpackMarshal(
+						cty.Object(map[string]cty.Type{
+							"id":  cty.String,
+							"foo": cty.String,
+							"timeouts": cty.Object(map[string]cty.Type{
+								"create": cty.String,
+							}),
+						}),
+						cty.ObjectVal(map[string]cty.Value{
+							"id":  cty.StringVal("existing"),
+							"foo": cty.StringVal("bar"),
+							"timeouts": cty.ObjectVal(map[string]cty.Value{
+								"create": cty.NullVal(cty.String),
+							}),
+						}),
+					),
+				},
+				PlannedPrivate:              []byte(`{"_new_extra_shim":{}}`),
+				UnsafeToUseLegacyTypeSystem: true,
+				PlannedIdentity: &tfprotov5.ResourceIdentityData{
+					IdentityData: &tfprotov5.DynamicValue{
+						MsgPack: mustMsgpackMarshal(
+							cty.Object(map[string]cty.Type{
+								"name": cty.String,
+							}),
+							cty.ObjectVal(map[string]cty.Value{
+								"name": cty.StringVal("existing"),
+							}),
+						),
+					},
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
_Assisted-by: Claude opus-4.7 (via OpenCode)_

## Summary

- Fix a regression introduced in #1444 where adopting Resource Identity caused SDKv2 providers to emit spurious plan diffs (e.g. `- timeouts {}`) on no-op updates.
- `schemaMapWithIdentity.Diff` always copies the prior identity into `diff.Identity`, so a non-empty `diff.Identity` is not on its own evidence of an identity change. The previous `len(diff.Identity) == 0` guard in `PlanResourceChange` therefore caused the no-op shortcut to be skipped for every resource that adopted `Identity`, forcing the planned state to be re-built from the legacy flatmap diff. That round-trip drops state shapes the flatmap path can't faithfully reproduce — most visibly an empty `timeouts {}` block left behind by older provider versions.
- Compare `diff.Identity` against `priorState.Identity` instead, so the shortcut still fires when identity is merely carried over unchanged.

Reported in hashicorp/terraform-provider-google#27055.

## Test plan

- New regression test `TestPlanResourceChange/identity-noop-preserves-empty-timeouts-block` exercises the timeouts/identity scenario; verified failing on `main` and passing with the fix.
- `go test ./...` passes across the module.