### PR TITLE
helper/schema: reject Identity on data sources in InternalValidate

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260707-102915.yaml
+++ b/.changes/unreleased/BUG FIXES-20260707-102915.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'helper/schema: Provider.InternalValidate now rejects data sources that define Identity, which is only supported for managed resources'
+time: 2026-07-07T10:29:15+03:00
+custom:
+    Issue: "1511"

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -1302,6 +1302,10 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 
 	// Data source
 	if r.isTopLevel() && !writable {
+		if r.Identity != nil {
+			return fmt.Errorf("must not define Identity, only managed resources support identity")
+		}
+
 		tsm = schema
 		for k := range tsm {
 			if isReservedDataSourceFieldName(k) {

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -703,6 +703,57 @@ func TestResourceInternalValidate(t *testing.T) {
 			false,
 		},
 
+		"non-writable must not define Identity": {
+			&Resource{
+				Read: Noop,
+				Schema: map[string]*Schema{
+					"goo": {
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+				Identity: &ResourceIdentity{
+					SchemaFunc: func() map[string]*Schema {
+						return map[string]*Schema{
+							"id": {
+								Type:              TypeString,
+								RequiredForImport: true,
+							},
+						}
+					},
+				},
+			},
+			false,
+			true,
+		},
+
+		"writable may define Identity": {
+			&Resource{
+				Create: Noop,
+				Read:   Noop,
+				Update: Noop,
+				Delete: Noop,
+				Schema: map[string]*Schema{
+					"goo": {
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+				Identity: &ResourceIdentity{
+					SchemaFunc: func() map[string]*Schema {
+						return map[string]*Schema{
+							"id": {
+								Type:              TypeString,
+								RequiredForImport: true,
+							},
+						}
+					},
+				},
+			},
+			true,
+			false,
+		},
+
 		"non-writable *must not* have Create": {
 			&Resource{
 				Create: Noop,


### PR DESCRIPTION
Identity is a managed resource concept, but a data source defining one passed `InternalValidate` silently and the identity never worked, which is confusing to debug from the provider side (see the report in the issue). Per the maintainer direction in the issue, this adds validation so it fails fast.

`Resource.InternalValidate` now rejects `Identity` on top-level non-writable resources, alongside the existing must-not-implement checks for Create, Update, Delete and CustomizeDiff. Through `Provider.InternalValidate` the error reads:

```
data source scaleway_instance_snapshot: must not define Identity, only managed resources support identity
```

The check is scoped to top-level data sources, nested `Elem` resources are untouched. Note this turns a silently ignored `Identity` on a data source into a hard validation error, which is the intent here, but it will surface for any provider currently shipping one.

Two table tests added: a data source with `Identity` (fails validation) and a writable resource with `Identity` (still valid), so managed resources are provably unaffected. Changie entry included.

Closes #1511