### PR TITLE
helper/retry: omit last error from UnexpectedStateError message when nil

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260706-152904.yaml
+++ b/.changes/unreleased/BUG FIXES-20260706-152904.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/retry: Omitted the last error suffix from the UnexpectedStateError message when there is no last error, instead of printing a nil value'
+time: 2026-07-06T15:29:04+03:00
+custom:
+    Issue: "1359"

--- a/helper/retry/error.go
+++ b/helper/retry/error.go
@@ -41,11 +41,19 @@ type UnexpectedStateError struct {
 }
 
 func (e *UnexpectedStateError) Error() string {
+	if e.LastError != nil {
+		return fmt.Sprintf(
+			"unexpected state '%s', wanted target '%s'. last error: %s",
+			e.State,
+			strings.Join(e.ExpectedState, ", "),
+			e.LastError,
+		)
+	}
+
 	return fmt.Sprintf(
-		"unexpected state '%s', wanted target '%s'. last error: %s",
+		"unexpected state '%s', wanted target '%s'",
 		e.State,
 		strings.Join(e.ExpectedState, ", "),
-		e.LastError,
 	)
 }
 

--- a/helper/retry/error_test.go
+++ b/helper/retry/error_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package retry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnexpectedStateErrorError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *UnexpectedStateError
+		want string
+	}{
+		{
+			name: "with last error",
+			err: &UnexpectedStateError{
+				State:         "failed",
+				ExpectedState: []string{"running", "ready"},
+				LastError:     errors.New("compute quota exceeded"),
+			},
+			want: "unexpected state 'failed', wanted target 'running, ready'. last error: compute quota exceeded",
+		},
+		{
+			name: "nil last error",
+			err: &UnexpectedStateError{
+				State:         "failed",
+				ExpectedState: []string{"running"},
+			},
+			want: "unexpected state 'failed', wanted target 'running'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`UnexpectedStateError.Error()` formats `LastError` with `%s` unconditionally, so when the retry gave up without an underlying error the message ends in `last error: %!s(<nil>)`.

This only includes the suffix when a last error actually exists, the same way `TimeoutError.Error()` right below it already handles its nil case. Added a small table test covering both paths (the nil case reproduces the `%!s(<nil>)` output before the fix), plus a changie entry.

Closes #1359